### PR TITLE
Script changes to allow builds on Windows

### DIFF
--- a/scripts/buildLocales.js
+++ b/scripts/buildLocales.js
@@ -44,12 +44,13 @@ async function run() {
   shell.exec(`node ./scripts/generateLocales.js --arkham_cards ${argv.arkham_cards}`)
   for (const localeCode of localeCodes) {
     shell.exec(`node ./scripts/generateReturnCampaigns.js -i build/i18n/${localeCode} -o build/i18n/${localeCode}/build`);
-    shell.exec(`./scripts/build.sh -i build/i18n/${localeCode}/campaigns -o build/i18n/${localeCode}/build -r build/i18n/${localeCode}/build/return_campaigns`)
-    shell.exec(`./scripts/generate-campaign-logs.sh -o build/i18n/${localeCode}/build`);
+    shell.exec(`sh ./scripts/build.sh -i build/i18n/${localeCode}/campaigns -o build/i18n/${localeCode}/build -r build/i18n/${localeCode}/build/return_campaigns`);
+    shell.exec(`sh ./scripts/generate-campaign-logs.sh -o build/i18n/${localeCode}/build`);
     shell.cp(`./build/i18n/${localeCode}/build/allCampaigns.json`, `./build/allCampaigns_${localeCode}.json`);
     shell.cp(`./build/i18n/${localeCode}/build/scenarioNames.json`, `./build/scenarioNames_${localeCode}.json`);
     shell.cp(`./build/i18n/${localeCode}/build/campaignLogs.json`, `./build/campaignLogs_${localeCode}.json`);
     shell.cp(`./build/i18n/${localeCode}/build/encounterSets.json`, `./build/encounterSets_${localeCode}.json`);
+    
   }
 }
 

--- a/scripts/generateNarrationScript.js
+++ b/scripts/generateNarrationScript.js
@@ -103,7 +103,7 @@ async function getOrCreatePOFile(scenarioPoFile, localeCode, scenario, quiet) {
  * @param {string} localeCode  - Locale code (en, es, ...)
  */
 async function readEncounterSets(localeCode) {
-  const json = await readJSON(`encounter_sets/${localeCode}.json`);
+  const json = await readJSON(`encounter_sets${path.sep}${localeCode}.json`);
   const encounter_sets = {};
   for(let i = 0; i < json.length; i++) {
     const entry = json[i];
@@ -132,7 +132,7 @@ function messageId(msgId, context) {
  * @param {string} localeCode - Locale code (fr, it, es ...)
  */
 async function generateNarration(localeCode) {
-  const allCampaigns = await readJSON(localeCode === 'en' ? `${argv.arkham_cards}/build/allCampaigns.json` : `${argv.arkham_cards}/build/allCampaigns_${localeCode}.json`);
+  const allCampaigns = await readJSON(localeCode === 'en' ? `${argv.arkham_cards}${path.sep}build${path.sep}allCampaigns.json` : `${argv.arkham_cards}${path.sep}build${path.sep}allCampaigns_${localeCode}.json`);
   const printErr = (err) => {
     if (err) {
       console.log(err);
@@ -140,9 +140,9 @@ async function generateNarration(localeCode) {
   };
 
   // First we gather all the known PO entries.
-  fs.mkdirSync(`${argv.arkham_cards}/build/${localeCode}`, { recursive: true, exists: true });
+  fs.mkdirSync(`${argv.arkham_cards}${path.sep}build${path.sep}${localeCode}`, { recursive: true, exists: true });
   for (const { campaign, scenarios } of allCampaigns) {
-    fs.mkdirSync(`${argv.arkham_cards}/build/${localeCode}/${campaign.id}/`, { recursive: true, exists: true });
+    fs.mkdirSync(`${argv.arkham_cards}${path.sep}build${path.sep}${localeCode}${path.sep}${campaign.id}${path.sep}`, { recursive: true, exists: true });
     if (campaign.steps) {
       let output = '';
       const print = (s) => {
@@ -163,7 +163,7 @@ async function generateNarration(localeCode) {
           print("------");
         }
       }
-      fs.writeFileSync(`${argv.arkham_cards}/build/${localeCode}/${campaign.id}/0_campaign.txt`, output);
+      fs.writeFileSync(`${argv.arkham_cards}${path.sep}build${path.sep}${localeCode}${path.sep}${campaign.id}${path.sep}0_campaign.txt`, output);
     }
     const allScenarios = [...campaign.scenarios, ...(campaign.hidden_scenarios || [])];
     for (const idx in allScenarios) {
@@ -207,7 +207,7 @@ async function generateNarration(localeCode) {
             }
           }
         }
-        fs.writeFileSync(`${argv.arkham_cards}/build/${localeCode}/${campaign.id}/${parseInt(idx, 10) + 1}_${scenario.id}.txt`, output);
+        fs.writeFileSync(`${argv.arkham_cards}${path.sep}build${path.sep}${localeCode}${path.sep}${campaign.id}${path.sep}${parseInt(idx, 10) + 1}_${scenario.id}.txt`, output);
       }
     }
   }

--- a/scripts/generateReturnCampaigns.js
+++ b/scripts/generateReturnCampaigns.js
@@ -17,7 +17,7 @@ const argv = yargs
       alias: 'o',
       description: 'Output directory',
       type: 'string',
-      default: './build',
+      default: `.${path.sep}build`,
     }
   ).help()
   .alias('help', 'h')
@@ -31,20 +31,20 @@ const getFilePaths = (folderPath) => {
   return [...filePaths, ...dirFiles];
 };
 
-const output_dir = argv.output || './build';
+const output_dir = argv.output || `.${path.sep}build`;
 
 if (!fs.existsSync(output_dir)) {
   fs.mkdirSync(output_dir, { recursive: true })
 }
-if (!fs.existsSync(`${output_dir}/return_campaigns`)) {
-  fs.mkdirSync(`${output_dir}/return_campaigns`, { recursive: true })
+if (!fs.existsSync(`${output_dir}${path.sep}return_campaigns`)) {
+  fs.mkdirSync(`${output_dir}${path.sep}return_campaigns`, { recursive: true })
 }
 const input_dir = argv.input || '.';
-const input_replace_dir = input_dir === '.' ? '' : `${input_dir}/`;
+const input_replace_dir = input_dir === '.' ? '' : `${input_dir}${path.sep}`;
 
 console.log(`Generating Return Campaigns: (${input_dir}) -> (${output_dir})`);
 
-getFilePaths(`${input_dir}/return_campaigns`).sort().map(file => {
+getFilePaths(`${input_dir}${path.sep}return_campaigns`).sort().map(file => {
   if (file.endsWith('.schema.json') || !file.endsWith('.json')) {
     return;
   }
@@ -53,11 +53,11 @@ getFilePaths(`${input_dir}/return_campaigns`).sort().map(file => {
   const originalId = json.original_id;
   if (file.endsWith('campaign.json')) {
     const originalData = fs.readFileSync(
-      file.replace('return_campaigns/rt', 'campaigns/'),
+      file.replace(`return_campaigns${path.sep}rt`, `campaigns${path.sep}`),
       'utf-8'
     ).toString();
     const originalJson = jsonlint.parse(originalData);
-    const targetDir = `${output_dir}/return_campaigns/${json.id}`;
+    const targetDir = `${output_dir}${path.sep}return_campaigns${path.sep}${json.id}`;
     if (!fs.existsSync(targetDir)) {
       fs.mkdirSync(targetDir, { recursive: true });
     }
@@ -74,10 +74,10 @@ getFilePaths(`${input_dir}/return_campaigns`).sort().map(file => {
       ];
     }
 
-    fs.writeFileSync(`${targetDir}/campaign.json`,
+    fs.writeFileSync(`${targetDir}${path.sep}campaign.json`,
       JSON.stringify(newCampaign, null, 2)
     );
-    const campaign_dir = file.replace('return_campaigns/rt', 'campaigns/').replace('/campaign.json', '')
+    const campaign_dir = file.replace(`return_campaigns${path.sep}rt`, `campaigns${path.sep}`).replace(`${path.sep}campaign.json`, '')
     console.log(`Campaign Dir: ${campaign_dir}`)
     getFilePaths(campaign_dir).sort().map(originalFile => {
       if (originalFile.endsWith('.schema.json') ||
@@ -88,7 +88,7 @@ getFilePaths(`${input_dir}/return_campaigns`).sort().map(file => {
       }
       const originalScenarioJson = jsonlint.parse(fs.readFileSync(originalFile, 'utf-8').toString());
       if (originalScenarioJson.type === 'interlude' || originalScenarioJson.type === 'epilogue') {
-        const outputFile = originalFile.replace(`${input_replace_dir}campaigns/`, `${output_dir}/return_campaigns/rt`);
+        const outputFile = originalFile.replace(`${input_replace_dir}campaigns${path.sep}`, `${output_dir}${path.sep}return_campaigns${path.sep}rt`);
         console.log(`Saving Interlude/Epilogue to ${outputFile} (original: ${originalFile})`);
         fs.writeFileSync(outputFile, JSON.stringify(originalScenarioJson, null, 2));
       }
@@ -97,7 +97,7 @@ getFilePaths(`${input_dir}/return_campaigns`).sort().map(file => {
     if (!json.id || !json.original_id) {
       throw new Error(`${file} is missing id/original_id (${JSON.stringify(json)})`);
     }
-    const newFile = file.replace('return_campaigns/rt', 'campaigns/')
+    const newFile = file.replace(`return_campaigns${path.sep}rt`, `campaigns${path.sep}`)
       .replace(json.id, json.original_id);
     const originalJson = jsonlint.parse(fs.readFileSync(newFile, 'utf-8').toString());
     const newStepsIds = new Set(json.steps.map(step => step.id));
@@ -105,7 +105,7 @@ getFilePaths(`${input_dir}/return_campaigns`).sort().map(file => {
       ...originalJson.steps.filter(step => !newStepsIds.has(step.id)),
       ...json.steps,
     ];
-    const outputFile = file.replace(`${input_replace_dir}return_campaigns/`, `${output_dir}/return_campaigns/`);
+    const outputFile = file.replace(`${input_replace_dir}return_campaigns${path.sep}`, `${output_dir}${path.sep}return_campaigns${path.sep}`);
     fs.writeFileSync(outputFile,
       JSON.stringify({
         ...originalJson,

--- a/scripts/generateStandalones.js
+++ b/scripts/generateStandalones.js
@@ -18,7 +18,7 @@ const argv = yargs
       alias: 'o',
       description: 'Output directory',
       type: 'string',
-      default: './build',
+      default: `.${path.sep}build`,
     }
   ).help()
   .alias('help', 'h')
@@ -32,7 +32,7 @@ const getFilePaths = (folderPath) => {
   return [...filePaths, ...dirFiles];
 };
 
-const output_dir = argv.output || './build';
+const output_dir = argv.output || `.${path.sep}build`;
 
 if (!fs.existsSync(output_dir)) {
   fs.mkdirSync(output_dir, { recursive: true })
@@ -42,7 +42,7 @@ if (!fs.existsSync(`${output_dir}`)) {
 }
 const input_dir = argv.input || '.';
 const standaloneList = [];
-getFilePaths(`${input_dir}/campaigns`).sort().map(file => {
+getFilePaths(`${input_dir}${path.sep}campaigns`).sort().map(file => {
   if (file.endsWith('.schema.json') || !file.endsWith('.json')) {
     return;
   }
@@ -57,8 +57,8 @@ getFilePaths(`${input_dir}/campaigns`).sort().map(file => {
     return;
   }
   if (json.standalone_setup) {
-    const parts = file.split('/');
-    const campaignFile =  jsonlint.parse(fs.readFileSync(filter(parts, x => x !== parts[parts.length - 1]).join('/') + '/campaign.json', 'utf-8').toString())
+    const parts = file.split(`${path.sep}`);
+    const campaignFile =  jsonlint.parse(fs.readFileSync(filter(parts, x => x !== parts[parts.length - 1]).join(`${path.sep}`) + `${path.sep}campaign.json`, 'utf-8').toString())
     standaloneList.push({
       type: 'scenario',
       campaignId: campaignFile.id,
@@ -66,4 +66,4 @@ getFilePaths(`${input_dir}/campaigns`).sort().map(file => {
     });
   }
 });
-fs.writeFileSync(`${output_dir}/standalone.json`, JSON.stringify(standaloneList, null, 2));
+fs.writeFileSync(`${output_dir}${path.sep}standalone.json`, JSON.stringify(standaloneList, null, 2));

--- a/scripts/i18nStatus.js
+++ b/scripts/i18nStatus.js
@@ -2,7 +2,7 @@ const promisify = require("util").promisify;
 const fs = require("fs");
 const path = require("path");
 const PO = require("pofile");
-const getFilePaths = require("./utils/getFilePaths");
+const getFilePaths = require(`.${path.sep}utils${path.sep}getFilePaths`);
 const unorm = require('unorm');
 const yargs = require('yargs');
 
@@ -132,7 +132,7 @@ async function readPOFile(scenarioPoFile) {
  * @param {string} localeCode - Locale code (fr, it, es ...)
  */
 async function checkLocale(localeCode) {
-  const allPoFiles = getFilePaths(`i18n/${localeCode}`);
+  const allPoFiles = getFilePaths(`i18n${path.sep}${localeCode}`);
   for (const scenarioPoFile of allPoFiles.sort()) {
     let missing = 0;
     if (scenarioPoFile.indexOf(".DS_Store") !== -1) {

--- a/scripts/scrapeArkhamDbFaq.js
+++ b/scripts/scrapeArkhamDbFaq.js
@@ -83,7 +83,7 @@ async function fetchFaq() {
   }
   Object.keys(faqByPack).forEach(pack_code => {
     const json = faqByPack[pack_code];
-    fs.writeFileSync(`./faq/en/${pack_code}.json`, JSON.stringify(json, null, 2));
+    fs.writeFileSync(`.${path.sep}faq${path.sep}en${path.sep}${pack_code}.json`, JSON.stringify(json, null, 2));
   });
 }
 

--- a/scripts/updateLangNarration.js
+++ b/scripts/updateLangNarration.js
@@ -83,7 +83,7 @@ async function writeJSON(object, filePath) {
 async function checkNarration(step, localeCode, audioDir) {
   if (step.narration) {
     const id = step.narration.id;
-    const file = `${audioDir}/${id}.mp3`
+    const file = `${audioDir}${path.sep}${id}.mp3`
     if (await exists(file)) {
       if (argv.verbose) {
         console.log(`Found: ${file}`);
@@ -129,8 +129,8 @@ async function updateScenarioNarration(localeCode, scenario, audioDir) {
  * @param {string} audioDir - Folder containing all audio files.
  */
 async function updateLangNarration(localeCode, audioDir) {
-  const allScenarios = getFilePaths("./campaigns");
-  const allReturnScenarios = getFilePaths("./return_campaigns");
+  const allScenarios = getFilePaths(`.${path.sep}campaigns`);
+  const allReturnScenarios = getFilePaths(`.${path.sep}return_campaigns`);
   for (const scenario of [...allScenarios, ...allReturnScenarios].sort()) {
     if (scenario.indexOf(".DS_Store") !== -1) {
       continue;


### PR DESCRIPTION
Switched '/' separators to be platform-agnostic (where that's necessary), and added explicit 'sh' to two shell commands. 

This should allow everything to run on Windows as well as Mac, (though haven't tested on Mac).