### PR TITLE
fr: ptc: Remove extra \n

### DIFF
--- a/i18n/fr/campaigns/ptc/a_phantom_of_truth.po
+++ b/i18n/fr/campaigns/ptc/a_phantom_of_truth.po
@@ -84,9 +84,7 @@ msgid "You awaken from your fitful dream, sweating and gagging. This cannot go o
 msgstr "Vous émergez d'un rêve qui avait l'air si réel, en panique et couvert de sueur. Cela ne peut pas continuer ainsi. Il ne vous reste plus qu'une seule option si vous voulez poursuivre votre enquête. Vous devez trouver ce Nigel Engram, metteur en scène du Roi en Jaune et architecte de toute cette folie. Lui seul possède les réponses que vous cherchez. Vous faites vos bagages : direction Paris, la Ville Lumière."
 
 msgid "Check Campaign Log. <i>If Jordan Perry is listed under VIPs Interviewed</i>:"
-msgstr ""
-"Vérifiez votre Carnet de Campagne. <i>Si Jordan Perry est inscrit sous la mention\n"
-"« Personnalités Interrogées »</i> :"
+msgstr "Vérifiez votre Carnet de Campagne. <i>Si Jordan Perry est inscrit sous la mention « Personnalités Interrogées »</i> :"
 
 msgid "According to Mr. Jordan Perry, who had financed several performances of The King in Yellow across the world, Nigel Engram was an eccentric and impassioned man, almost to the point of mania. Rumor was, he hadn’t directed any other works since discovering The King in Yellow. Jordan had first met with Mr. Engram at a café in Montparnasse, “L’agneau Perdu.” You travel there first, hoping to find Mr. Engram…"
 msgstr "Selon M. Jordan Perry, qui a financé plusieurs mises en scène du Roi en Jaune à travers le monde, Nigel Engram était un homme excentrique, passionné à l'extrême. La rumeur disait qu'il n'avait jamais dirigé aucune autre pièce avant de découvrir Le Roi en Jaune. Jordan l'avait rencontré pour la première fois dans un café de Montparnasse, « L'Agneau Perdu ». Ce sera votre première destination : M. Engram s'y trouvera peut-être…"


### PR DESCRIPTION
It's not present in the English version, and breaks display of the
string. Bug reported by franakin74