### PR TITLE
TSK: Arkham and Cairo text info bug

### DIFF
--- a/campaigns/tskc/campaign.json
+++ b/campaigns/tskc/campaign.json
@@ -926,9 +926,6 @@
             "entries": [
               {
                 "text": "If you know one thing for certain, there's always something strange happening in <minicaps>Arkham</minicaps>."
-              },
-              {
-                "text": "Suggested scenarios:"
               }
             ]
           },
@@ -1241,9 +1238,6 @@
             "entries": [
               {
                 "text": "Your friend Jesse Burke has written to you with concerns about a strange epidemic of slumber that has struck the citizens of <minicaps>Cairo</minicaps>. Jessie has reason to believe this might be the work of the Brotherhood of the Beast led by a mysterious ‘Xzharah’."
-              },
-              {
-                "text": "Suggested scenarios: "
               }
             ]
           },


### PR DESCRIPTION
In two possible side scenarios in TSK, the text "suggested scenarios" is appended to the info box. This duplicates the title directly afterwards so I think this counts as a bug.

Screenshot:
![signal-2023-01-01-211117](https://user-images.githubusercontent.com/1726277/210183446-42c31c99-1246-43cb-a4ca-af34db705258.png)
