### PR TITLE
Changes to Lucia, Rodney, Richard deckbuilding 0-4

### DIFF
--- a/cards/zoc.json
+++ b/cards/zoc.json
@@ -36,616 +36,607 @@
               }
           },
           {
-              "text": ["<b>Fight\\.<\\/b>"],
-              "level": {
-                  "min": 0,
-                  "max": 3
-              }
-          },
-          {
-              "faction": [
-                  "survivor"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 0
-              },
-              "limit": 5,
-              "error": "You cannot have more than 5 Survivor cards"
-          }
-      ],
-      "deck_requirements": "size:30, card:zoc_31002, card:zoc_31003, random:subtype:basicweakness",
-      "double_sided": true,
-      "faction_code": "guardian",
-      "flavor": "\"Stay back!\"",
-      "health": 7,
-      "illustrator": "Mark Molnar",
-      "is_unique": true,
-      "name": "Sampson Welch",
-      "pack_code": "zoc",
-      "position": 1,
-      "quantity": 1,
-      "sanity": 4,
-      "skill_agility": 3,
-      "skill_intellect": 2,
-      "skill_combat": 4,
-      "skill_willpower": 3,
-      "subname": "The Beat Cop",
-      "text": "You begin the game with Brock in play.\n[reaction] When an enemy leaves your location: Take a fight action against that enemy. (Limit once per round)\n[elder_sign] effect: +2. You may choose a non-[[Elite]] enemy at a connected location and move it to your location. If you do, ready Brock.",
-      "traits": "Police.",
-      "type_code": "investigator"
-  },
-  {
-      "code": "zoc_31002",
-      "cost": 2,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "name": "Brock",
-      "subname": "Man's Best Friend",
-      "is_unique": true,
-      "pack_code": "zoc",
-      "position": 2,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31001",
-      "skill_agility": 1,
-      "skill_combat": 1,
-      "text": "Sampson Welch deck only.\n[free] During your turn, exhaust Brock: Disengage from an enemy and move them to a connecting location.\n[reaction] During a fight action, exhaust Brock: Add your [agility] to this attack.",
-      "flavor": "Not so friendly if not fed.",
-      "health": 3,
-      "sanity": 2,
-      "illustrator": "Mark Molnar",
-      "traits": "Ally. Creature.",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31003",
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Jake Murray",
-      "name": "Targeted for The Chase",
-      "pack_code": "zoc",
-      "position": 3,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31001",
-      "subtype_code": "weakness",
-      "text": "<b>Revelation</b> - Each hunter enemy at a connecting location moves one location closer to you and engages you. Each enemy engaged with you readies, then attacks you. If no enemies were readied or moved by this effect, either discard Brock or shuffle Targeted for The Chase back into your deck.",
-      "traits": "Omen.",
-      "type_code": "treachery"
-  },
-  {
-      "back_flavor": "You had a case you needed solved, Rodney Dorman had your back. He got the evidence, the interviews, and he worked fast and quick so you see justice done. That is, until his last trip to France where he had been invited to see a showing of \"The King in Yellow\". An absolutely fascinating play that stuck with him a bit too much once he returned to Arkham. His mind kept spinning and spinning until he could not take it anymore, resorting him to rely on treatment through booze. The reliability he was known for is long gone. Now, he has been trying to get off the bottle and go through his massive backlog of unsolved cases. He worked as hard as he can, but no matter what he did, he cannot get that play out of his mind (or what was left of it anyways).",
-      "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Seeker cards ([seeker]) level 0-5, [[Insight]] cards level 0-3, up to 5 other Rogue and/or Guardian ([rogue]/[guardian]) cards level 0-1, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Case #17, Case #75, Case #257, Case #1910, Unhappy Client, 1 random basic weakness.",
-      "code": "zoc_31004",
-      "deck_limit": 1,
-      "deck_options": [
-          {
-              "faction": [
-                  "neutral"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "faction": [
-                  "seeker"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "trait": [
-                  "insight"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 3
-              }
-          },
-          {
-              "faction": [
-                  "rogue",
-                  "guardian"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 1
-              },
-              "limit": 10,
-              "error": "You cannot have more than 10 Rogue and/or Guardian cards"
-          }
-      ],
-      "deck_requirements": "size:30, card:zoc_31005, card:zoc_31006, card:zoc_31007, card:zoc_31008, card:zoc_31009, random:subtype:basicweakness",
-      "double_sided": true,
-      "faction_code": "seeker",
-      "flavor": "\"Everyone deserves a fair trial.\"",
-      "health": 7,
-      "illustrator": "Scott Gustafson",
-      "is_unique": true,
-      "name": "Rodney Dorman",
-      "pack_code": "zoc",
-      "position": 4,
-      "quantity": 1,
-      "sanity": 7,
-      "skill_agility": 2,
-      "skill_intellect": 4,
-      "skill_combat": 3,
-      "skill_willpower": 3,
-      "subname": "The Attorney",
-      "text": "<b>Forced</b> - When the game begins: Reveal cards from the top of your deck until you reveal a [[Case]] asset. Put that asset into play. Shuffle each other revealed card back into your deck.\nThe first investigate action you perform on each turn does not provoke attacks of opportunity.\n[elder_sign] effect: +1. You may shuffle a [[Case]] asset from your discard pile into your deck.",
-      "traits": "Veteran.",
-      "type_code": "investigator"
-  },
-  {
-      "code": "zoc_31005",
-      "cost": 2,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Norman Saunders",
-      "name": "Case #17",
-      "pack_code": "zoc",
-      "position": 5,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31004",
-      "skill_combat": 1,
-      "text": "Fast. Rodney Dorman deck only.\nUses (2 evidence). If there is no evidence on Case #17, discard it.\n[reaction] When you discover a clue while engaged with an enemy, spend 1 evidence: You may either exhaust that enemy or deal 1 damage to that enemy.",
-      "traits": "Case.",
-      "subname": "Fraud",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31006",
-      "cost": 1,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Rafał Szłapa",
-      "name": "Case #75",
-      "pack_code": "zoc",
-      "position": 6,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31004",
-      "skill_agility": 1,
-      "text": "Fast. Rodney Dorman deck only.\nUses (3 evidence). If there is no evidence on Case #75, discard it.\n[reaction] When an enemy engages you, spend 1 evidence: Gain 1 resource.",
-      "traits": "Case.",
-      "subname": "Robbery",
-      "flavor": "\"Your honor, my client was simply returning the artifacts.\"",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31007",
-      "cost": 1,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Thaldir",
-      "name": "Case #257",
-      "pack_code": "zoc",
-      "position": 7,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31004",
-      "skill_intellect": 1,
-      "text": "Fast. Rodney Dorman deck only.\nUses (3 evidence). If there is no evidence on Case #257, discard it.\n[reaction] When an enemy engages you, spend 1 evidence: Draw 1 card.",
-      "traits": "Case.",
-      "subname": "Missing Items",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31008",
-      "cost": 3,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Rafał Szłapa",
-      "name": "Case #1910",
-      "pack_code": "zoc",
-      "position": 8,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31004",
-      "skill_willpower": 1,
-      "text": "Fast. Rodney Dorman deck only.\n[reaction] When a non-[[Elite]] enemy engages you, you may disengage from that enemy. Then, either exhaust that enemy or move immediately to a connecting location. Discard Case #1910.",
-      "traits": "Case.",
-      "subname": "Premeditated Assault",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31009",
-      "deck_limit": 1,
-      "enemy_damage": 1,
-      "enemy_evade": 3,
-      "enemy_fight": 3,
-      "faction_code": "neutral",
-      "flavor": "Some people would do anything to get their case heard.",
-      "health": 3,
-      "illustrator": "Elder Sign: Gates of Arkham",
-      "name": "Unhappy Client",
-      "pack_code": "zoc",
-      "position": 9,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31004",
-      "subtype_code": "weakness",
-      "text": "<b>Prey</b> - Rodney Dorman only.\nHunter.\nTreat all [[Case]] assets' printed text box as if it were blank (except for [[Traits]]).\n[action] <b>Parley.</b> Place 1 of your clues at your location. Deal 1 damage to Unhappy Client.",
-      "traits": "Humanoid. Criminal.",
-      "type_code": "enemy"
-  },
-  {
-      "back_flavor": "The war effort was rough for all, and for Lucia Deveraux it was no exception. She had simply signed up as a nurse, claiming expertise in medicine at the time. However, more and more soldiers kept coming back with even more bizarre wounds, many of which seemed to be more than what resulted from just bullets and explosions. Regardless, she did her job without paying much mind to it. Flash forward to years later, Lucia has found it difficult to find employment. Sure, she can help give out some medicines or whatnot, but her constant nightmares of what she saw haunt her tremendously. Worse yet, she believes that whatever caused those horrific tragedies is coming for her next, around every corner and in every shadow. \"Just gotta help a few more fellas, and that'll be enough dough to skip this town for good\", she keeps telling herself.",
-      "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: [[Spirit]] cards level 0-5, Rogue cards ([rogue]) level 0-4, [[Relic]] cards level 0, Neutral cards level 0-5, up to 5 other [[Science]] and/or [[Talent]] cards level 0-1.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Lucia's Scalpel, Nurses' Bag, Ones We Lost, 1 random basic weakness.",
-      "code": "zoc_31010",
-      "deck_limit": 1,
-      "deck_options": [
-          {
-              "trait": [
-                  "spirit"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "faction": [
-                  "rogue"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 4
-              }
-          },
-          {
-              "trait": [
-                  "relic"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 0
-              }
-          },
-          {
-              "faction": [
-                  "neutral"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "trait": [
-                  "science",
-                  "talent"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 1
-              },
-              "limit": 5
-          }
-      ],
-      "deck_requirements": "size:30, card:zoc_31011, card:zoc_31012, card:zoc_31013, random:subtype:basicweakness",
-      "double_sided": true,
-      "faction_code": "rogue",
-      "health": 8,
-      "illustrator": "Oleg Kuzmin",
-      "is_unique": true,
-      "name": "Lucia Deveraux",
-      "pack_code": "zoc",
-      "position": 10,
-      "quantity": 1,
-      "sanity": 6,
-      "skill_agility": 5,
-      "skill_intellect": 4,
-      "skill_combat": 1,
-      "skill_willpower": 2,
-      "subname": "The Nurse",
-      "text": "You may take an additional action during your turn, which can only be used to play cards or activate [action] abilities that heal investigators.\n[reaction] After the above action is taken: Gain 1 resource. (Limit once per round)\n[elder_sign] effect: +1. If this test is successful, heal 1 damage or horror from an investigator at your location.",
-      "traits": "Veteran. Medic.",
-      "type_code": "investigator",
-      "flavor": "\"Yeah yeah, quit yer yappin', I'll be right there...\""
-  },
-  {
-      "code": "zoc_31011",
-      "cost": 3,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "name": "Lucia's Scalpel",
-      "is_unique": true,
-      "pack_code": "zoc",
-      "position": 11,
-      "quantity": 1,
-      "slot": "Hand",
-      "restrictions": "investigator:zoc_31010",
-      "skill_agility": 1,
-      "skill_combat": 1,
-      "text": "Fast. Lucia Deveraux deck only.\n[action] <b>Fight.</b> This attack uses [agility] instead of [combat] and deals +1 damage. If you succeed, you may resolve the below ability, ignoring action costs.\n[action] Heal 2 damage or horror from an investigator at your location. Then, take 1 damage or horror.",
-      "illustrator": "Esther Mercy",
-      "traits": "Item. Melee. Tool. Science.",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31012",
-      "cost": 2,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "name": "Nurses' Bag",
-      "pack_code": "zoc",
-      "position": 12,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31010",
-      "skill_agility": 1,
-      "skill_intellect": 1,
-      "skill_wild": 1,
-      "text": "Lucia Deveraux deck only.\n[action] Exhaust Nurses' Bag: One at a time, discard the top card of your deck until you discard a card with the [[Item]] trait. Draw that card. Shuffle each weakness that was discarded by this effect back into your deck.\n[reaction] When you heal damage or horror from an investigator at your location, exhaust Nurses' Bag: Gain as many resources as the total damage and/or horror healed.",
-      "illustrator": "Miguel Ángel González",
-      "traits": "Item. Science.",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31013",
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Filipe Pagliuso",
-      "name": "Ones We Lost",
-      "pack_code": "zoc",
-      "position": 13,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31010",
-      "subtype_code": "weakness",
-      "text": "<b>Revelation</b> - Place Ones We Lost in your threat area.\nYou get -1 to each of your skills for each point of damage on you <i>(to a minimum of 0)</i>.\n<b>Forced</b> - At the end of your turn: If you have 3 or more damage on your investigator and healed any investigators this turn, discard Ones We Lost.",
-      "traits": "Flaw.",
-      "flavor": "No one's ever really gone.",
-      "type_code": "treachery"
-  },
-  {
-      "back_flavor": "By all accounts, Richard Carlisle is dead. Everyone saw the news story, it was a massive wreck. A gigantic car crash smashing his Ford to absolute bits! The strangest part of it all was that in the wreck of the totalled vehicle, the body of Mr. Carlisle was not found at all. A few days later, a man named Richard Carlisle started appearing again, alive and well. He claims to be the same man, talks the same talk, walks the same walk, and even has the same daredevil attitude that probably got him in that accident to begin with. However, when asked about how he survived it was very strange. His only answer was an odd claim. A claim to have just 'crawled out once he saw a smirk'.",
-      "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Mystic cards ([mystic]) level 0-5, [[Gambit]] cards level 0-3, up to 10 other Rogue and/or Survivor cards ([rogue]/[survivor]) level 0-1, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Smirk, Toll of Magic, 1 random basic weakness.",
-      "code": "zoc_31014",
-      "deck_limit": 1,
-      "deck_options": [
-          {
-              "faction": [
-                  "neutral"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "faction": [
-                  "mystic"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "trait": [
-                  "gambit"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 3
-              }
-          },
-          {
-              "faction": [
-                  "rogue",
-                  "survivor"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 1
-              },
-              "limit": 10,
-              "error": "You cannot have more than 10 Rogue and/or Survivor cards"
-          }
-      ],
-      "deck_requirements": "size:30, card:zoc_31015,card:zoc_31016, random:subtype:basicweakness",
-      "double_sided": true,
-      "faction_code": "mystic",
-      "health": 6,
-      "is_unique": true,
-      "name": "Richard Carlisle",
-      "pack_code": "zoc",
-      "position": 14,
-      "quantity": 1,
-      "sanity": 8,
-      "skill_agility": 4,
-      "skill_intellect": 2,
-      "skill_combat": 1,
-      "skill_willpower": 5,
-      "subname": "The Warlock",
-      "text": "[reaction] When you succeed on a skill test on a [[Spell]] card, for every 2 points you succeed by you may (choose one):\n- Draw 1 card.\n- Gain 1 resource.\n- Discover 1 clue at your location.\n- Deal 1 damage to an enemy at your location.\n(Limit once per round per effect)\n[elder_sign] effect: 0. Double the icons on all cards committed to this test.",
-      "traits": "Sorcerer. Criminal.",
-      "type_code": "investigator",
-      "illustrator": "Chris McGrath"
-  },
-  {
-      "code": "zoc_31015",
-      "cost": 4,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "name": "\"Smirk\"",
-      "subname": "Source of All Power",
-      "is_unique": true,
-      "pack_code": "zoc",
-      "position": 15,
-      "quantity": 1,
-      "skill_wild": 2,
-      "slot": "Ally",
-      "restrictions": "investigator:zoc_31014",
-      "text": "Richard Carlisle deck only.\n[reaction] When committing cards to a skill test, exhaust \"Smirk\": All cards committed to this test gain a [wild] icon until the end of the test.\n[reaction] When you use Richard Carlisle's [reaction] ability, exhaust \"Smirk\": This use of his ability does not count towards its limit.",
-      "traits": "Ally. Avatar. Ancient One?",
-      "type_code": "asset",
-      "illustrator": "Benjamin Weustemaat"
-  },
-  {
-      "code": "zoc_31016",
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "Filipe Pagliuso",
-      "name": "Toll of Magic",
-      "pack_code": "zoc",
-      "position": 16,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31014",
-      "subtype_code": "weakness",
-      "text": "<b>Revelation</b> - Test [willpower] (0). Skill icons on cards committed to this test subtract from your skill value instead of adding to it.\nFor every 2 points you succeed by, you must either take 1 damage or take 1 horror.",
-      "traits": "Omen.",
-      "flavor": "Did you really think you could control this power?",
-      "type_code": "treachery"
-  },
-  {
-      "back_flavor": "Nobody was sure how Melissa Swanson was able to do her 'parlor tricks', as she called them. She always had a way with the arcane, and she always used it to her advantage. A strong combination of feminine wiles and esoteric arts, she always got her way. When she grew older, she grew quite a fondness for ancient artifacts and treats, so she devoted her spare time into researching the origin of such items. The deeper she delved, the more profane knowledge that man was not destined to know was unlocked for her. Not that she minded, anyways. After all, she was always good at handling whatever magic was thrown her way.",
-      "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Mystic cards ([mystic]) level 0-5, [[Innate]] cards level 0-3, Neutral cards level 0-5, up to 5 other Seeker cards ([seeker]) level 0.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Unstoppable Power, Price of Power, 1 random basic weakness.",
-      "code": "zoc_31017",
-      "deck_limit": 1,
-      "deck_options": [
-          {
-              "faction": [
-                  "neutral"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "faction": [
-                  "mystic"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "trait": [
-                  "innate"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 3
-              }
-          },
-          {
-              "faction": [
-                  "seeker"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 0
-              },
-              "limit": 5
-          }
-      ],
-      "deck_requirements": "size:30, card:zoc_31018,card:zoc_31019, random:subtype:basicweakness",
-      "double_sided": true,
-      "faction_code": "mystic",
-      "health": 5,
-      "illustrator": "Luisa Preissler",
-      "is_unique": true,
-      "name": "Melissa Swanson",
-      "flavor": "\"Some of us are just naturally this skilled.\"",
-      "pack_code": "zoc",
-      "position": 17,
-      "quantity": 1,
-      "sanity": 9,
-      "skill_agility": 2,
-      "skill_intellect": 4,
-      "skill_combat": 2,
-      "skill_willpower": 4,
-      "subname": "The Antiquarian",
-      "traits": "Socialite. Sorcerer.",
-      "text": "[free] After an investigator at your location commits a card to a skill test, spend 1 charge from an asset you control: That card gains [wild] [wild] icons until the end of the test. (Limit once per test)\n[elder_sign] effect: +0. After this test ends, search the top 3 cards of your deck for a skill card and add it to your hand. Shuffle your deck.",
-      "type_code": "investigator"
-  },
-  {
-      "code": "zoc_31018",
-      "cost": 3,
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "restrictions": "investigator:zoc_31017",
-      "name": "Unstoppable Power",
-      "pack_code": "zoc",
-      "position": 18,
-      "quantity": 1,
-      "skill_wild": 3,
-      "text": "Melissa Swanson deck only.\nPerform a basic action. For each skill test that occurs during that action, commit every eligible skill card from your hand and discard pile. This action does not provoke attacks of opportunity.",
-      "traits": "Spell.",
-      "type_code": "event",
-      "illustrator": "Mykz Revecho"
-  },
-  {
-      "code": "zoc_31019",
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "illustrator": "wombo.art",
-      "name": "Price of Power",
-      "pack_code": "zoc",
-      "position": 19,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31017",
-      "subtype_code": "weakness",
-      "text": "<b>Revelation</b> - Place Price of Power in your threat area.\n<b>Forced</b> - At the end of your turn: Choose and discard 1 skill card from your hand. If you cannot, take 2 horror and discard Price of Power.",
-      "traits": "Curse.",
-      "type_code": "treachery"
-  },
-  {
-      "back_flavor": "Bad luck used to follow Walter around like a bad hair day. Endless calamity and misery surrounded the poor guy so to get through the day he always tried to pray. He prayed and prayed and prayed, but he did not get an answer. No answers caused Walter to get desperate. He traveled the world, learning all sorts of ancient rituals and arts, anything that would work to help his rotten luck turn around. Walter called out to any powers that be, but he may not appreciate who will be the one that answers.",
-      "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Survivor cards ([survivor]) level 0-3, [[Ritual]] cards level 0-5, Neutral cards level 0-5, up to 5 Mystic cards ([mystic]) level 0.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Pocket Bible, Desperation, 1 random basic weakness.\n<b>Bonus Experience</b>: You begin the campaign with 5 additional experience (does not affect the number of weaknesses you must take in Standalone Mode).",
-      "code": "zoc_31020",
-      "deck_limit": 1,
-      "deck_options": [
-          {
-              "faction": [
-                  "neutral"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "faction": [
-                  "survivor"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 3
-              }
-          },
-          {
-              "trait": [
-                  "ritual"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 5
-              }
-          },
-          {
-              "faction": [
-                  "mystic"
-              ],
-              "level": {
-                  "min": 0,
-                  "max": 0
-              },
-              "limit": 5,
-              "error": "You cannot have more than 5 Mystic cards"
-          }
-      ],
-      "deck_requirements": "size:30, card:zoc_31021,card:zoc_31022, random:subtype:basicweakness",
-      "double_sided": true,
-      "faction_code": "survivor",
-      "health": 6,
-      "illustrator": "Mauro Belfiore",
-      "is_unique": true,
-      "name": "Walter Crankovitch",
-      "flavor": "\"By all the power vested in me, you will be gone from this realm!\"",
+                "text": ["<b>Fight\\.<\\/b>"],
+                "level": {
+                    "min": 0,
+                    "max": 3
+                }
+            },
+            {
+                "faction": [
+                    "survivor"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 0
+                },
+                "limit": 5,
+                "error": "You cannot have more than 5 Survivor cards"
+            }
+        ],
+        "deck_requirements": "size:30, card:zoc_31002, card:zoc_31003, random:subtype:basicweakness",
+        "double_sided": true,
+        "faction_code": "guardian",
+        "flavor": "\"Stay back!\"",
+        "health": 7,
+        "illustrator": "Mark Molnar",
+        "is_unique": true,
+        "name": "Sampson Welch",
+        "pack_code": "zoc",
+        "position": 1,
+        "quantity": 1,
+        "sanity": 4,
+        "skill_agility": 3,
+        "skill_intellect": 2,
+        "skill_combat": 4,
+        "skill_willpower": 3,
+        "subname": "The Beat Cop",
+        "text": "You begin the game with Brock in play.\n[reaction] When an enemy leaves your location: Take a fight action against that enemy. (Limit once per round)\n[elder_sign] effect: +2. You may choose a non-[[Elite]] enemy at a connected location and move it to your location. If you do, ready Brock.",
+        "traits": "Police.",
+        "type_code": "investigator"
+    },
+    {
+        "code": "zoc_31002",
+        "cost": 2,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "name": "Brock",
+        "subname": "Man's Best Friend",
+        "is_unique": true,
+        "pack_code": "zoc",
+        "position": 2,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31001",
+        "skill_agility": 1,
+        "skill_combat": 1,
+        "text": "Sampson Welch deck only.\n[free] During your turn, exhaust Brock: Disengage from an enemy and move them to a connecting location.\n[reaction] During a fight action, exhaust Brock: Add your [agility] to this attack.",
+        "flavor": "Not so friendly if not fed.",
+        "health": 3,
+        "sanity": 2,
+        "illustrator": "Mark Molnar",
+        "traits": "Ally. Creature.",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31003",
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Jake Murray",
+        "name": "Targeted for The Chase",
+        "pack_code": "zoc",
+        "position": 3,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31001",
+        "subtype_code": "weakness",
+        "text": "<b>Revelation</b> - Each hunter enemy at a connecting location moves one location closer to you and engages you. Each enemy engaged with you readies, then attacks you. If no enemies were readied or moved by this effect, either discard Brock or shuffle Targeted for The Chase back into your deck.",
+        "traits": "Omen.",
+        "type_code": "treachery"
+    },
+    {
+        "back_flavor": "You had a case you needed solved, Rodney Dorman had your back. He got the evidence, the interviews, and he worked fast and quick so you see justice done. That is, until his last trip to France where he had been invited to see a showing of \"The King in Yellow\". An absolutely fascinating play that stuck with him a bit too much once he returned to Arkham. His mind kept spinning and spinning until he could not take it anymore, resorting him to rely on treatment through booze. The reliability he was known for is long gone. Now, he has been trying to get off the bottle and go through his massive backlog of unsolved cases. He worked as hard as he can, but no matter what he did, he cannot get that play out of his mind (or what was left of it anyways).",
+        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Seeker cards ([seeker]) level 0-5, [[Insight]] cards level 0-4, up to 10 other Rogue and/or Guardian ([rogue]/[guardian]) cards level 0-1, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Case #17, Case #75, Case #257, Case #1910, Unhappy Client, 1 random basic weakness.",
+        "code": "zoc_31004",
+        "deck_limit": 1,
+        "deck_options": [
+            {
+                "faction": [
+                    "neutral"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "faction": [
+                    "seeker"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "trait": [
+                    "insight"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 4
+                }
+            },
+            {
+                "faction": [
+                    "rogue",
+                    "guardian"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 1
+                },
+                "limit": 10,
+                "error": "You cannot have more than 10 Rogue and/or Guardian cards"
+            }
+        ],
+        "deck_requirements": "size:30, card:zoc_31005, card:zoc_31006, card:zoc_31007, card:zoc_31008, card:zoc_31009, random:subtype:basicweakness",
+        "double_sided": true,
+        "faction_code": "seeker",
+        "flavor": "\"Everyone deserves a fair trial.\"",
+        "health": 7,
+        "illustrator": "Scott Gustafson",
+        "is_unique": true,
+        "name": "Rodney Dorman",
+        "pack_code": "zoc",
+        "position": 4,
+        "quantity": 1,
+        "sanity": 7,
+        "skill_agility": 2,
+        "skill_intellect": 4,
+        "skill_combat": 3,
+        "skill_willpower": 3,
+        "subname": "The Attorney",
+        "text": "<b>Forced</b> - When the game begins: Reveal cards from the top of your deck until you reveal a [[Case]] asset. Put that asset into play. Shuffle each other revealed card back into your deck.\nThe first investigate action you perform on each turn does not provoke attacks of opportunity.\n[elder_sign] effect: +1. You may shuffle a [[Case]] asset from your discard pile into your deck.",
+        "traits": "Civic. Veteran.",
+        "type_code": "investigator"
+    },
+    {
+        "code": "zoc_31005",
+        "cost": 2,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Norman Saunders",
+        "name": "Case #17",
+        "pack_code": "zoc",
+        "position": 5,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31004",
+        "skill_combat": 1,
+        "text": "Fast. Rodney Dorman deck only.\nUses (2 evidence). If there is no evidence on Case #17, discard it.\n[reaction] When you discover a clue while engaged with an enemy, spend 1 evidence: You may either exhaust that enemy or deal 1 damage to that enemy.",
+        "traits": "Case.",
+        "subname": "Fraud",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31006",
+        "cost": 1,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Rafał Szłapa",
+        "name": "Case #75",
+        "pack_code": "zoc",
+        "position": 6,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31004",
+        "skill_agility": 1,
+        "text": "Fast. Rodney Dorman deck only.\nUses (3 evidence). If there is no evidence on Case #75, discard it.\n[reaction] When an enemy engages you, spend 1 evidence: Gain 1 resource.",
+        "traits": "Case.",
+        "subname": "Robbery",
+        "flavor": "\"Your honor, my client was simply returning the artifacts.\"",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31007",
+        "cost": 1,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Thaldir",
+        "name": "Case #257",
+        "pack_code": "zoc",
+        "position": 7,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31004",
+        "skill_intellect": 1,
+        "text": "Fast. Rodney Dorman deck only.\nUses (3 evidence). If there is no evidence on Case #257, discard it.\n[reaction] When an enemy engages you, spend 1 evidence: Draw 1 card.",
+        "traits": "Case.",
+        "subname": "Missing Items",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31008",
+        "cost": 3,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Rafał Szłapa",
+        "name": "Case #1910",
+        "pack_code": "zoc",
+        "position": 8,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31004",
+        "skill_willpower": 1,
+        "text": "Fast. Rodney Dorman deck only.\n[reaction] When a non-[[Elite]] enemy engages you, you may disengage from that enemy. Then, either exhaust that enemy or move immediately to a connecting location. Discard Case #1910.",
+        "traits": "Case.",
+        "subname": "Premeditated Assault",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31009",
+        "deck_limit": 1,
+        "enemy_damage": 1,
+        "enemy_evade": 3,
+        "enemy_fight": 3,
+        "faction_code": "neutral",
+        "flavor": "Some people would do anything to get their case heard.",
+        "health": 3,
+"illustrator": "Elder Sign: Gates of Arkham",
+        "name": "Unhappy Client",
+        "pack_code": "zoc",
+        "position": 9,
+        "quantity": 1,
+                "restrictions": "investigator:zoc_31004",
+        "subtype_code": "weakness",
+        "text": "<b>Prey</b> - Rodney Dorman only.\nHunter.\nTreat all [[Case]] assets' printed text box as if it were blank (except for [[Traits]]).\n[action] <b>Parley.</b> Place 1 of your clues at your location. Deal 1 damage to Unhappy Client.",
+        "traits": "Humanoid. Criminal.",
+        "type_code": "enemy"
+    },
+    {
+        "back_flavor": "The war effort was rough for all, and for Lucia Deveraux it was no exception. She had simply signed up as a nurse, claiming expertise in medicine at the time. However, more and more soldiers kept coming back with even more bizarre wounds, many of which seemed to be more than what resulted from just bullets and explosions. Regardless, she did her job without paying much mind to it. Flash forward to years later, Lucia has found it difficult to find employment. Sure, she can help give out some medicines or whatnot, but her constant nightmares of what she saw haunt her tremendously. Worse yet, she believes that whatever caused those horrific tragedies is coming for her next, around every corner and in every shadow. \"Just gotta help a few more fellas, and that'll be enough dough to skip this town for good\", she keeps telling herself.",
+        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Rogue cards ([rogue]) level 0-5, [[Science]] cards level 0-4, up to 10 other Guardian and/or Survivor ([guardian]/[survivor]) cards level 0-1, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Lucia's Scalpel, Nurses' Bag, Ones We Lost, 1 random basic weakness.",
+        "code": "zoc_31010",
+        "deck_limit": 1,
+        "deck_options": [
+            {
+                "faction": [
+                    "neutral"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "faction": [
+                    "rogue"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "trait": [
+                    "science"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 4
+                }
+            },
+            {
+                "faction": [
+                    "survivor",
+                    "guardian"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 1
+                },
+                "limit": 10
+            }
+        ],
+        "deck_requirements": "size:30, card:zoc_31011, card:zoc_31012, card:zoc_31013, random:subtype:basicweakness",
+        "double_sided": true,
+        "faction_code": "rogue",
+        "health": 8,
+        "illustrator": "Oleg Kuzmin",
+        "is_unique": true,
+        "name": "Lucia Deveraux",
+        "pack_code": "zoc",
+        "position": 10,
+        "quantity": 1,
+        "sanity": 6,
+        "skill_agility": 5,
+        "skill_intellect": 4,
+        "skill_combat": 1,
+        "skill_willpower": 2,
+        "subname": "The Nurse",
+        "text": "You may take an additional action during your turn, which can only be used to play cards or activate [action] abilities that heal investigators.\n[reaction] After one of your card effects heals an investigator: Gain 1 resource. (Limit once per round)\n[elder_sign] effect: +1. If this test is successful, heal 1 damage or horror from an investigator at your location.",
+        "traits": "Veteran. Medic.",
+        "type_code": "investigator",
+        "flavor": "\"Yeah yeah, quit yer yappin', I'll be right there...\""
+    },
+    {
+        "code": "zoc_31011",
+        "cost": 3,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "name": "Lucia's Scalpel",
+        "is_unique": false,
+        "pack_code": "zoc",
+        "position": 11,
+        "quantity": 1,
+        "slot": "Hand",
+        "restrictions": "investigator:zoc_31010",
+        "skill_agility": 1,
+        "skill_combat": 1,
+        "text": "Fast. Lucia Deveraux deck only.\n[action]: <b>Fight.</b> This attack uses [agility] instead of [combat] and deals +1 damage. If you succeed, you may resolve the below ability without paying its [action] cost.\n[action] Exhaust Lucia's Scalpel: Test [agility] (1). For each point you succeed by, you may heal 1 damage or 1 horror from an investigator at your location.",
+        "illustrator": "Esther Mercy",
+        "traits": "Item. Melee. Tool. Science.",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31012",
+        "cost": 2,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "name": "Nurses' Bag",
+        "pack_code": "zoc",
+        "position": 12,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31010",
+        "skill_agility": 1,
+        "skill_intellect": 1,
+        "skill_wild": 1,
+        "text": "Lucia Deveraux deck only.\n[action] Exhaust Nurses' Bag: One at a time, discard the top card of your deck until you discard a card with the [[Item]] trait. Draw that card. Shuffle each weakness that was discarded by this effect back into your deck.\n[reaction] When you heal damage or horror from an investigator at your location, exhaust Nurses' Bag: Gain as many resources as the total damage and/or horror healed.",
+        "illustrator": "Miguel Ángel González",
+        "traits": "Item. Science.",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31013",
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Filipe Pagliuso",
+        "name": "Ones We Lost",
+        "pack_code": "zoc",
+        "position": 13,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31010",
+        "subtype_code": "weakness",
+        "text": "<b>Revelation</b> - Place Ones We Lost in your threat area.\nYou get -1 to each of your skills for each point of damage on you <i>(to a minimum of 0)</i>.\n<b>Forced</b> - At the end of your turn: If you have 3 or more damage on your investigator and healed any investigators this turn, discard Ones We Lost.",
+        "traits": "Flaw.",
+        "flavor": "No one's ever really gone.",
+        "type_code": "treachery"
+    },
+    {
+        "back_flavor": "By all accounts, Richard Carlisle is dead. Everyone saw the news story, it was a massive wreck. A gigantic car crash smashing his Ford to absolute bits! The strangest part of it all was that in the wreck of the totalled vehicle, the body of Mr. Carlisle was not found at all. A few days later, a man named Richard Carlisle started appearing again, alive and well. He claims to be the same man, talks the same talk, walks the same walk, and even has the same daredevil attitude that probably got him in that accident to begin with. However, when asked about how he survived it was very strange. His only answer was an odd claim. A claim to have just 'crawled out once he saw a smirk'.",
+        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Mystic cards ([mystic]) level 0-5, [[Gambit]] cards level 0-4, up to 10 other Rogue and/or Survivor cards ([rogue]/[survivor]) level 0-1, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Smirk, Toll of Magic, 1 random basic weakness.",
+        "code": "zoc_31014",
+        "deck_limit": 1,
+        "deck_options": [
+            {
+                "faction": [
+                    "neutral"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "faction": [
+                    "mystic"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "trait": [
+                    "gambit"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 4
+                }
+            },
+            {
+                "faction": [
+                    "rogue",
+                    "survivor"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 1
+                },
+                "limit": 10,
+                "error": "You cannot have more than 10 Rogue and/or Survivor cards"
+            }
+        ],
+        "deck_requirements": "size:30, card:zoc_31015,card:zoc_31016, random:subtype:basicweakness",
+        "double_sided": true,
+        "faction_code": "mystic",
+        "health": 6,
+        "is_unique": true,
+        "name": "Richard Carlisle",
+        "pack_code": "zoc",
+        "position": 14,
+        "quantity": 1,
+        "sanity": 8,
+        "skill_agility": 4,
+        "skill_intellect": 2,
+        "skill_combat": 1,
+        "skill_willpower": 5,
+        "subname": "The Warlock",
+        "text": "[reaction] When you succeed on a skill test on a [[Spell]] card, for every 2 points you succeed by you may (choose one):\n- Draw 1 card.\n- Gain 1 resource.\n- Discover 1 clue at your location.\n- Deal 1 damage to an enemy at your location.\n(Limit once per round per effect)\n[elder_sign] effect: 0. Double the icons on all cards committed to this test.",
+        "traits": "Sorcerer. Criminal.",
+        "type_code": "investigator",
+        "illustrator": "Chris McGrath"
+    },
+    {
+        "code": "zoc_31015",
+        "cost": 4,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "name": "\"Smirk\"",
+        "subname": "Source of All Power",
+        "is_unique": true,
+        "pack_code": "zoc",
+        "position": 15,
+        "quantity": 1,
+        "skill_wild": 2,
+        "slot": "Ally",
+        "restrictions": "investigator:zoc_31014",
+        "text": "Richard Carlisle deck only.\n[reaction] When committing cards to a skill test, exhaust \"Smirk\": All cards committed to this test gain a [wild] icon until the end of the test.\n[reaction] When you use Richard Carlisle's [reaction] ability, exhaust \"Smirk\": This use of his ability does not count towards its limit.",
+        "traits": "Ally. Avatar. Ancient One?",
+        "type_code": "asset",
+        "illustrator": "Benjamin Weustemaat"
+    },
+    {
+        "code": "zoc_31016",
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "Filipe Pagliuso",
+        "name": "Toll of Magic",
+        "pack_code": "zoc",
+        "position": 16,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31014",
+        "subtype_code": "weakness",
+        "text": "<b>Revelation</b> - Test [willpower] (0). Skill icons on cards committed to this test subtract from your skill value instead of adding to it.\nFor every 2 points you succeed by, you must either take 1 damage or take 1 horror.",
+        "traits": "Omen.",
+        "flavor": "Did you really think you could control this power?",
+        "type_code": "treachery"
+    },
+    {
+        "back_flavor": "Nobody was sure how Melissa Swanson was able to do her 'parlor tricks', as she called them. She always had a way with the arcane, and she always used it to her advantage. A strong combination of feminine wiles and esoteric arts, she always got her way. When she grew older, she grew quite a fondness for ancient artifacts and treats, so she devoted her spare time into researching the origin of such items. The deeper she delved, the more profane knowledge that man was not destined to know was unlocked for her. Not that she minded, anyways. After all, she was always good at handling whatever magic was thrown her way.",
+        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Mystic cards ([mystic]) level 0-5, [[Innate]] cards level 0-3, Neutral cards level 0-5, up to 5 other Seeker cards ([seeker]) level 0.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Unstoppable Power, Price of Power, 1 random basic weakness.",
+        "code": "zoc_31017",
+        "deck_limit": 1,
+        "deck_options": [
+            {
+                "faction": [
+                    "neutral"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "faction": [
+                    "mystic"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "trait": [
+                    "innate"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 3
+                }
+            },
+            {
+                "faction": [
+                    "seeker"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 0
+                },
+                "limit": 5
+            }
+        ],
+        "deck_requirements": "size:30, card:zoc_31018,card:zoc_31019, random:subtype:basicweakness",
+        "double_sided": true,
+        "faction_code": "mystic",
+        "health": 5,
+        "illustrator": "Luisa Preissler",
+        "is_unique": true,
+        "name": "Melissa Swanson",
+        "flavor": "\"Some of us are just naturally this skilled.\"",
+        "pack_code": "zoc",
+        "position": 17,
+        "quantity": 1,
+        "sanity": 9,
+        "skill_agility": 2,
+        "skill_intellect": 4,
+        "skill_combat": 2,
+        "skill_willpower": 4,
+        "subname": "The Antiquarian",
+        "traits": "Socialite. Sorcerer.",
+        "text": "[free] After an investigator at your location commits a card to a skill test, spend 1 charge from an asset you control: That card gains [wild] [wild] icons until the end of the test. (Limit once per test)\n[elder_sign] effect: +0. After this test ends, search the top 3 cards of your deck for a skill card and add it to your hand. Shuffle your deck.",
+        "type_code": "investigator"
+    },
+    {
+        "code": "zoc_31018",
+        "cost": 3,
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "restrictions": "investigator:zoc_31017",
+        "name": "Unstoppable Power",
+        "pack_code": "zoc",
+        "position": 18,
+        "quantity": 1,
+        "skill_wild": 3,
+        "text": "Melissa Swanson deck only.\nPerform a basic action. For each skill test that occurs during that action, commit every eligible skill card from your hand and discard pile. This action does not provoke attacks of opportunity.",
+        "traits": "Spell.",
+        "type_code": "event",
+        "illustrator": "Mykz Revecho"
+    },
+    {
+        "code": "zoc_31019",
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "illustrator": "wombo.art",
+        "name": "Price of Power",
+        "pack_code": "zoc",
+        "position": 19,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31017",
+        "subtype_code": "weakness",
+        "text": "<b>Revelation</b> - Place Price of Power in your threat area.\n<b>Forced</b> - At the end of your turn: Choose and discard 1 skill card from your hand. If you cannot, take 2 horror and discard Price of Power.",
+        "traits": "Curse.",
+        "type_code": "treachery"
+    },
+    {
+        "back_flavor": "Bad luck used to follow Walter around like a bad hair day. Endless calamity and misery surrounded the poor guy so to get through the day he always tried to pray. He prayed and prayed and prayed, but he did not get an answer. No answers caused Walter to get desperate. He traveled the world, learning all sorts of ancient rituals and arts, anything that would work to help his rotten luck turn around. Walter called out to any powers that be, but he may not appreciate who will be the one that answers.",
+        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Survivor cards ([survivor]) level 0-3, [[Ritual]] cards level 0-5, Neutral cards level 0-5, up to 5 Mystic cards ([mystic]) level 0.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Pocket Bible, Desperation, 1 random basic weakness.\n<b>Bonus Experience</b>: You begin the campaign with 5 additional experience (does not affect the number of weaknesses you must take in Standalone Mode).",
+        "code": "zoc_31020",
+        "deck_limit": 1,
+        "deck_options": [
+            {
+                "faction": [
+                    "neutral"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "faction": [
+                    "survivor"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 3
+                }
+            },
+            {
+                "trait": [
+                    "ritual"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 5
+                }
+            },
+            {
+                "faction": [
+                    "mystic"
+                ],
+                "level": {
+                    "min": 0,
+                    "max": 0
+                },
+                "limit": 5,
+                "error": "You cannot have more than 5 Mystic cards"
+            }
+        ],
+        "deck_requirements": "size:30, card:zoc_31021,card:zoc_31022, random:subtype:basicweakness",
+        "double_sided": true,
+        "faction_code": "survivor",
+        "health": 6,
+        "illustrator": "Mauro Belfiore",
+        "is_unique": true,
+        "name": "Walter Crankovitch",
+        "flavor": "\"By all the power vested in me, you will be gone from this realm!\"",
       "pack_code": "zoc",
       "position": 20,
       "quantity": 1,
@@ -667,33 +658,33 @@
       "illustrator": "linhsiang",
       "name": "Pocket Bible",
       "subname": "English Standard Version",
-      "pack_code": "zoc",
-      "position": 21,
-      "quantity": 1,
-      "slot": "Hand",
-      "restrictions": "investigator:zoc_31020",
-      "skill_willpower": 1,
-      "skill_intellect": 1,
-      "skill_wild": 1,
-      "text": "Walter Crankovitch deck only.\nAll [[Ritual]] cards in play take no slots.\n[reaction] After you play or resolve an ability on a [[Ritual]] card, exhaust Pocket Bible: Add 1 [bless] token to the chaos bag or heal 1 horror from an investigator or [[Ally]] asset at your location.",
-      "flavor": "Has many scribbles of notes to aid your allies and harm your enemies.",
-      "traits": "Item. Relic. Tome.",
-      "type_code": "asset"
-  },
-  {
-      "code": "zoc_31022",
-      "deck_limit": 1,
-      "faction_code": "neutral",
-      "name": "Desperation",
-      "pack_code": "zoc",
-      "position": 22,
-      "quantity": 1,
-      "restrictions": "investigator:zoc_31020",
-      "skill_wild": 1,
-      "subtype_code": "weakness",
-      "text": "Commit Desperation only to skill tests that occur during a [action] or [free] on a [[Ritual]] card. Icons on this card subtract from the total skill value.\n<b>Forced</b> - If this test fails, return Desperation to your hand.\n<b>Forced</b> - If Desperation is in your hand at the end of your turn: Reveal Desperation and take 2 horror.",
-      "traits": "Task. Omen.",
-      "type_code": "skill",
-      "illustrator": "Oswin Neumann"
-  }
+        "pack_code": "zoc",
+        "position": 21,
+        "quantity": 1,
+        "slot": "Hand",
+        "restrictions": "investigator:zoc_31020",
+        "skill_willpower": 1,
+        "skill_intellect": 1,
+        "skill_wild": 1,
+        "text": "Walter Crankovitch deck only.\nAll [[Ritual]] cards in play take no slots.\n[reaction] After you play or resolve an ability on a [[Ritual]] card, exhaust Pocket Bible: Add 1 [bless] token to the chaos bag or heal 1 horror from an investigator or [[Ally]] asset at your location.",
+        "flavor": "Has many scribbles of notes to aid your allies and harm your enemies.",
+        "traits": "Item. Relic. Tome.",
+        "type_code": "asset"
+    },
+    {
+        "code": "zoc_31022",
+        "deck_limit": 1,
+        "faction_code": "neutral",
+        "name": "Desperation",
+        "pack_code": "zoc",
+        "position": 22,
+        "quantity": 1,
+        "restrictions": "investigator:zoc_31020",
+        "skill_wild": 1,
+        "subtype_code": "weakness",
+        "text": "Commit Desperation only to skill tests that occur during a [action] or [free] on a [[Ritual]] card. Icons on this card subtract from the total skill value.\n<b>Forced</b> - If this test fails, return Desperation to your hand.\n<b>Forced</b> - If Desperation is in your hand at the end of your turn: Reveal Desperation and take 2 horror.",
+        "traits": "Task. Omen.",
+        "type_code": "skill",
+        "illustrator": "Oswin Neumann"
+    }
 ]

--- a/cards/zoc.json
+++ b/cards/zoc.json
@@ -348,7 +348,7 @@
         "restrictions": "investigator:zoc_31010",
         "skill_agility": 1,
         "skill_combat": 1,
-        "text": "Fast. Lucia Deveraux deck only.\n[action]: <b>Fight.</b> This attack uses [agility] instead of [combat] and deals +1 damage. If you succeed, you may resolve the below ability without paying its [action] cost.\n[action] Exhaust Lucia's Scalpel: Test [agility] (1). For each point you succeed by, you may heal 1 damage or 1 horror from an investigator at your location.",
+        "text": "Fast. Lucia Deveraux deck only.\n[action]: <b>Fight.</b> This attack uses [agility] instead of [combat] and deals +1 damage. If you succeed, you may resolve the below ability without paying its [action] cost.\n[action] Exhaust Lucia's Scalpel: Test [agility] (1). For each point you succeed by, you may heal 1 damage or 1 horror from an investigator at your location (to a maximum of 4).",
         "illustrator": "Esther Mercy",
         "traits": "Item. Melee. Tool. Science.",
         "type_code": "asset"


### PR DESCRIPTION
Rodney and Richard's trait access are now 0-4 instead of 0-3, Lucia's deckbuilding was changed to fit the pattern of Rodney and Richard 
Added missing trait for Rodney (Civic)
Lucia's Scalpel reworked