### PR TITLE
Mourning Chorus resolution pruning

### DIFF
--- a/campaigns/zcp/campaign.json
+++ b/campaigns/zcp/campaign.json
@@ -1,7 +1,7 @@
 {
   "id": "zcp",
   "position": 22,
-  "version": 3,
+  "version": 4,
   "name": "Call of the Plaguebearer",
   "tarot": [
     "late_risers",

--- a/campaigns/zcp/mourning_chorus.json
+++ b/campaigns/zcp/mourning_chorus.json
@@ -2016,6 +2016,16 @@
           {
             "id": "arkham_advertiser",
             "text": "Arkham Advertiser",
+            "condition": {
+              "type": "campaign_log",
+              "section": "arkham_advertiser",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2035,6 +2045,16 @@
           {
             "id": "bank_of_arkham",
             "text": "Bank of Arkham",
+            "condition": {
+              "type": "campaign_log",
+              "section": "bank_of_arkham",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2054,6 +2074,16 @@
           {
             "id": "general_store",
             "text": "General Store",
+            "condition": {
+              "type": "campaign_log",
+              "section": "general_store",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2073,6 +2103,16 @@
           {
             "id": "hibbs_roadhouse",
             "text": "Hibb's Roadhouse",
+            "condition": {
+              "type": "campaign_log",
+              "section": "hibbs_roadhouse",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2092,6 +2132,16 @@
           {
             "id": "mas_boarding_house",
             "text": "Ma's Boarding House",
+            "condition": {
+              "type": "campaign_log",
+              "section": "mas_boarding_house",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2111,6 +2161,16 @@
           {
             "id": "orne_library",
             "text": "Orne Library",
+            "condition": {
+              "type": "campaign_log",
+              "section": "orne_library",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2130,6 +2190,16 @@
           {
             "id": "river_docks",
             "text": "River Docks",
+            "condition": {
+              "type": "campaign_log",
+              "section": "river_docks",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2149,6 +2219,16 @@
           {
             "id": "ye_olde_magick_shoppe",
             "text": "Ye Olde Magick Shoppe",
+            "condition": {
+              "type": "campaign_log",
+              "section": "ye_olde_magick_shoppe",
+              "id": "defended",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2191,6 +2271,16 @@
           {
             "id": "doyle",
             "text": "Doyle Jeffries",
+            "condition": {
+              "type": "campaign_log",
+              "section": "arkham_advertiser",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2203,6 +2293,16 @@
           {
             "id": "armitage",
             "text": "Henry Armitage",
+            "condition": {
+              "type": "campaign_log",
+              "section": "orne_library",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2215,6 +2315,16 @@
           {
             "id": "hibbs",
             "text": "Hibbs",
+            "condition": {
+              "type": "campaign_log",
+              "section": "hibbs_roadhouse",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2227,6 +2337,16 @@
           {
             "id": "ma",
             "text": "Ma Matheson",
+            "condition": {
+              "type": "campaign_log",
+              "section": "mas_boarding_house",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2239,6 +2359,16 @@
           {
             "id": "beecher",
             "text": "Miram Beecher",
+            "condition": {
+              "type": "campaign_log",
+              "section": "ye_olde_magick_shoppe",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2251,6 +2381,16 @@
           {
             "id": "the_loving_couple",
             "text": "The Loving Couple",
+            "condition": {
+              "type": "campaign_log",
+              "section": "general_store",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2263,6 +2403,16 @@
           {
             "id": "thing_in_water",
             "text": "The Thing in the Water",
+            "condition": {
+              "type": "campaign_log",
+              "section": "river_docks",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",
@@ -2275,6 +2425,16 @@
           {
             "id": "vice_president",
             "text": "The Vice President",
+            "condition": {
+              "type": "campaign_log",
+              "section": "bank_of_arkham",
+              "id": "infected",
+              "options": [
+                {
+                  "boolCondition": true
+                }
+              ]
+            },
             "effects": [
               {
                 "type": "campaign_log",

--- a/campaigns/zcp/mourning_chorus.json
+++ b/campaigns/zcp/mourning_chorus.json
@@ -8,7 +8,7 @@
     "$check_tarot_reading",
     "gather_encounter_sets",
     "setup_locations",
-    "maybe_assign_infected_defended",
+    "assign_infected_defended_branch",
     "check_too_many_infected",
     "check_defended_locations",
     "check_arkham_advertiser_defended",
@@ -187,6 +187,30 @@
       "hidden": true,
       "type": "branch",
       "condition": {
+        "type": "math",
+        "opA": {
+          "type": "campaign_log_count",
+          "section": "hidden",
+          "id": "defended_or_infected"
+        },
+        "opB": {
+          "type": "constant",
+          "value": 8
+        },
+        "operation": "compare",
+        "options": [
+          {
+            "numCondition": -1,
+            "steps": ["assign_infected_defended_branch"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "assign_infected_defended_branch",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
         "type": "campaign_data",
         "campaign_data": "version",
         "min_version": 3,
@@ -194,26 +218,26 @@
           {
             "boolCondition": true,
             "steps": [
-              "preloop_assign_infected_defended",
-              "loop_assign_infected_defended"
+              "assign_infected_defended_preloop",
+              "assign_infected_defended_loop"
             ]
           },
           {
             "boolCondition": false,
             "steps": [
-              "legacy_assign_infected_defended"
+              "assign_infected_defended"
             ]
           }
         ]
       }
     },
     {
-      "id": "preloop_assign_infected_defended",
+      "id": "assign_infected_defended_preloop",
       "type": "story",
       "text": "Check your campaign log. In a random order, for each location not marked as either \"Defended\" or \"Infected\", mark it as the value which appears less."
     },
     {
-      "id": "loop_assign_infected_defended",
+      "id": "assign_infected_defended_loop",
       "type": "branch",
       "hidden": true,
       "loop": true,
@@ -867,35 +891,6 @@
                 "value": 1
               }
             ]
-          }
-        ]
-      }
-    },
-
-
-
-
-
-    {
-      "id": "legacy_assign_infected_defended",
-      "hidden": true,
-      "type": "branch",
-      "condition": {
-        "type": "math",
-        "opA": {
-          "type": "campaign_log_count",
-          "section": "hidden",
-          "id": "defended_or_infected"
-        },
-        "opB": {
-          "type": "constant",
-          "value": 8
-        },
-        "operation": "compare",
-        "options": [
-          {
-            "numCondition": -1,
-            "steps": ["assign_infected_defended"]
           }
         ]
       }
@@ -2017,20 +2012,20 @@
           {
             "boolCondition": true,
             "steps": [
-              "record_rallied"
+              "record_rallied_pruned"
             ]
           },
           {
             "boolCondition": false,
             "steps": [
-              "record_rallied_legacy"
+              "record_rallied"
             ]
           }
         ]
       }
     },
     {
-      "id": "record_rallied",
+      "id": "record_rallied_pruned",
       "text": "In your Campaign Log, record <i>Rallied</i> under the name of each location you have \"rallied\".",
       "type": "input",
       "input": {
@@ -2273,7 +2268,7 @@
       }
     },
     {
-      "id": "record_rallied_legacy",
+      "id": "record_rallied",
       "text": "In your Campaign Log, record <i>Rallied</i> under the name of each location you have \"rallied\".",
       "type": "input",
       "input": {
@@ -2447,20 +2442,20 @@
           {
             "boolCondition": true,
             "steps": [
-              "record_eliminated_elites"
+              "record_eliminated_elites_pruned"
             ]
           },
           {
             "boolCondition": false,
             "steps": [
-              "record_eliminated_elites_legacy"
+              "record_eliminated_elites"
             ]
           }
         ]
       }
     },
     {
-      "id": "record_eliminated_elites",
+      "id": "record_eliminated_elites_pruned",
       "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
       "type": "input",
       "input": {
@@ -2659,7 +2654,7 @@
       }
     },
     {
-      "id": "record_eliminated_elites_legacy",
+      "id": "record_eliminated_elites",
       "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
       "type": "input",
       "input": {

--- a/campaigns/zcp/mourning_chorus.json
+++ b/campaigns/zcp/mourning_chorus.json
@@ -2006,6 +2006,30 @@
       ]
     },
     {
+      "id": "record_rallied_version",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
+        "type": "campaign_data",
+        "campaign_data": "version",
+        "min_version": 4,
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": [
+              "record_rallied"
+            ]
+          },
+          {
+            "boolCondition": false,
+            "steps": [
+              "record_rallied_legacy"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": "record_rallied",
       "text": "In your Campaign Log, record <i>Rallied</i> under the name of each location you have \"rallied\".",
       "type": "input",
@@ -2249,6 +2273,193 @@
       }
     },
     {
+      "id": "record_rallied_legacy",
+      "text": "In your Campaign Log, record <i>Rallied</i> under the name of each location you have \"rallied\".",
+      "type": "input",
+      "input": {
+        "type": "checklist",
+        "text": "\"Rallied\"",
+        "choices": [
+          {
+            "id": "arkham_advertiser",
+            "text": "Arkham Advertiser",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "arkham_advertiser",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "bank_of_arkham",
+            "text": "Bank of Arkham",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "bank_of_arkham",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "general_store",
+            "text": "General Store",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "general_store",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "hibbs_roadhouse",
+            "text": "Hibb's Roadhouse",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "hibbs_roadhouse",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "mas_boarding_house",
+            "text": "Ma's Boarding House",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "mas_boarding_house",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "orne_library",
+            "text": "Orne Library",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "orne_library",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "river_docks",
+            "text": "River Docks",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "river_docks",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "id": "ye_olde_magick_shoppe",
+            "text": "Ye Olde Magick Shoppe",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "ye_olde_magick_shoppe",
+                "id": "rallied",
+                "text": "Rallied"
+              },
+              {
+                "type": "campaign_log_count",
+                "section": "hidden",
+                "id": "rallied",
+                "operation": "add",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "record_eliminated_elites_version",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
+        "type": "campaign_data",
+        "campaign_data": "version",
+        "min_version": 4,
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": [
+              "record_eliminated_elites"
+            ]
+          },
+          {
+            "boolCondition": false,
+            "steps": [
+              "record_eliminated_elites_legacy"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": "record_eliminated_elites",
       "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
       "type": "input",
@@ -2435,6 +2646,125 @@
                 }
               ]
             },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "vice_president",
+                "text": "The Vice President"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "record_eliminated_elites_legacy",
+      "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
+      "type": "input",
+      "input": {
+        "type": "checklist",
+        "text": "Eliminated",
+        "choices": [
+          {
+            "id": "priest_of_plagues",
+            "text": "Priest of Plagues",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "priest_of_plagues",
+                "text": "Priest of Plagues"
+              }
+            ]
+          },
+          {
+            "id": "doyle",
+            "text": "Doyle Jeffries",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "doyle",
+                "text": "Doyle Jeffries"
+              }
+            ]
+          },
+          {
+            "id": "armitage",
+            "text": "Henry Armitage",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "armitage",
+                "text": "Henry Armitage"
+              }
+            ]
+          },
+          {
+            "id": "hibbs",
+            "text": "Hibbs",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "hibbs",
+                "text": "Hibbs"
+              }
+            ]
+          },
+          {
+            "id": "ma",
+            "text": "Ma Matheson",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "ma",
+                "text": "Ma Matheson"
+              }
+            ]
+          },
+          {
+            "id": "beecher",
+            "text": "Miram Beecher",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "beecher",
+                "text": "Miram Beecher"
+              }
+            ]
+          },
+          {
+            "id": "the_loving_couple",
+            "text": "The Loving Couple",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "the_loving_couple",
+                "text": "The Loving Couple"
+              }
+            ]
+          },
+          {
+            "id": "thing_in_water",
+            "text": "The Thing in the Water",
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "thing_in_water",
+                "text": "The Thing in the Water"
+              }
+            ]
+          },
+          {
+            "id": "vice_president",
+            "text": "The Vice President",
             "effects": [
               {
                 "type": "campaign_log",
@@ -2732,8 +3062,8 @@
       "steps": [
         "earn_xp",
         "record_crater_of_the_unbinding",
-        "record_rallied",
-        "record_eliminated_elites"
+        "record_rallied_version",
+        "record_eliminated_elites_version"
       ]
     },
     {
@@ -2743,8 +3073,8 @@
       "steps": [
         "earn_xp",
         "record_site_of_the_unbinding",
-        "record_rallied",
-        "record_eliminated_elites"
+        "record_rallied_version",
+        "record_eliminated_elites_version"
       ]
     }
   ]

--- a/campaigns/zcp/the_afternoon_war.json
+++ b/campaigns/zcp/the_afternoon_war.json
@@ -1170,20 +1170,20 @@
           {
             "boolCondition": false,
             "steps": [
-              "record_eliminated_elites_legacy"
+              "record_eliminated_elites"
             ]
           },
           {
             "boolCondition": true,
             "steps": [
-              "record_eliminated_elites"
+              "record_eliminated_elites_pruned"
             ]
           }
         ]
       }
     },
     {
-      "id": "record_eliminated_elites",
+      "id": "record_eliminated_elites_pruned",
       "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
       "type": "input",
       "input": {

--- a/campaigns/zcp/the_afternoon_war.json
+++ b/campaigns/zcp/the_afternoon_war.json
@@ -580,7 +580,7 @@
     },
     {
       "id": "check_rallied_locations",
-      "text": "Check your campaign log. For each location recorded as \"Rallied\", put the corresponding story asset into play at that:"
+      "text": "Check your campaign log. For each location recorded as \"Rallied\", put the corresponding story asset into play at that location:"
     },
 
 
@@ -1158,8 +1158,299 @@
         }
       ]
     },
-
-
+    {
+      "id": "record_eliminated_elites_version",
+      "type": "branch",
+      "hidden": true,
+      "condition": {
+        "type": "campaign_data",
+        "campaign_data": "version",
+        "min_version": 4,
+        "options":[
+          {
+            "boolCondition": false,
+            "steps": [
+              "record_eliminated_elites_legacy"
+            ]
+          },
+          {
+            "boolCondition": true,
+            "steps": [
+              "record_eliminated_elites"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "record_eliminated_elites",
+      "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
+      "type": "input",
+      "input": {
+        "type": "checklist",
+        "text": "Eliminated",
+        "choices": [
+          {
+            "id": "priest_of_plagues",
+            "text": "Priest of Plagues",
+            "condition": {
+              "type": "campaign_log",
+              "section": "eliminated",
+              "id": "priest_of_plagues",
+              "options": [{ "boolCondition": false }]
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "priest_of_plagues",
+                "text": "Priest of Plagues"
+              }
+            ]
+          },
+          {
+            "id": "doyle",
+            "text": "Doyle Jeffries",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "doyle",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "arkham_advertiser",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "doyle",
+                "text": "Doyle Jeffries"
+              }
+            ]
+          },
+          {
+            "id": "armitage",
+            "text": "Henry Armitage",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "armitage",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "orne_library",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "armitage",
+                "text": "Henry Armitage"
+              }
+            ]
+          },
+          {
+            "id": "hibbs",
+            "text": "Hibbs",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "hibbs",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "hibbs_roadhouse",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "hibbs",
+                "text": "Hibbs"
+              }
+            ]
+          },
+          {
+            "id": "ma",
+            "text": "Ma Matheson",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "ma",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "mas_boarding_house",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "ma",
+                "text": "Ma Matheson"
+              }
+            ]
+          },
+          {
+            "id": "beecher",
+            "text": "Miram Beecher",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "beecher",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "ye_olde_magick_shoppe",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "beecher",
+                "text": "Miram Beecher"
+              }
+            ]
+          },
+          {
+            "id": "the_loving_couple",
+            "text": "The Loving Couple",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "the_loving_couple",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "general_store",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "the_loving_couple",
+                "text": "The Loving Couple"
+              }
+            ]
+          },
+          {
+            "id": "thing_in_water",
+            "text": "The Thing in the Water",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "thing_in_water",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "river_docks",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "thing_in_water",
+                "text": "The Thing in the Water"
+              }
+            ]
+          },
+          {
+            "id": "vice_president",
+            "text": "The Vice President",
+            "condition": {
+              "type": "multi",
+              "conditions": [
+                {
+                  "type": "campaign_log",
+                  "section": "eliminated",
+                  "id": "vice_president",
+                  "options": [{ "boolCondition": false }]
+                },
+                {
+                  "type": "campaign_log",
+                  "section": "bank_of_arkham",
+                  "id": "infected",
+                  "options": [{ "boolCondition": true }]
+                }
+              ],
+              "count": 2
+            },
+            "effects": [
+              {
+                "type": "campaign_log",
+                "section": "eliminated",
+                "id": "vice_president",
+                "text": "The Vice President"
+              }
+            ]
+          }
+        ]
+      }
+    },
     {
       "id": "record_eliminated_elites",
       "text": "In your Campaign Log, record the name of each [[Elite]] enemy in the victory display as <i>Eliminated</i>",
@@ -1599,7 +1890,7 @@
         "check_messenger_of_flame_defeated",
         "ask_messenger_of_the_king_in_victory",
         "check_messenger_of_the_king_defeated",
-        "record_eliminated_elites",
+        "record_eliminated_elites_version",
         "$upgrade_decks",
         "$proceed",
         "trap"

--- a/campaigns/zcp/the_midnight_hour.json
+++ b/campaigns/zcp/the_midnight_hour.json
@@ -80,7 +80,7 @@
     },
     {
       "id": "set_aside_cards",
-      "text": "Set the following cards aside, out of play: Messenger of Flame, Messenger of the King, Body of Baalshandor, Mind of Baalshandor, Soul of Baalshandor, Flesh Unbound, Growing Destruction, Fear the Writhing Life, One of Many."
+      "text": "Set the following cards aside, out of play: Messenger of the Flame, Messenger of the King, Body of Baalshandor, Mind of Baalshandor, Soul of Baalshandor, Flesh Unbound, Growing Destruction, Fear the Writhing Life, One of Many."
     },
 
     {
@@ -416,7 +416,7 @@
 
     {
       "id": "check_hibbs_roadhouse_rallied",
-      "text": "If Hibbs Roadhouse is rallied:",
+      "hidden": true, 
       "type": "branch",
       "condition": {
         "type": "campaign_log",
@@ -696,7 +696,7 @@
     {
       "id": "place_baalshandor_at_site",
       "bullet_type": "small",
-      "text": "Put the Baalshandor enemy into play at the location recorded as the <i>Site of Unbinding</i>."
+      "text": "Put the Baalshandor enemy into play at the location recorded as the <i>Site of Unbinding</i>, and remove the Crater of Unbinding from the game."
     },
     {
       "id": "check_greyson_cut_ties",
@@ -734,7 +734,7 @@
     {
       "id": "setup_greysons_loyalists",
       "bullet_type": "small",
-      "text": "Put the Greyson's Loyalists asset into play."
+      "text": "Put the Greyson's Loyalists asset into play at Hibb's Roadhouse."
     },
     {
       "id": "remove_greysons_loyalists",


### PR DESCRIPTION
Prune Mourning Chorus resolution options to only display defended locations (for rallying), and to only display the elites corresponding to infected locations (for elimination).