### PR TITLE
[German] Fix a header in the interlude of tfa

### DIFF
--- a/i18n/de/campaigns/tfa/restless_nights.po
+++ b/i18n/de/campaigns/tfa/restless_nights.po
@@ -26,7 +26,7 @@ msgid "Those nights in the jungle, I barely slept. A strange fog rolled through 
 msgstr "In den Nächten im Dschungel habe ich kaum geschlafen. Jede Nacht waberte ein seltsamer Nebel durch das Lager und erfüllte die Luft mit einer intensiven, eigenartigen Kälte. Mein Schlafsack hat mir etwas Schutz gegen die Elemente geboten, aber wir waren nicht auf so unnatürliches Wetter eingestellt. Jedes Mal, wenn ich einzuschlafen begann, summten Fliegen und Mücken in meinen Ohren. Und wenn ich endlich schlief, kroch ein Insekt oder eine Eidechse über mein Gesicht und ich fuhr aus dem Schlaf hoch. Ich wette, ich werde auf dieser Reise nur sehr wenig Schlaf bekommen …"
 
 msgid "Restful Sleep"
-msgstr "Unruhiges Umherwälzen"
+msgstr "Erholsamer Schlaf"
 
 msgid "Mercifully, I was able to sleep through each night. However, while my body rested, my mind was plagued by nightmares. A cavern like a gaping maw, bathed in dim red light…the walls slithering with the glimmering scales of a hundred vipers…it might have been better had I not slept at all."
 msgstr "Glücklicherweise konnte ich in den letzten Nächten gut schlafen. Aber während mein Körper sich ausruhte, wurde mein Geist von Albträumen geplagt. Eine Höhle, die aussah wie ein weit aufgerissenes Maul, von einem düsteren roten Licht erleuchtet … An den Wänden glitzerten die Schuppen von hundert Vipern … Vielleicht wäre es besser gewesen, nicht zu schlafen."


### PR DESCRIPTION
The header "Restful sleep" has been copy-pasted instead of being translated properly.