### PR TITLE
[DE] Fix imbalanced html elements

### DIFF
--- a/i18n/de/campaigns/side/in_the_labyrinths_of_lunacy.po
+++ b/i18n/de/campaigns/side/in_the_labyrinths_of_lunacy.po
@@ -154,7 +154,7 @@ msgid "Group C Instructions"
 msgstr "Anweisungen für Gruppe C"
 
 msgid "Because you are playing in <i>Epic Multiplayer Mode</i>, gather all cards from the <i>Epic Multiplayer</i> encounter set."
-msgstr "Da im <i>Epischen Mehrspielermodus<i> gespielt wird, werden alle Karten aus dem Begegnungsset <i>Epischer Mehrspielermodus</i> herausgesucht."
+msgstr "Da im <i>Epischen Mehrspielermodus</i> gespielt wird, werden alle Karten aus dem Begegnungsset <i>Epischer Mehrspielermodus</i> herausgesucht."
 
 msgid "Remove all cards from the <i>Single Group</i> encounter set from the game."
 msgstr "Alle Karten aus dem Begegnungsset <i>Einzelgruppe</i> werden aus dem Spiel entfernt."

--- a/i18n/de/campaigns/tfa/expeditions_end.po
+++ b/i18n/de/campaigns/tfa/expeditions_end.po
@@ -26,7 +26,7 @@ msgid "<i>It belongs in a museum. Alejandro and the museum staff will be able to
 msgstr "<i>Es gehört in ein Museum. Alejandro und seine Mitarbeiter können es dort studieren und seinen Zweck herausfinden.</i>"
 
 msgid "<i>It is too dangerous to be on display. We should keep it hidden and safe until we know more about it.</i>"
-msgstr "Es auszustellen wäre zu gefährlich. Es sollte an einem sicheren Ort versteckt werden, bis wir mehr über das Ding wissen.</i>"
+msgstr "<i>Es auszustellen wäre zu gefährlich. Es sollte an einem sicheren Ort versteckt werden, bis wir mehr über das Ding wissen.</i>"
 
 msgid ""
 "<right><fancy>Sunday, July 19th, 1925</fancy></right>\n"

--- a/i18n/de/campaigns/tfa/the_city_of_archives.po
+++ b/i18n/de/campaigns/tfa/the_city_of_archives.po
@@ -98,7 +98,7 @@ msgid "#X# tasks were completed"
 msgstr "#X# Aufgaben wurden abgeschlossen"
 
 msgid "Because all 6 tasks were completed, record in your Campaign Log that <i>the process was perfected</i>. Each investigator earns 4 bonus experience as they gain insight into the secrets of the Earth."
-msgstr "Da alle 6 Aufgaben abgeschlossen wurden, wird im Kampagnenlogbuch notiert: <i>Der Prozess wurde perfektioniert<Ii>. Jeder Ermittler erhält 4 zusätzliche Erfahrungspunkte, weil er Einsicht in die Geheimnisse der Erde erhalten hat."
+msgstr "Da alle 6 Aufgaben abgeschlossen wurden, wird im Kampagnenlogbuch notiert: <i>Der Prozess wurde perfektioniert</i>. Jeder Ermittler erhält 4 zusätzliche Erfahrungspunkte, weil er Einsicht in die Geheimnisse der Erde erhalten hat."
 
 msgid "the process was perfected."
 msgstr "Der Prozess wurde perfektioniert."

--- a/i18n/de/return_campaigns/rtdwl/campaign.po
+++ b/i18n/de/return_campaigns/rtdwl/campaign.po
@@ -44,7 +44,7 @@ msgid "The Gang’s All Here"
 msgstr "Die ganze Bande ist hier"
 
 msgid "In “The Survivors,” the following characters <i>survived The Dunwich Legacy</i>:"
-msgstr "In \"Die Überlebenden\" haben folgende Charaktere <i>„das Vermächtnis von Dunwich überlebt“<i>:"
+msgstr "In \"Die Überlebenden\" haben folgende Charaktere <i>das Vermächtnis von Dunwich überlebt</i>:"
 
 msgid "Dr. Henry Armitage"
 msgstr "Dr. Henry Armitage"

--- a/i18n/de/return_campaigns/rttcu/campaign.po
+++ b/i18n/de/return_campaigns/rttcu/campaign.po
@@ -83,7 +83,7 @@ msgid "Music of the Outer Gods"
 msgstr "Musik der Äußeren Götter"
 
 msgid "Accept your fate and win <i>The Circle Undone</i> campaign by joining the Pipers of Azathoth."
-msgstr "Akzeptiere dein Schicksal und gewinne die Kampagne Der gebrochene Kreis</i>, indem du dich den Pfeifern von Azathoth anschließt."
+msgstr "Akzeptiere dein Schicksal und gewinne die Kampagne <i>Der gebrochene Kreis</i>, indem du dich den Pfeifern von Azathoth anschließt."
 
 msgid "Weaver of Shadow and Mist"
 msgstr "Weber der Schatten und Nebel"


### PR DESCRIPTION
I've noticed another imbalanced html element in the DE translations for TFA.

I've written a small script that validates whether the `msgstr` strings contain valid html for this and fixed the other imbalanced html in the de translations. Maybe an automated check should be integrated that runs such a script so that future issues of that kind are avoided?