### PR TITLE
taboos: fr: Add 2.0 taboos

### DIFF
--- a/i18n/fr/taboos.po
+++ b/i18n/fr/taboos.po
@@ -86,7 +86,7 @@ msgstr ""
 msgid "This card’s [action] ability gains: “This attack may target a non-[[Elite]] enemy up to one location away from its standard range, ignoring the aloof and retaliate keywords.”"
 msgstr ""
 "Mutée.\n"
-"La capacité [action] de cette carte gagne : « Cette attaque peut cibler un ennemi non-[[Élite]] dans un lieu connexe. Ignorez les mots-clés Distant et Riposte pour cette attaque. »"
+"La capacité [action] de cette carte gagne : « Cette attaque peut cibler un ennemi non-[[Élite]] éloigné jusqu’à un lieu de sa portée standard, en ignorant les mots-clés Distant et Riposte. »"
 
 msgid "This card loses the text: “Attached asset cannot be used to attack enemies engaged with you.”"
 msgstr ""
@@ -106,7 +106,7 @@ msgstr ""
 msgid "This card’s ability gains: “Remove each committed copy of Three Aces from the game.”"
 msgstr ""
 "Mutée.\n"
-"La capacité de cette carte gagne : « Retirez de la partie chaque exemplaire de Brelan d'As attribué à ce test. »"
+"La capacité de cette carte gagne : « Retirez de la partie chaque exemplaire de Brelan d'As attribué au test de compétence. »"
 
 msgid "This card’s ability gains: “Remove A Watchful Peace from the game.”"
 msgstr ""
@@ -120,42 +120,60 @@ msgstr ""
 
 msgid "This card’s [fast] ability is now a [action] ability."
 msgstr ""
-
-msgid "This card’s [reaction] ability now reads: “After you successfully investigate, exhaust Dr. Milan Christopher...”"
-msgstr ""
+"Mutée.\n"
+"La capacité [fast] de cette carte est désormais une capacité [action]."
 
 msgid "This card now reads \"a symbol\" instead of the list of indicated symbols."
 msgstr ""
+"Mutée.\n"
+"Cette carte indique désormais « un symbole » au lieu de la liste de symboles indiqués."
 
 msgid "This card's fight ability now reads \"+1 damage\" instead of \"+2 damage.\""
 msgstr ""
+"Mutée.\n"
+"La capacité Combattre de cette carte indique désormais « +1 dégât » au lieu de  « +2 dégâts. »"
 
 msgid "This card's forced ability is moved to its reverse side, and it should now read: \"<b>Additional Setup</b>: After you draw your opening hand, choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\" This card's front side additionally gains: \"[action]: Switch roles. Does not provoke attacks of opportunity.\""
 msgstr ""
+"Mutée.\n"
+"La capacité Forcé de cette carte est déplacée sur son verso et indique désormais : « <b>Mise en Place Complémentaire</b> : Après avoir pioché votre main de départ : choisissez un rôle ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral). »\nDe plus, le recto de cette carte gagne : « [action]: Changez de rôle. Cette action ne provoque pas d'attaque d'opportunité. »"
 
 msgid "This card's revelation ability now reads: \"Discard 1 card in your hand or play area of your current role. Then...\""
 msgstr ""
+"Mutée.\n"
+"La capacité Révélation de cette carte indique désormais : « Défaussez une carte de votre rôle actuel depuis votre main ou de votre zone de jeu. Ensuite… »"
 
 msgid "This card now reads \"a non-[elder_sign] symbol\" instead of \"a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol.\""
 msgstr ""
+"Mutée.\n"
+"Cette carte indique désormais « un symbole non-[elder_sign] » au lieu de « un symbole [skull], [cultist], [tablet], [elder_thing] ou [auto_fail]. »"
 
 msgid "This card now reads \"a non-[auto_fail] symbol\" instead of \"a [skull], [cultist], [tablet], or [elder_thing] chaos token.\""
 msgstr ""
+"Mutée.\n"
+"Cette carte indique désormais « un symbole non-[auto_fail] » au lieu de « un symbole [skull], [cultist], [tablet] ou [elder_thing]. »"
 
 msgid "This investigator now reads: \"Deck Size: 50\" and \"Deckbuilding Requirements (do not count towards deck size): 3 copies of Occult Evidence...\""
 msgstr ""
+"Mutée.\n"
+"Cette carte investigateur indique désormais : « Taille du deck : 50 » et « Exigences du deck (ne comptent pas dans la limite de taille du deck) : 3 exemplaires de Preuve Occulte... »",
 
 msgid "This card loses the exceptional keyword and gains \"Limit 1 per deck.\""
 msgstr ""
+"Mutée.\n"
+"Cette carte perd le mot-clé Exceptionnel et gagne « Limite de 1 par deck. »"
 
 msgid "This card's constant ability now reads: \"...you get +1 [intellect], +1 [agility], and ignore the first attack of opportunity you take each turn.\""
 msgstr ""
-
-msgid "This card's gains: \"Max once per round.\""
-msgstr ""
+"Mutée.\n"
+"La capacité permanente de cette carte indique désormais : “…vous gagnez +1 [intellect], +1 [agility] et vous avez le droit d'ignorer la première attaque d'opportunité que vous subissez à chaque round.”"
 
 msgid "This card should read \"following basic actions\" instead of \"following actions.\""
 msgstr ""
+"Mutée.\n"
+"Cette carte indique désormais « actions basiques suivantes » au lieu de « action suivantes. »"
 
 msgid "This card's parenthetical now reads: \"...(If you succeed by 3 or more, you may exhaust Cyclopean Hammer to instead deal +2 damage and move the enemy up to two locations away from you.)\""
 msgstr ""
+"Mutée.\n"
+"Le texte entre parenthèses de cette carte indique désormais : « …(En cas de réussite avec une différence de 3 ou plus, vous avez le droit d'incliner le Marteau Cyclopéen pour infliger +2 dégâts et le déplacer jusqu'à 2 lieux en l'éloignant de vous, à la place.) »"

--- a/taboos.json
+++ b/taboos.json
@@ -494,7 +494,7 @@
             },
             {
                 "code": "01033",
-                "text": "This card’s [reaction] ability now reads: “After you successfully investigate, exhaust Dr. Milan Christopher...”"
+                "text": "This card’s [reaction] ability now reads: “After you successfully investigate, exhaust Dr. Milan Christopher…”"
             },
             {
                 "code": "02002",
@@ -619,7 +619,7 @@
             },
             {
                 "code": "08055",
-                "text": "This card's gains: \"Max once per round.\""
+                "text": "This card gains: “Max once per round.”"
             },
             {
                 "code": "08098",


### PR DESCRIPTION
This is an unofficial translation.
This commit also adjusts a few strings in taboos.json to reuse existing
strings, and changes some older fr taboo strings to match the official
wording.