### PR TITLE
Plaguebearer update

### DIFF
--- a/campaigns/zcp/campaign.json
+++ b/campaigns/zcp/campaign.json
@@ -1,7 +1,7 @@
 {
   "id": "zcp",
   "position": 22,
-  "version": 2,
+  "version": 3,
   "name": "Call of the Plaguebearer",
   "tarot": [
     "late_risers",

--- a/campaigns/zcp/dead_or_alive.json
+++ b/campaigns/zcp/dead_or_alive.json
@@ -170,7 +170,7 @@
           "type": "campaign_log",
           "section": "campaign_notes",
           "id": "west_has_recovered_the_reagant",
-          "text": "West has recoverred the reagant."
+          "text": "West has recovered the reagant."
         }
       ]
     },

--- a/campaigns/zcp/mourning_chorus.json
+++ b/campaigns/zcp/mourning_chorus.json
@@ -187,6 +187,700 @@
       "hidden": true,
       "type": "branch",
       "condition": {
+        "type": "campaign_data",
+        "campaign_data": "version",
+        "min_version": 3,
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": [
+              "preloop_assign_infected_defended",
+              "loop_assign_infected_defended"
+            ]
+          },
+          {
+            "boolCondition": false,
+            "steps": [
+              "legacy_assign_infected_defended"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "preloop_assign_infected_defended",
+      "type": "story",
+      "text": "Check your campaign log. In a random order, for each location not marked as either \"Defended\" or \"Infected\", mark it as the value which appears less."
+    },
+    {
+      "id": "loop_assign_infected_defended",
+      "type": "branch",
+      "hidden": true,
+      "loop": true,
+      "condition": {
+        "type": "math",
+        "opA": {
+          "type": "campaign_log_count",
+          "section": "hidden",
+          "id": "defended_or_infected"
+        },
+        "opB": {
+          "type": "constant",
+          "value": 8
+        },
+        "operation": "compare",
+        "options": [
+          {
+            "numCondition": -1,
+            "steps": ["choose_defend_infect"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "choose_defend_infect",
+      "type": "branch",
+      "hidden": true,
+      "condition": {
+        "type": "math",
+        "opA": {
+          "type": "campaign_log_count",
+          "section": "hidden",
+          "id": "defended"
+        },
+        "opB": {
+          "type": "campaign_log_count",
+          "section": "hidden",
+          "id": "infected"
+        },
+        "operation": "compare",
+        "options": [
+          {
+            "numCondition": 1,
+            "repeatable": true,
+            "steps": ["assign_infected"]
+          },
+          {
+            "numCondition": 0,
+            "repeatable": true,
+            "steps": ["assign_defended"]
+          },
+          {
+            "numCondition": -1,
+            "repeatable": true,
+            "steps": ["assign_defended"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "assign_defended",
+      "type": "input",
+      "text": "Choose a location (at random) to mark as Defended",
+      "input": {
+        "type": "choose_one",
+        "random": true,
+        "choices": [
+          {
+            "id": "arkham_advertiser",
+            "text": "Arkham Advertiser",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "arkham_advertiser",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "arkham_advertiser",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "bank_of_arkham",
+            "text": "Bank of Arkham",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "bank_of_arkham",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "bank_of_arkham",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "general_store",
+            "text": "General Store",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "general_store",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "general_store",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "hibbs_roadhouse",
+            "text": "Hibb's Roadhouse",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "hibbs_roadhouse",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "hibbs_roadhouse",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "mas_boarding_house",
+            "text": "Ma's Boarding House",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "mas_boarding_house",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "mas_boarding_house",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "orne_library",
+            "text": "Orne Library",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "orne_library",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "orne_library",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "river_docks",
+            "text": "River Docks",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "river_docks",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "river_docks",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "ye_olde_magick_shoppe",
+            "text": "Ye Olde Magick Shoppe",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "ye_olde_magick_shoppe",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "ye_olde_magick_shoppe",
+                "id": "defended",
+                "text": "Defended"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "assign_infected",
+      "type": "input",
+      "text": "Choose a location (at random) to mark as Infected",
+      "input": {
+        "type": "choose_one",
+        "random": true,
+        "choices": [
+          {
+            "id": "arkham_advertiser",
+            "text": "Arkham Advertiser",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "arkham_advertiser",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "arkham_advertiser",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "bank_of_arkham",
+            "text": "Bank of Arkham",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "bank_of_arkham",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "bank_of_arkham",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "general_store",
+            "text": "General Store",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "general_store",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "general_store",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "hibbs_roadhouse",
+            "text": "Hibb's Roadhouse",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "hibbs_roadhouse",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "hibbs_roadhouse",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "mas_boarding_house",
+            "text": "Ma's Boarding House",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "mas_boarding_house",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "mas_boarding_house",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "orne_library",
+            "text": "Orne Library",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "orne_library",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "orne_library",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "river_docks",
+            "text": "River Docks",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "river_docks",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "river_docks",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "ye_olde_magick_shoppe",
+            "text": "Ye Olde Magick Shoppe",
+            "condition": {
+              "type": "campaign_log_count",
+              "section": "ye_olde_magick_shoppe",
+              "id": "$num_entries",
+              "options": [
+                {
+                  "numCondition": 0
+                }
+              ]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "ye_olde_magick_shoppe",
+                "id": "infected",
+                "text": "Infected"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "infected",
+                "operation": "add",
+                "value": 1
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "defended_or_infected",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+
+
+
+
+
+    {
+      "id": "legacy_assign_infected_defended",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
         "type": "math",
         "opA": {
           "type": "campaign_log_count",

--- a/cards/zcp.json
+++ b/cards/zcp.json
@@ -14,6 +14,26 @@
     "type_code": "scenario"
   },
   {
+    "clues": 1,
+    "code": "zcp_00012",
+    "double_sided": true,
+    "encounter_code": "late_risers",
+    "encounter_position": 12,
+    "faction_code": "mythos",
+    "back_text": "Barricade (1[per_investigator])",
+    "back_flavor": "Peering through the barricades, you can spot several inexplicable devices and something that looks like a cadaver",
+    "illustrator": "Carl Shedd",
+    "name": "Lab Delta",
+    "pack_code": "zcp",
+    "position": 12,
+    "quantity": 1,
+    "shroud": 2,
+    "flavor": "Was it your imagination, or did the corpse on the slab just twitch?",
+    "text": "[reaction] When you investigate this location: Increase its shroud level by 4 for this investigation. If you succeed, investigators at this location may spend 3[per_investigator] clues, as a group, to put the set-aside Ripped Hallway location into play.",
+    "traits": "Agency. Delta.",
+    "type_code": "location"
+  },
+  {
     "code": "zcp_00017b",
     "encounter_code": "late_risers",
     "encounter_position": 17,
@@ -361,6 +381,24 @@
     "type_code": "scenario"
   },
   {
+    "clues": 1,
+    "code": "zcp_00129",
+    "double_sided": true,
+    "encounter_code": "high_noon_descent",
+    "encounter_position": 21,
+    "faction_code": "mythos",
+    "back_flavor": "An unsettling glow, like light through water, comes from deeper in the Omega Wing...",
+    "name": "The Left Artery",
+    "pack_code": "zcp",
+    "position": 129,
+    "quantity": 1,
+    "shroud": 1,
+    "flavor": "Something watches you through the window whenever you avert your gaze.",
+    "text": "<b>Forced</b> - After you start your turn at this location: Take 1 direct horror.",
+    "traits": "Miasma. Sub-Level.",
+    "type_code": "location"
+  },
+  {
     "code": "zcp_00138",
     "cost": 5,
     "deck_limit": 1,
@@ -398,7 +436,7 @@
     "type_code": "scenario"
   },
   {
-    "back_text": "Hard / Expert\n[skull]: -X. X is 2 greater than the [[Floor]] of your location.\n[cultist]: -7. If you succeed, you may immediately discover a clue from any revealed location.\n[tablet]: -4. Move the Tendrils of the First one location towards you.\n[elder_thing]: -3. If you fail, each investigator who has <i>Heeded the Call</i> must move one location towards the First Among Many for each point you failed by.",
+    "back_text": "Hard / Expert\n[skull]: -X. X is 2 greater than the [[Floor]] of your location.\n[cultist]: -7. If you succeed, you may immediately discover a clue from any revealed location.\n[tablet]: -4. If you fail, move the Tendrils of the First one location towards you.\n[elder_thing]: -3. If you fail, each investigator who has <i>Heeded the Call</i> must move one location towards the First Among Many for each point you failed by.",
     "code": "zcp_00179",
     "double_sided": true,
     "encounter_code": "death_at_sundown",
@@ -424,5 +462,33 @@
     "quantity": 1,
     "text": "Easy / Standard\n[skull]: -X. X is the number of locations with horror on them (max 4).\n[cultist]: -4. If you succeed, deal 1 damage to any enemy in play or discover 1 clue from any location in play.\n[tablet]: -4. If you fail, move once towards the nearest [[Miasma]] location.\n[elder_thing]: -3. If you fail, each investigator who has <i>Heeded the Call</i> must resolve the <b>Forced</b> ability on each [[Miasma]] location as if they had started their turn there.",
     "type_code": "scenario"
+  },
+  
+  {
+    "back_link": "zcp_00241b",
+    "code": "zcp_00241",
+    "encounter_code": "the_midnight_hour",
+    "encounter_position": 31,
+    "faction_code": "mythos",
+    "name": "Messenger of the Flame",
+    "pack_code": "zcu",
+    "position": 241,
+    "quantity": 1,
+    "text": "<b>Forced</b> - At the start of the enemy phase, if Messenger of the Flame is at a <b>Miasma</b> location without horror: Defeat that location. Otherwise, move Messenger of the Flame once towards the nearest <b>Miasma</b> location without horror.\n[action] If it is not act 1, the investigators spend 3[per_investigator] clues, as a group: <b>Parley</b>. Out of desperation, you seek a bargain with Cthugha. Flip this card and resolve its story text.",
+    "type_code": "asset"
+  },
+  {
+    "code": "zdm_00016b",
+    "encounter_code": "the_midnight_hour",
+    "encounter_position": 31,
+    "faction_code": "mythos",
+    "flavor": "story text",
+    "hidden": true,
+    "name": "Feed the Flame",
+    "pack_code": "zcp",
+    "position": 241,
+    "quantity": 1,
+    "text": "text text",
+    "type_code": "story"
   }
 ]

--- a/cards/zdm.json
+++ b/cards/zdm.json
@@ -10,7 +10,7 @@
     "pack_code": "zdm",
     "position": 1,
     "quantity": 2,
-    "text": "<rev> Test <wil> (3). For each point you fail by, either discard a non-story asset you control, or take 1 horror.",
+    "text": "<b>Revelation</b> - Test [willpower] (3). For each point you fail by, either discard a non-story asset you control, or take 1 horror.",
     "traits": "Madness. Paradox.",
     "type_code": "treachery"
   },
@@ -24,7 +24,7 @@
     "pack_code": "zdm",
     "position": 2,
     "quantity": 2,
-    "text": "Peril.\n<rev> Test <wil> (X). X is your \"Memories.\" If you fail, search the encounter deck for the topmost hidden card and draw it. Shuffle the encounter deck.",
+    "text": "Peril.\n<b>Revelation</b> - Test [willpower] (X). X is your \"Memories.\" If you fail, search the encounter deck for the topmost hidden card and draw it. Shuffle the encounter deck.",
     "traits": "Scheme.",
     "type_code": "treachery"
   },
@@ -38,7 +38,7 @@
     "pack_code": "zdm",
     "position": 3,
     "quantity": 1,
-    "text": "Hidden. Peril.\n<rev> Secretly add this card to your hand.\n<rea> When an investigator would defeat an enemy at your location, heal all damage from it instead: Discard this card.\n<for> When the game ends, or if you are eliminated, if this card is in your hand: Add it to the victory display.",
+    "text": "Hidden. Peril.\n<b>Revelation</b> - Secretly add this card to your hand.\n[reaction] When an investigator would defeat an enemy at your location, heal all damage from it instead: Discard this card.\n<b>Forced</b> - When the game ends, or if you are eliminated, if this card is in your hand: Add it to the victory display.",
     "traits": "Pact.",
     "type_code": "treachery",
     "victory": 0
@@ -53,7 +53,7 @@
     "pack_code": "zdm",
     "position": 4,
     "quantity": 1,
-    "text": "Hidden. Peril.\n<rev> Secretly add this card to your hand.\n<rea> When an investigator would discover any amount of clues from your location, place 1 of their clues on that location instead of discovering clues: Discard this card.\n<for> When the game ends, or if you are eliminated, if this card is in your hand: Add it to the victory display.",
+    "text": "Hidden. Peril.\n<b>Revelation</b> - Secretly add this card to your hand.\n[reaction] When an investigator would discover any amount of clues from your location, place 1 of their clues on that location instead of discovering clues: Discard this card.\n<b>Forced</b> - When the game ends, or if you are eliminated, if this card is in your hand: Add it to the victory display.",
     "traits": "Pact.",
     "type_code": "treachery",
     "victory": 0
@@ -68,7 +68,7 @@
     "pack_code": "zdm",
     "position": 5,
     "quantity": 1,
-    "text": "Hidden. Peril.\n<rev> Secretly add this card to your hand.\n<rea> When an investigator would successfully evade an enemy at your location, that enemy immediately attacks them instead: Discard this card.\n<for> When the game ends, or if you are eliminated, if this card is in your hand: Add it to the victory display.",
+    "text": "Hidden. Peril.\n<b>Revelation</b> - Secretly add this card to your hand.\n[reaction] When an investigator would successfully evade an enemy at your location, that enemy immediately attacks them instead: Discard this card.\n<b>Forced</b> - When the game ends, or if you are eliminated, if this card is in your hand: Add it to the victory display.",
     "traits": "Pact.",
     "type_code": "treachery",
     "victory": 0
@@ -91,7 +91,7 @@
     "pack_code": "zdm",
     "position": 7,
     "quantity": 1,
-    "text": "Massive.\n<rev> Spawn the Feaster from Afar at your location.\n<for> After The Feaster from Afar attacks you: Heal all damage from it and place it at the bottom of the scanning deck.",
+    "text": "Massive.\n<b>Revelation</b> - Spawn the Feaster from Afar at your location.\n<b>Forced</b> - After The Feaster from Afar attacks you: Heal all damage from it and place it at the bottom of the scanning deck.",
     "traits": "Avatar. Ancient One. Elite.",
     "type_code": "enemy",
     "victory": 1
@@ -106,7 +106,7 @@
     "pack_code": "zdm",
     "position": 8,
     "quantity": 1,
-    "text": "Surge. Cannot be cancelled or ignored.\n<rev> If there are 3 or more tally marks under \"Impending Doom\" in your Campaign Log, shuffle the set aside The Feaster from Afar enemy into the scanning deck. Then, remove <fullname> from the game.",
+    "text": "Surge. Cannot be cancelled or ignored.\n<b>Revelation</b> - If there are 3 or more tally marks under \"Impending Doom\" in your Campaign Log, shuffle the set aside The Feaster from Afar enemy into the scanning deck. Then, remove <fullname> from the game.",
     "traits": "Omen.",
     "type_code": "treachery"
   },
@@ -120,7 +120,7 @@
     "pack_code": "zdm",
     "position": 9,
     "quantity": 2,
-    "text": "<rev> Test <com> (3). If you fail, you must either (choose one): Discard a non-story asset you control, or choose and discard 3 cards from your hand.",
+    "text": "<b>Revelation</b> - Test [combat] (3). If you fail, you must either (choose one): Discard a non-story asset you control, or choose and discard 3 cards from your hand.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -133,7 +133,7 @@
     "pack_code": "zdm",
     "position": 10,
     "quantity": 2,
-    "text": "<rev> Test <agi> (3). If you fail, you must either (choose one): Take 2 damage, or discard each event in your hand.",
+    "text": "<b>Revelation</b> - Test [agility] (3). If you fail, you must either (choose one): Take 2 damage, or discard each event in your hand.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -147,7 +147,7 @@
     "pack_code": "zdm",
     "position": 11,
     "quantity": 2,
-    "text": "<rev> Test <wil> (3). If you fail, put this card into play in your threat area.\nYou must commit all eligible skill cards in your hand to skill tests performed at your location.\n<act> Take 1 horror: Discard <fullname>.",
+    "text": "<b>Revelation</b> - Test [willpower] (3). If you fail, put this card into play in your threat area.\nYou must commit all eligible skill cards in your hand to skill tests performed at your location.\n<act> Take 1 horror: Discard <fullname>.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -160,7 +160,7 @@
     "pack_code": "zdm",
     "position": 12,
     "quantity": 2,
-    "text": "Peril.\n<rev> Add Grim Future to any investigator's threat area.\n<for> When the act or agenda advances: Take 1 damage and 1 horror. Test<agis> (3). If you succeed, discard <fullname>.",
+    "text": "Peril.\n<b>Revelation</b> - Add Grim Future to any investigator's threat area.\n<b>Forced</b> - When the act or agenda advances: Take 1 damage and 1 horror. Test [agility] (3). If you succeed, discard <fullname>.",
     "traits": "Endtimes.",
     "type_code": "treachery"
   },
@@ -174,7 +174,7 @@
     "pack_code": "zdm",
     "position": 13,
     "quantity": 3,
-    "text": "<rev> Put <fullname> into play next to the agenda deck.\n<for> After a scenario card places any amount of doom on a card: Place 1 additional doom and discard <fullname>. This effect may cause the current agenda to advance.",
+    "text": "<b>Revelation</b> - Put <fullname> into play next to the agenda deck.\n<b>Forced</b> - After a scenario card places any amount of doom on a card: Place 1 additional doom and discard <fullname>. This effect may cause the current agenda to advance.",
     "traits": "Omen. Endtimes.",
     "type_code": "treachery"
   },
@@ -353,7 +353,7 @@
     "encounter_code": "the_tatterdemalion",
     "encounter_position": 9,
     "faction_code": "mythos",
-    "back_text": "The pressure door leading to the back of the ship needs to be rewired. As an additional cost to enter the <fullname>, investigators in the Mess Hall must spend 1<pers> clues, as a group.",
+    "back_text": "The pressure door leading to the back of the ship needs to be rewired. As an additional cost to enter the <fullname>, investigators in the Mess Hall must spend 1[per_investigator] clues, as a group.",
     "back_illustrator": "Bruno Villalva",
     "illustrator": "Jason Courtney",
     "name": "Cargo Hold",
@@ -362,7 +362,7 @@
     "quantity": 1,
     "shroud": 2,
     "flavor": "As you step through the door, you see dozens of corpses, mutilated and mangled. Scrawled on the floor, in blood and gore, are the words \"no hope\".",
-    "text": "<for> After you enter the <fullname>: Test <wil> (2). If you fail, take 1 horror.",
+    "text": "<b>Forced</b> - After you enter the <fullname>: Test [willpower] (2). If you fail, take 1 horror.",
     "traits": "Tatterdemalion. Access.",
     "type_code": "location"
   },
@@ -402,7 +402,7 @@
     "quantity": 1,
     "shroud": 4,
     "flavor": "The huge room hums. The vibrations under your feet are so thick, they reach straight through the soles of your shoes. Everything looks and feels too hot.",
-    "text": "<for> At the end of your turn, if you are at the <fullname> and do not control Radiation Tablets: Take 1 damage.",
+    "text": "<b>Forced</b> - At the end of your turn, if you are at the <fullname> and do not control Radiation Tablets: Take 1 damage.",
     "traits": "Tatterdemalion.",
     "type_code": "location"
   },
@@ -422,7 +422,7 @@
     "quantity": 1,
     "shroud": 3,
     "flavor": "Slammed together, like compacted teeth, are the three empty coffins. Further inspection reveals that the escape pods have all been sabotaged.",
-    "text": "<rea> After you succeed at evading an enemy at this location: Defeat that enemy. (Group limit 3 times per game.)",
+    "text": "[reaction] After you succeed at evading an enemy at this location: Defeat that enemy. (Group limit 3 times per game.)",
     "traits": "Tatterdemalion. Access.",
     "type_code": "location"
   },
@@ -461,7 +461,7 @@
     "quantity": 1,
     "shroud": 1,
     "flavor": "No signs of human activity. There is enough food to feed the entire waking crew for months -- even years. ",
-    "text": "<rea> When you gain any amount of resources during your turn at the <fullname>: Gain 1 additional resource. (Limit once per round.)",
+    "text": "[reaction] When you gain any amount of resources during your turn at the <fullname>: Gain 1 additional resource. (Limit once per round.)",
     "traits": "Tatterdemalion.",
     "type_code": "location"
   },
@@ -481,7 +481,7 @@
     "quantity": 1,
     "shroud": 3,
     "flavor": "There is a whole bank of instruments and controls. It will take some time to decipher how to read them.",
-    "text": "<for> After you perform a scan at this location, if there are no clues on it: Add 1<pers> clues on it from the token bank.",
+    "text": "<b>Forced</b> - After you perform a scan at this location, if there are no clues on it: Add 1[per_investigator] clues on it from the token bank.",
     "traits": "Tatterdemalion. Access.",
     "type_code": "location"
   },
@@ -502,7 +502,7 @@
     "pack_code": "zdm",
     "position": 29,
     "quantity": 1,
-    "text": "Peril. Hidden.\n<rev> Secretly add this card to your hand.\n<b>Forced --</b> After you discover the last clue from a location: Spawn Cybervirus engaged with you.",
+    "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add this card to your hand.\n<b>Forced --</b> After you discover the last clue from a location: Spawn Cybervirus engaged with you.",
     "traits": "Virtual. ",
     "type_code": "enemy",
     "victory": 1
@@ -520,7 +520,7 @@
     "position": 30,
     "quantity": 1,
     "slot": "Body",
-    "text": "<rev> You may put <fullname> into play under the control of any investigator.\n<act> <act> If you are at an <t>Access</t> location: Move to another <t>Access</t> location. Then, <b>Scan.</b> Search for the topmost card in the scanning deck with the icon below and draw it. Shuffle the scanning deck.",
+    "text": "<b>Revelation</b> - You may put <fullname> into play under the control of any investigator.\n<act> <act> If you are at an <t>Access</t> location: Move to another <t>Access</t> location. Then, <b>Scan.</b> Search for the topmost card in the scanning deck with the icon below and draw it. Shuffle the scanning deck.",
     "traits": "Armor. Item.",
     "type_code": "asset"
   },
@@ -590,7 +590,7 @@
     "position": 34,
     "quantity": 1,
     "subname": "Artificial Co-Pilot",
-    "text": "Aloof. Alert.\n<act>: <b>Parley.</b> Test <wil> (3). If you fail, <fullname> attacks you. If you succeed, choose one of the icons below. <b>Scan.</b> Search for the topmost card in the scanning deck with the chosen icon and draw it. Shuffle the scanning deck.",
+    "text": "Aloof. Alert.\n<act>: <b>Parley.</b> Test [willpower] (3). If you fail, <fullname> attacks you. If you succeed, choose one of the icons below. <b>Scan.</b> Search for the topmost card in the scanning deck with the chosen icon and draw it. Shuffle the scanning deck.",
     "traits": "AI. Machine.",
     "type_code": "enemy",
     "victory": 0
@@ -628,7 +628,7 @@
     "position": 36,
     "quantity": 1,
     "subname": "Artificial Co-Pilot",
-    "text": "Aloof. Retaliate.\n<for> After you defeat this enemy: <b>Scan.</b> Search for the topmost card in the scanning deck with the icon below and draw it. Shuffle the scanning deck.",
+    "text": "Aloof. Retaliate.\n<b>Forced</b> - After you defeat this enemy: <b>Scan.</b> Search for the topmost card in the scanning deck with the icon below and draw it. Shuffle the scanning deck.",
     "traits": "Humanoid. AI. Machine.",
     "type_code": "enemy",
     "victory": 1
@@ -644,7 +644,7 @@
     "pack_code": "zdm",
     "position": 37,
     "quantity": 1,
-    "text": "<rev> You may put this card into play under the control of any investigator.\nUses (3 supplies).\n<rea> After an investigator at your location takes any amount of damage, exhaust Medical Foam and spend 1 supply: Heal that amount of damage from them.",
+    "text": "<b>Revelation</b> - You may put this card into play under the control of any investigator.\nUses (3 supplies).\n[reaction] After an investigator at your location takes any amount of damage, exhaust Medical Foam and spend 1 supply: Heal that amount of damage from them.",
     "traits": "Medical. Science. Item.",
     "type_code": "asset"
   },
@@ -659,7 +659,7 @@
     "pack_code": "zdm",
     "position": 38,
     "quantity": 1,
-    "text": "<rev> You may put this card into play under the control of any investigator.\n<act> Spend 2<pers> clues, as a group: <b>Scan.</b> Search for the topmost card in the scanning deck with the icon below and draw it. Shuffle the scanning deck.",
+    "text": "<b>Revelation</b> - You may put this card into play under the control of any investigator.\n<act> Spend 2[per_investigator] clues, as a group: <b>Scan.</b> Search for the topmost card in the scanning deck with the icon below and draw it. Shuffle the scanning deck.",
     "traits": "Device.",
     "type_code": "asset"
   },
@@ -674,7 +674,7 @@
     "pack_code": "zdm",
     "position": 39,
     "quantity": 1,
-    "text": "<rev> You may put this card into play under the control of any investigator.\nUses (3 supplies).\n<fre> Spend 1 supply: You get +1 <com> and +1 <agi> until the end of the round.",
+    "text": "<b>Revelation</b> - You may put this card into play under the control of any investigator.\nUses (3 supplies).\n<fre> Spend 1 supply: You get +1 [combat] and +1 [agility] until the end of the round.",
     "traits": "Medical. Science. Item.",
     "type_code": "asset"
   },
@@ -707,7 +707,7 @@
     "quantity": 1,
     "shroud": 2,
     "flavor": "An endless maze of cramped and dirty tunnels.",
-    "text": "<rev> Put this location into play.\n<for> When you would enter <fullname>: Test <agis> (3). If you fail, cancel the effects of the move.",
+    "text": "<b>Revelation</b> - Put this location into play.\n<b>Forced</b> - When you would enter <fullname>: Test [agility] (3). If you fail, cancel the effects of the move.",
     "traits": "Tatterdemalion.",
     "type_code": "location"
   },
@@ -751,7 +751,7 @@
     "pack_code": "zdm",
     "position": 44,
     "quantity": 2,
-    "text": "<rev> Attach this card to your current location.\nWhile you are at attached location, each move action and <acts> ability costs 1 additional action.\n<rea> At the end of the round, if you are at attached location: Discard Artificial Gravity Malfunction.",
+    "text": "<b>Revelation</b> - Attach this card to your current location.\nWhile you are at attached location, each move action and <acts> ability costs 1 additional action.\n[reaction] At the end of the round, if you are at attached location: Discard Artificial Gravity Malfunction.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -765,7 +765,7 @@
     "pack_code": "zdm",
     "position": 45,
     "quantity": 2,
-    "text": "Hidden. Peril.\n<rev> Secretly add this card to your hand.\n<for> At the end of your turn, if there are 1 or more clues on your location: Take 2 damage and discard <fullname>.\n<act><act>: Discard Cabin Pressure.",
+    "text": "Hidden. Peril.\n<b>Revelation</b> - Secretly add this card to your hand.\n<b>Forced</b> - At the end of your turn, if there are 1 or more clues on your location: Take 2 damage and discard <fullname>.\n<act><act>: Discard Cabin Pressure.",
     "traits": "Madness.",
     "type_code": "treachery"
   },
@@ -780,7 +780,7 @@
     "pack_code": "zdm",
     "position": 46,
     "quantity": 2,
-    "text": "<rev> Test <agi> (4). For each point you fail by, either choose and discard a card from your hand, or take 1 damage. If you control the EVA Suit story asset, you automatically succeed.",
+    "text": "<b>Revelation</b> - Test [agility] (4). For each point you fail by, either choose and discard a card from your hand, or take 1 damage. If you control the EVA Suit story asset, you automatically succeed.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -795,7 +795,7 @@
     "pack_code": "zdm",
     "position": 47,
     "quantity": 2,
-    "text": "<rev> Attach <fullname> to the nearest <t>Access</t> location.\n<for> At the end of the round: Each investigator at attached location without the EVA Suit story asset takes 3 direct damage. Discard <fullname>.",
+    "text": "<b>Revelation</b> - Attach <fullname> to the nearest <t>Access</t> location.\n<b>Forced</b> - At the end of the round: Each investigator at attached location without the EVA Suit story asset takes 3 direct damage. Discard <fullname>.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -810,7 +810,7 @@
     "pack_code": "zdm",
     "position": 48,
     "quantity": 2,
-    "text": "<rev> Test <agi> or <com> (3). If you fail, deal 1 direct damage to your investigator and to each <t>Ally</t> asset you control. If you control Radiation Tablets, you automatically succeed at this test.",
+    "text": "<b>Revelation</b> - Test [agility] or [combat] (3). If you fail, deal 1 direct damage to your investigator and to each <t>Ally</t> asset you control. If you control Radiation Tablets, you automatically succeed at this test.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -824,7 +824,7 @@
     "pack_code": "zdm",
     "position": 49,
     "quantity": 3,
-    "text": "<rev> Put this card into play in your threat area.\nAs an additional cost to perform a scan, discard cards from the top of the encounter deck until an <t>AI</t> encounter card is discarded and draw it.\n<for> At the end of your turn: Test <agi> (3). If you succeed, discard All-Seeing Eye.",
+    "text": "<b>Revelation</b> - Put this card into play in your threat area.\nAs an additional cost to perform a scan, discard cards from the top of the encounter deck until an <t>AI</t> encounter card is discarded and draw it.\n<b>Forced</b> - At the end of your turn: Test [agility] (3). If you succeed, discard All-Seeing Eye.",
     "traits": "AI.",
     "type_code": "treachery"
   },
@@ -839,7 +839,7 @@
     "pack_code": "zdm",
     "position": 50,
     "quantity": 2,
-    "text": "<rev> Test <agi> (2). This test gains +1 difficulty for each <t>AI</t> encounter card in your threat area. If you fail, each investigator at your location takes 1 damage, and <fullname> gains surge.",
+    "text": "<b>Revelation</b> - Test [agility] (2). This test gains +1 difficulty for each <t>AI</t> encounter card in your threat area. If you fail, each investigator at your location takes 1 damage, and <fullname> gains surge.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -853,7 +853,7 @@
     "pack_code": "zdm",
     "position": 51,
     "quantity": 2,
-    "text": "Hidden. Peril.\n<rev> Secretly add this card to your hand.\n<for> At the end of your turn, if there is at least 1 <t>AI</t> encounter card in your threat area: Take 2 horror and discard <fullname>.\n<act><act>: Discard <fullname>.",
+    "text": "Hidden. Peril.\n<b>Revelation</b> - Secretly add this card to your hand.\n<b>Forced</b> - At the end of your turn, if there is at least 1 <t>AI</t> encounter card in your threat area: Take 2 horror and discard <fullname>.\n<act><act>: Discard <fullname>.",
     "traits": "Terror.",
     "type_code": "treachery"
   },
@@ -867,7 +867,7 @@
     "pack_code": "zdm",
     "position": 52,
     "quantity": 2,
-    "text": "<rev> Put <fullname> into play in your threat area.\nYou get -1 to each of your skills while fighting or evading <t>AI</t> enemies.\n<act> Choose and discard 2 cards from your hand: Discard <fullname>.",
+    "text": "<b>Revelation</b> - Put <fullname> into play in your threat area.\nYou get -1 to each of your skills while fighting or evading <t>AI</t> enemies.\n<act> Choose and discard 2 cards from your hand: Discard <fullname>.",
     "traits": "AI. Scheme.",
     "type_code": "treachery"
   },
@@ -888,7 +888,7 @@
     "pack_code": "zdm",
     "position": 53,
     "quantity": 3,
-    "text": "<spa> Nearest location with no clues.\n<for> After <fullname> enters play: Place 1 clue on its location <i>(from the token bank)</i>.",
+    "text": "<spa> Nearest location with no clues.\n<b>Forced</b> - After <fullname> enters play: Place 1 clue on its location <i>(from the token bank)</i>.",
     "traits": "AI. Spider. Machine.",
     "type_code": "enemy"
   },
@@ -1019,7 +1019,7 @@
     "skill_wild": 2,
     "slot": "Ally",
     "subname": "Quantum Physicist",
-    "text": "[reaction] When your turn begins, put the top card of the encounter deck face-down into your threat area: <b>Fight</b>/<b>Evade</b>/<b>Investigate.</b> If you fail, deal 1 damage to Erwin Simmons.\n<b>Forced</b> - When Erwin Simmons leaves play: Draw all face-down encounter cards in your threat area.",
+    "text": "[reaction] When your turn begins, put the top card of the encounter deck face-down into your threat area: <b>Fight</b>/<b>Evade</b>/<b>Investigate.</b> If you fail, deal 1 damage to Erwin Simmons.\n<b>Forced</b> - - When Erwin Simmons leaves play: Draw all face-down encounter cards in your threat area.",
     "traits": "Scientist. Human. Ally.",
     "type_code": "asset"
   },

--- a/errata/en/errata.json
+++ b/errata/en/errata.json
@@ -300,6 +300,42 @@
           "text": "This card’s ability should read: “…end of your turn. If each surviving investigator has resigned, immediately advance to act 3b.”"
         }
       ]
+    },
+    {
+      "encounter_code": "late_risers",
+      "cards": [
+        {
+          "code": ["zcp_00012"],
+          "text": "This location's [reaction] ability should read “When you investigate this location: Increase its shroud level by 4 <i>for this investigation</i>...”"
+        }
+      ]
+    },
+    {
+      "encounter_code": "high_noon_descent",
+      "cards": [
+        {
+          "code": ["zcp_00129"],
+          "text": "This location should have a yellow circle instead of a blue cross as its location icon."
+        }
+      ]
+    },
+    {
+      "encounter_code": "death_at_sundown",
+      "cards": [
+        {
+          "code": ["zcp_00179"],
+          "text": "On Hard/Expert, the [tablet] should read “-4. If you fail, move...”"
+        }
+      ]
+    },
+    {
+      "encounter_code": "the_midnight_hour",
+      "cards":[
+        {
+          "code": ["zcp_00241"],
+          "text": "Both times this card refers to Feed the Flame, it should refer to Messenger of the Flame."
+        }
+      ]
     }
   ],
   "faq": [
@@ -512,7 +548,7 @@
       "questions": [
         {
           "question": "What happens when you are entering the <b>Ventilation Shaft</b> from a forced effect (i.e. the Dream-Gate), but fail the [agility] test?",
-          "answer": "Choose another revealed locastion to move into instead. If there are no valid options, move into the Ventilation Shaft anyway."
+          "answer": "Choose another revealed location to move into instead. If there are no valid options, move into the Ventilation Shaft anyway."
         },
         {
           "question": "How does <b>UPL-A21</b> work? Can an invesigator without <b>AI</b> cards engage it?",
@@ -656,6 +692,50 @@
           "answer": "In future scenarios, you must swap your investigator card with a Body of a Yithian card during Step 10 of Setting Up the Game, as outlined in the Rules Reference, just as you would when playing “The City of Archives” scenario (see above)."
         }
       ]
+    },
+    {
+      "scenario_code": "night_on_the_town",
+      "questions": [
+        {
+          "question": "When I discard a Spreading Miasma from the game, what happens to the clues on it?",
+          "answer": "They are returned to the token pool, like any other token on a discarded enocounter card."
+        },
+        {
+          "question": "Can I use Sophie/Lucky/Fieldwork on a Defend test?",
+          "answer": "You cannot. Defend tests cannot have their skill values increased."
+        }
+      ]
+    },
+    {
+      "scenario_code": "dead_by_dawn",
+      "questions": [
+        {
+          "question":"After advancing Act 1, should the enemy be exhausted?",
+          "answer":"It should not, but the damage should still be on it"
+        },
+        {
+          "question": "Some enemies have 0 health, shouldn't they be defeated?",
+          "answer": "Normally yes, but pay attention to the “Cannot be defeated” clause on their cards."
+        }
+      ]
+    },
+    {
+      "scenario_code": "mourning_chorus",
+      "questions": [
+        {
+          "question": "What happens when I evade an enemy during Act 2?",
+          "answer": "No doom is removed. The chorus is growing in intensity, and your chance is closing."
+        }
+      ]
+    },
+    {
+      "scenario_code":"death_at_sundown",
+      "questions": [
+        {
+          "question": "When I defeat Tendrils of the First, what happens to the damage on it?",
+          "answer": "The damage is removed and it is placed in the victory display, as normal."
+        }
+      ]
     }
   ],
   "campaign_faq": [
@@ -724,6 +804,15 @@
         {
           "question": "If performing the </i><b>Shift</b><i> ability on the [[Unstable]] side of a key would not affect each investigator or each enemy in play, can I still shift the key?",
           "answer": "To perform a <b>Shift</b> ability on a key, you must resolve as much of that ability as possible, and if that ability changed the game state at all, you are considered to have successfully shifted that key.\nFor example, to shift The Last Blossom from its [[Unstable]] side, you must heal at least 1 damage from an enemy in play (though you must heal 1 damage from as many enemies as possible). Similarly, in order to shift The Bale Engine from its [[Unstable]] side, at minimum 1 investigator needs to discard 1 resource (but each investigator must discard as many resources as possible, to a max of 3)."
+        }
+      ]
+    },
+    {
+      "cycles": ["zcp"],
+      "questions": [
+        {
+          "question": "What happens when I am moved, but cannot move closer to or further from the target?",
+          "answer": "You do not move."
         }
       ]
     }

--- a/i18n/de/campaigns/zcp/dead_or_alive.po
+++ b/i18n/de/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/fr/campaigns/zcp/dead_or_alive.po
+++ b/i18n/fr/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/it/campaigns/zcp/dead_or_alive.po
+++ b/i18n/it/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/ko/campaigns/zcp/dead_or_alive.po
+++ b/i18n/ko/campaigns/zcp/dead_or_alive.po
@@ -58,7 +58,7 @@ msgstr "당신은 웨스트라는 사람을 잘 알지 못하기에, 그를 믿�
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr "그 조사자 덱에서 ‘수상한 서류 가방’을 제거합니다."
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr "웨스트가 시약을 회수했다"
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/pl/campaigns/zcp/dead_or_alive.po
+++ b/i18n/pl/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/pt/campaigns/zcp/dead_or_alive.po
+++ b/i18n/pt/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/ru/campaigns/zcp/dead_or_alive.po
+++ b/i18n/ru/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/uk/campaigns/zcp/dead_or_alive.po
+++ b/i18n/uk/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/vi/campaigns/zcp/dead_or_alive.po
+++ b/i18n/vi/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."

--- a/i18n/zh/campaigns/zcp/dead_or_alive.po
+++ b/i18n/zh/campaigns/zcp/dead_or_alive.po
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Remove the Suspicious Briefcase asset from the controlling investigator's deck."
 msgstr ""
 
-msgid "West has recoverred the reagant."
+msgid "West has recovered the reagant."
 msgstr ""
 
 msgid "Any one investigator may add Herbert West to their deck for the remainder of the campaign. This card does not count against deck size."


### PR DESCRIPTION
Copied info from the previous pull request, tidied very slightly:

> Typos fixed in a Plaguebearer campaign entry, a Dark Matter FAQ, and throughout the Dark Matter card set (replacing what I think are Eons tags(?) with their equivalents.)
>
>Added most of the FAQ items from the end of the Plaguebearer campaign guide to their respective scenarios, one as a campaign FAQ, and the last one is the Dead or Alive choice limiter, which should be an implementation fix.
>
>Added three cards to the Plaguebearer file, and their errata.
>
>Some of the FAQs are rephrased slightly from what's printed, to remove scenario specification (e.g. "After advancing Act 1 of Dead by Dawn...") that isn't necessary in this format. Messenger of the Flame errata rewritten to be more compact, and to correct both instances of the error, instead of just the first. Checked with DJS for approval of these, can provide message screenshots if you'd like to verify.
>
> In Mourning Chorus: 
>"maybe_assign_infected_defended" was a check of whether there were unmarked locations, it is now the version check. My understanding is that by leaving the name unchanged, it stops things breaking, and that since the new or newly named steps are only coming from here, we're safe?
>
>"legacy_assign_infected_defended" is the former content of "maybe_assign_infected_defended". I didn't see a clear way to nest conditionals, so if seemed like this and "loop..." needed to be their own blocks?
>
>"assign_infected_defended" is unchanged.
>
>"preloop_assign_infected_defended" is the campaign guide text from "assign_infected_defended". I wasn't sure if putting it into "loop...." would make it repeat itself every time.
>
> "loop_assign_infected_defended" is the loop. As long as there are unmarked locations, it'll throw to a block that marks one of the player's choice. Note, the guide language allows player to choose to defend or infect in case of a tie, this logic forces them to defend. Since there's an even number of locations, this does not make a difference (since if there's a tie, there'll always be one or more locations after, and the next step will be an infect). Confirmed with DJS that this is okay.
>
> "assign_defended" and "assign_infected" do what they say. Effects blocks are taken from Night on the Town, not from the legacy section (since we need to keep updating defended_or_infected et al, to make the loop work right. I assume that the "steps" block found in the EOTE interludes is optional here?

