### PR TITLE
rtptc: fr: Keep 'Lunatic' wording

### DIFF
--- a/i18n/fr/return_campaigns/rtptc/return_to_the_last_king.po
+++ b/i18n/fr/return_campaigns/rtptc/return_to_the_last_king.po
@@ -17,7 +17,7 @@ msgid "Remove Agenda 1a - \"Fashionably Late\" from the game and replace it with
 msgstr "Retirez de la partie l'Intrigue 1a – « Légèrement en Retard » et remplacez-la par la nouvelle Intrigue 1a – « Mieux Vaut Jamais que Tard »."
 
 msgid "Set the Shocking Display treachery and the new Dianne Devine <i>(Hiding an Oath Unspoken)</i> ally aside, out of play. Remove the original Dianne Devine <i>(Mercurial and Mischevious)</i> from the game."
-msgstr "Mettez la traîtrise Spectacle Choquant et la nouvelle Dianne Devine <i>(Cache un Serment Indicible)</i> de côté, hors jeu. Retirez de la partie la Dianne Devine d'origine <i>(Malveillante et Aliéné)</i>."
+msgstr "Mettez la traîtrise Spectacle Choquant et la nouvelle Dianne Devine <i>(Cache un Serment Indicible)</i> de côté, hors jeu. Retirez de la partie la Dianne Devine d'origine <i>(Malveillante et Lunatique)</i>."
 
 msgid "Place the 8 “Sickening Reality” story cards underneath the scenario reference card."
 msgstr "Placez les 8 cartes Histoire « Effroyable Réalité » sous la carte de référence du scénario."


### PR DESCRIPTION
Commit 00be06cfe0127 changed 'Lunatique' to 'Aliéné' for a rtptc card.
This 'Aliéné' change is something specific to the revised edition.
There are no 'return to' printing with this wording change.
Making this change is also inconsistent with the English version which
hasn't changed.
This commit restores the previous wording for the card to use the same
terms as the printed card, and avoid confusion for ArkhamCards French
users.