### PR TITLE
[tskc] More update catalogueing rules for cross referencing

### DIFF
--- a/campaigns/tskc/01_riddles_and_rain.json
+++ b/campaigns/tskc/01_riddles_and_rain.json
@@ -11,7 +11,7 @@
     "check_multiplayer",
     "intro_5",
     "choose_offer",
-    "tracking_time_rule",
+    "$tracking_time_rule",
     "$check_tarot_reading",
     "gather_encounter_sets",
     "set_aside_encounter_sets",
@@ -24,7 +24,7 @@
   "rules": [
     {
       "title": "Tracking Time",
-      "steps": ["tracking_time_rule"]
+      "steps": ["$tracking_time_rule"]
     }
   ],
   "steps": [
@@ -258,13 +258,6 @@
           "value": 2
         }
       ]
-    },
-    {
-      "id": "tracking_time_rule",
-      "type": "rule_reminder",
-      "title": "Tracking Time",
-      "text": "Throughout this campaign, tracking the passage of time is of crucial importance. As time marches on, these paranormal events will grow more and more dangerous, and machinations beyond your understanding will progress. Additionally, some opportunities may only be open to you during certain windows of time. When you are instructed to mark one or more time in your Campaign Log, fill in that many boxes under the “Time Passed” header.\nIf you fill in a box that has a symbol (in the form of a Greek letter), proceed to the Status Reports section of the Campaign Guide, find the status report matching that letter, and read the text that follows.",
-      "example": "Note: The app will show you the appropriate Status Reports automatically after time is marked."
     },
     {
       "id": "gather_encounter_sets",

--- a/campaigns/tskc/02_the_foundation.json
+++ b/campaigns/tskc/02_the_foundation.json
@@ -11,11 +11,11 @@
     "intro_4",
     "leads",
     "read_embark_rules",
-    "embark_rule",
-    "embark_rule_1",
-    "embark_rule_2",
-    "embark_note",
-    "dossiers_rule",
+    "$embark_rule",
+    "$embark_rule_1",
+    "$embark_rule_2",
+    "$embark_note",
+    "$dossiers_rule",
     "unlock_map",
     "$embark"
   ],
@@ -23,14 +23,14 @@
     {
       "title": "Embarking and Travel",
       "steps": [
-        "embark_rule",
-        "embark_rule_1",
-        "embark_rule_2"
+        "$embark_rule",
+        "$embark_rule_1",
+        "$embark_rule_2"
       ]
     },
     {
       "title": "The Foundation Dossiers",
-      "steps": ["dossiers_rule"]
+      "steps": ["$dossiers_rule"]
     }
   ],
   "steps": [
@@ -212,45 +212,6 @@
       },
       "bullet_type": "none",
       "text": "Read the rules for “Embarking and Travel” and “The Foundation Dossiers” below. Then, when you are ready to proceed, <b>embark</b> from London to a new location."
-    },
-    {
-      "id": "embark_rule",
-      "type": "rule_reminder",
-      "title": "Embarking and Travel",
-      "text": "Whenever you <b>embark</b>, you may travel wherever you wish using the map included in <i>The Scarlet Keys</i> campaign expansion. Each space on the map is connected to one or more other spaces by paths. When you are ready to embark, travel along the paths to reach whichever destination you wish (as a group). For each path you use to reach your destination, you must mark 1 <b>time</b> in your Campaign Log (to a minimum of 1).\nAt each space on the map, there is a number and letter combination that will guide you to a particular page in this Campaign Guide. You do not have to stop at every space you travel through; however, if you wish to stop traveling and see what is at that space, turn to the page of the Campaign Guide that matches the indicated number and follow the story text there. This might lead you to an interlude or to a scenario. There is no perfect path to follow, so follow your gut… just be wary of how much time you spend (see “Tracking Time” in Campaign Setup).\n<i>For example: Shelley wishes to travel from Alexandria to Marrakesh. She first marks 1 <b>time</b> to use the path to Rome, but chooses not to stop there, and marks 1 more <b>time</b> to travel to Marrakesh, where she stops. Marrakesh is marked as “11–B,” so she opens the Campaign Guide to page 11 and reads File #11–B: Dead Heat.</i>",
-      "bullets": [
-        {
-          "text": "Some locations are marked by a red border and the lack of a letter. You can only travel to such a location once you are permitted to do so by a Campaign Log entry."
-        }
-      ]
-    },
-    {
-      "id": "embark_rule_1",
-      "text": "Some locations, marked by a green border, represent the sites of possible side stories <i>(found in other Arkam Horror: The Card Game standalone products)</i>. If you wish to incorporate a side story into this campaign, simply travel to the appropriate location on the map and spend additional time equal to the normal experience cost for playing that side story (instead of spending the experience cost).",
-      "bullets": [
-        {
-          "text": "If you are not stopping at one of these locations to embark on a side-story, you may skip it and continue traveling along the path. If so, count it as one contiguous path, not as two separate paths."
-        }
-      ]
-    },
-    {
-      "id": "embark_rule_2",
-      "text": "Once you have stopped at a location, you cannot stop there again for the remainder of the campaign unless instructed otherwise."
-    },
-    {
-      "id": "embark_note",
-      "text": "Note: this app will automatically calculate the shortest path when you choose a city and <b>embark</b>."
-    },
-    {
-      "id": "dossiers_rule",
-      "type": "rule_reminder",
-      "title": "The Foundation Dossiers",
-      "text": "Throughout this Campaign Guide, there are a number of Foundation Dossier sidebars. Investigators are allowed to peek at the Foundation Dossier sidebar for any space on the map, at any time. Use these sidebars to help guide your actions and plan your route. While reading a dossier, investigators are not allowed to peek at any other text on that page until they travel to that location.",
-      "bullets": [
-        {
-          "text": "Note: These Foundation Dossiers, along with any information or leads your investigators may have learned in their travels, are accessible in the app when browsing the map. This can be accessed while you are taking an <b>embark</b> action, or on the main campaign screen at any time."
-        }
-      ]
     },
     {
       "id": "unlock_map",

--- a/campaigns/tskc/campaign.json
+++ b/campaigns/tskc/campaign.json
@@ -2041,25 +2041,73 @@
     "choose_investigators",
     "difficulty_choice",
     "draw_weakness",
-    "keys_rule",
-    "keys_1",
-    "keys_2",
-    "keys_3",
-    "keys_4",
-    "keys_5",
-    "red_gloved_man",
-    "concealed_x",
-    "concealed_x_2",
-    "concealed_x_3",
-    "concealed_mini_cards",
-    "concealed_mini_cards_1",
-    "concealed_mini_cards_2",
-    "concealed_mini_cards_3",
-    "concealed_mini_cards_4",
-    "concealed_mini_cards_5",
-    "alert_rule",
-    "patrol_rule",
+    "$keys_rule",
+    "$keys_1",
+    "$keys_2",
+    "$keys_3",
+    "$keys_4",
+    "$keys_5",
+    "$red_gloved_man",
+    "$concealed_x",
+    "$concealed_x_2",
+    "$concealed_x_3",
+    "$concealed_mini_cards",
+    "$concealed_mini_cards_1",
+    "$concealed_mini_cards_2",
+    "$concealed_mini_cards_3",
+    "$concealed_mini_cards_4",
+    "$concealed_mini_cards_5",
+    "$alert_rule",
+    "$patrol_rule",
     "move_to_london"
+  ],
+  "rules": [
+    {
+      "title": "New Cardtype: Keys",
+      "steps": [
+        "$keys_rule",
+        "$keys_1",
+        "$keys_2",
+        "$keys_3",
+        "$keys_4",
+        "$keys_5"
+      ]
+    },
+    {
+      "title": "The Red-Gloved Man",
+      "steps": ["$red_gloved_man"]
+    },
+    {
+      "title": "Concealed X",
+      "steps": [
+        "$concealed_x",
+        "$concealed_x_2",
+        "$concealed_x_3"
+      ]
+    },
+    {
+      "title": "Concealed Mini-Cards",
+      "steps": [
+        "$concealed_mini_cards",
+        "$concealed_mini_cards_1",
+        "$concealed_mini_cards_2",
+        "$concealed_mini_cards_3",
+        "$concealed_mini_cards_4",
+        "$concealed_mini_cards_5"
+      ]
+    },
+    {
+      "title": "Tracking Time",
+      "steps": ["$maybe_tracking_time_rule"]
+    },
+    {
+      "title": "Embarking and Travel",
+      "steps": ["$maybe_embark_rule"]
+    },
+    {
+      "title": "The Foundation Dossiers",
+      "steps": ["$maybe_dossiers_rule"]
+    }
   ],
   "scenario_setup": [
     "$check_status_report"
@@ -2411,221 +2459,6 @@
           }
         ]
       }
-    },
-
-    {
-      "id": "keys_rule",
-      "title": "New Cardtype: Keys",
-      "type": "rule_reminder",
-      "text": "<i>The Scarlet Keys</i> campaign features a new cardtype: keys. Keys are powerful artifacts that may be “shifted” to either aid or hinder investigators, depending on whom they are attached to and whether their [[Stable]] or [[Unstable]] side is faceup.",
-      "bullets": [
-        {
-          "text": "During the resolution of a scenario, a key may become bound to a single bearer, whose name is marked in the Campaign Log. A key may be bound to an investigator, a story asset, or an enemy."
-        }
-      ]
-    },
-    {
-      "id": "keys_1",
-      "text": "A key always enters play attached to its bearer (as marked in the Campaign Log). At the start of each scenario, each investigator who is the bearer of 1 or more keys attaches those keys to their investigator card. Whenever a story asset or enemy enters play, if it is the bearer of 1 or more keys, those keys also enter play attached to their bearer.",
-      "bullets": [
-        {
-          "text": "If a key’s bearer is an investigator or a story asset, it enters play [[Stable]] side faceup."
-        },
-        {
-          "text": "If a key’s bearer is an enemy, it enters play [[Unstable]] side faceup."
-        }
-      ]
-    },
-    {
-      "id": "keys_2",
-      "text": "A key cannot leave play unless its bearer leaves play. If the bearer of 1 or more keys leaves play, each key they control is set aside, out of play. <i>(Those keys do, however, remain bound to their bearer for future scenarios unless explicitly noted otherwise.)</i>"
-    },
-    {
-      "id": "keys_3",
-      "text": "While a key is attached to an investigator, that investigator may trigger its shift ability during any player window as a [fast] ability. This is called “shifting” the key. As part of this ability’s resolution, it will instruct the investigator to flip the key to its other side, so its other shift ability is active. The investigator will then have to perform the shift ability on its [[Unstable]] side in order to flip it back over again.",
-      "bullets": [
-        {
-          "text": "While a key is attached to a story asset, it may be shifted by any investigator who controls that asset in the same way."
-        },
-        {
-          "text": "Each key (by title) attached to an investigator or story asset can only be shifted once per round."
-        }
-      ]
-    },
-    {
-      "id": "keys_4",
-      "text": "While a key is under an enemy’s control, its shift ability only resolves when a card or game effect instructs an investigator to shift that key, after which it remains [[Unstable]] side faceup.",
-      "bullets": [
-        {
-          "text": "A key attached to an enemy cannot be flipped to its [[Stable]] side."
-        },
-        {
-          "text": "There is no limit to the number of times a key attached to an enemy can be shifted."
-        }
-      ]
-    },
-    {
-      "id": "keys_5",
-      "text": "Some card effects may directly flip a key attached to an investigator or story asset from its [[Stable]] side to its [[Unstable]] side, or vice versa. This is not the same as shifting a key, and does not resolve its shift ability."
-    },
-
-
-    {
-      "id": "red_gloved_man",
-      "type": "rule_reminder",
-      "text": "During <i>The Scarlet Keys</i> campaign, investigators will confront a number of dangerous and mysterious members of the secret society known as the Red Coterie. One such member is the iconic Red-Gloved Man. As a result, while playing <i>The Scarlet Keys</i> campaign, investigators cannot purchase or include The Red-Gloved Man asset <i>(The Dunwich Legacy card #310)</i> in their decks."
-    },
-    {
-      "id": "concealed_x",
-      "type": "rule_reminder",
-      "title": "Concealed X",
-      "text": "Concealed X is a keyword that appears on some enemy cards in <i>The Scarlet Keys</i> campaign. Concealed enemies represent hidden enemies whose true location is a mystery until the investigators work to expose where—and in some cases, who—they truly are.\nWhen a scenario includes one or more concealed enemies, investigators are instructed to set aside several concealed mini-cards. These mini-cards are double-sided. The facedown side represents the possible location of a concealed enemy. The revealed side reveals the mini-card’s true nature—an enemy’s true location, or simply a decoy.",
-      "images": [
-        {
-          "image": {
-            "ratio": 1.509,
-            "uri": "/guide/tsk/concealed_back.jpg",
-            "alignment": "top"
-          },
-          "width": "quarter",
-          "text": "<i>A facedown concealed mini-card</i>"
-        },
-        {
-          "image": {
-            "ratio": 1.509,
-            "uri": "/guide/tsk/rgm_concealed.jpg",
-            "alignment": "top"
-          },
-          "width": "quarter",
-          "text": "<i>An enemy's mini-card marks the location of an enemy in the shadows.</i>"
-        },
-        {
-          "image": {
-            "ratio": 1.561,
-            "uri": "/guide/tsk/concealed_decoy.jpg",
-            "alignment": "top"
-          },
-          "width": "quarter",
-          "text": "<i>A decoy marks the location of nothing of consequence—a harmless bystander, or perhaps just a trick of the light.</i>"
-        }
-      ]
-    },
-    {
-      "id": "concealed_x_2",
-      "type": "rule_reminder",
-      "text": "When an investigator draws an enemy with the concealed X keyword (or is instructed to resolve an enemy’s concealed keyword), they spawn that enemy into a game area above the agenda deck, not at any location. This area is called “the shadows,” and represents enemies the investigators know exist somewhere on the map, but are unsure where. Then, that investigator takes the set-aside concealed mini-card that matches that enemy, along with X decoys (where X is defined by that enemy’s concealed X value), shuffles them facedown, and puts them into play distributed as evenly as possible among each location in play, starting with the locations nearest to them. Then, at each of those locations that already had 1 or more concealed mini-cards, they shuffle each of them facedown as well.\n<i>For example: Amina draws Coterie Agent (A), which has “concealed 2.” She first spawns the Coterie Agent into the shadows. Then, she takes the set-aside Coterie Agent (A) mini-card, along with 2 decoys, shuffles them facedown, and places one at each of the three locations nearest to her. Then, if any of those locations already had 1 or more concealed mini-cards, she would shuffle each concealed mini-card at those locations, as well.</i>",
-      "images": [
-        {
-          "image": {
-            "ratio": 0.885,
-            "uri": "/guide/tsk/concealed_example.jpg",
-            "alignment": "top"
-          },
-          "width": "full"
-        }
-      ]
-    },
-    {
-      "id": "concealed_x_3",
-      "type": "rule_reminder",
-      "text": "Enemies in the shadows observe the following additional rules:",
-      "bullets": [
-        {
-          "text": "Enemies in the shadows are considered to be in play, but not at any particular location. They cannot move until they leave the shadows."
-        },
-        {
-          "text": "Enemies in the shadows can qualify as the “nearest” enemy, but only if there are no other enemies in play at any location."
-        },
-        {
-          "text": "Enemies in the shadows cannot be damaged or leave play via player card effects."
-        }
-      ]
-    },
-    {
-      "id": "concealed_mini_cards",
-      "type": "rule_reminder",
-      "title": "Concealed Mini-Cards",
-      "text": "While in play, concealed mini-cards represent the possible location of an enemy in the shadows. In order to deal with such an enemy, its true location must first be discovered by exposing its mini-card. This can be done via one of three methods: fighting, evading, or investigating."
-    },
-    {
-      "id": "concealed_mini_cards_1",
-      "text": "Concealed mini-cards are not enemies and cannot be engaged like enemies. However, any investigator at the same location as a concealed mini-card may attempt to expose it by successfully attacking it or evading it (as if it were an engaged enemy), or by successfully investigating its location. The difficulty to successfully attack or evade a concealed mini-card is equal to the shroud value of its location.",
-      "bullets": [
-        {
-          "text": "An investigator may also use a card effect that automatically evades an enemy, deals damage to an enemy, or discovers a clue at a location in order to instead expose a concealed mini-card."
-        }
-      ]
-    },
-    {
-      "id": "concealed_mini_cards_2",
-      "text": "If an investigator chooses to expose a concealed mini-card, that effect replaces the standard effects of the action or ability that exposed it. <i>(i.e., if an enemy’s mini-card is exposed by evasion or damage, the matching enemy is not evaded, nor does it take damage. If a mini-card is exposed by discovering clues or investigating, no clues are discovered.)</i>"
-    },
-    {
-      "id": "concealed_mini_cards_3",
-      "text": "If a concealed mini-card is exposed <i>(via any of the above methods)</i>, flip it to its revealed side.",
-      "bullets": [
-        {
-          "text": "If it is a decoy, set it aside, out of play, with no effect."
-        },
-        {
-          "text": "If it is an enemy’s mini-card, that enemy is now exposed. Place the matching enemy in the shadows at that mini-card’s location, then set that mini-card aside, out of play. <i>(That enemy is no longer in the shadows, and is now at the location where its mini-card was located).</i> Then, if there are no other enemies in the shadows, set all remaining concealed mini-cards in play aside, out of play."
-        }
-      ]
-    },
-    {
-      "id": "concealed_mini_cards_4",
-      "text": "Only one concealed mini-card may be exposed per effect unless explicitly stated. <i>(i.e., an effect that deals 3 damage to each enemy at a location does not expose all concealed mini-cards at that location; only one.)</i>"
-    },
-    {
-      "id": "concealed_mini_cards_5",
-      "type": "rule_reminder",
-      "text": "<i>For example: There is a Coterie Agent and a Coterie Assassin in the shadows. There is a concealed mini-card at Kymani’s location and another concealed mini-card at a connecting location. (1) First, Kymani plays an event that discovers a clue at their location, but instead of discovering a clue, they choose to expose the concealed mini-card at their location, flipping it over. That mini-card is a decoy, and is set aside without effect. (2) Next, they move to the connecting location with the other concealed mini-card and attempt to expose it using an evade action. They succeed and flip the mini-card over… revealing the Coterie Assassin’s mini-card! (3) The Coterie Assassin’s mini-card is set aside, and the Coterie Assassin in the shadows is moved to Kymani’s location, engaging them. Because there is another enemy in the shadows, they do not remove any of the other concealed mini-cards from play.</i>",
-      "images": [
-        {
-          "image": {
-            "ratio": 0.752,
-            "uri": "/guide/tsk/expose_1.jpg",
-            "alignment": "top"
-          },
-          "width": "full"
-        },
-        {
-          "image": {
-            "ratio": 0.445,
-            "uri": "/guide/tsk/expose_2.jpg",
-            "alignment": "top"
-          },
-          "width": "full"
-        },
-        {
-          "image": {
-            "ratio": 0.572,
-            "uri": "/guide/tsk/expose_3.jpg",
-            "alignment": "top"
-          },
-          "width": "full"
-        }
-      ]
-    },
-    {
-      "id": "alert_rule",
-      "type": "rule_reminder",
-      "title": "Alert",
-      "text": "Each time an investigator fails a skill test while attempting to evade an enemy with the alert keyword, after applying all results for that skill test, that enemy performs an attack against the evading investigator. An enemy does not exhaust after performing an alert attack. This attack occurs whether the enemy is engaged with the evading investigator or not."
-    },
-    {
-      "id": "patrol_rule",
-      "title": "Patrol",
-      "type": "rule_reminder",
-      "text": "Some enemies have the patrol keyword. During the enemy phase (in framework step 3.2), each ready, unengaged enemy with the patrol keyword moves to a connecting location along the shortest path toward the designated location (as described in parentheses next to the word patrol).",
-      "bullets": [
-        {
-          "text": "If there are multiple locations that qualify as the designated location, the lead investigator may choose which location the enemy moves toward."
-        },
-        {
-          "text": "If an enemy with patrol would be compelled to move to a location which is blocked by a card ability, the enemy does not move."
-        }
-      ]
     }
   ],
   "achievements": [

--- a/campaigns/tskc/core.json
+++ b/campaigns/tskc/core.json
@@ -5,6 +5,23 @@
   "header": "",
   "type": "core",
   "setup": [
+    "$keys_rule",
+    "$keys_1",
+    "$keys_2",
+    "$keys_3",
+    "$keys_4",
+    "$keys_5",
+    "$concealed_x",
+    "$concealed_x_2",
+    "$concealed_x_3",
+    "$concealed_mini_cards",
+    "$concealed_mini_cards_1",
+    "$concealed_mini_cards_2",
+    "$concealed_mini_cards_3",
+    "$concealed_mini_cards_4",
+    "$concealed_mini_cards_5",
+    "$alert_rule",
+    "$patrol_rule",
     "$travel_time",
     "$check_status_report",
     "$maybe_embark_side_scenario",
@@ -20,6 +37,317 @@
     "$save_decks_with_xp"
   ],
   "steps": [
+    {
+      "id": "$keys_rule",
+      "title": "New Cardtype: Keys",
+      "type": "rule_reminder",
+      "text": "<i>The Scarlet Keys</i> campaign features a new cardtype: keys. Keys are powerful artifacts that may be “shifted” to either aid or hinder investigators, depending on whom they are attached to and whether their [[Stable]] or [[Unstable]] side is faceup.",
+      "bullets": [
+        {
+          "text": "During the resolution of a scenario, a key may become bound to a single bearer, whose name is marked in the Campaign Log. A key may be bound to an investigator, a story asset, or an enemy."
+        }
+      ]
+    },
+    {
+      "id": "$keys_1",
+      "text": "A key always enters play attached to its bearer (as marked in the Campaign Log). At the start of each scenario, each investigator who is the bearer of 1 or more keys attaches those keys to their investigator card. Whenever a story asset or enemy enters play, if it is the bearer of 1 or more keys, those keys also enter play attached to their bearer.",
+      "bullets": [
+        {
+          "text": "If a key’s bearer is an investigator or a story asset, it enters play [[Stable]] side faceup."
+        },
+        {
+          "text": "If a key’s bearer is an enemy, it enters play [[Unstable]] side faceup."
+        }
+      ]
+    },
+    {
+      "id": "$keys_2",
+      "text": "A key cannot leave play unless its bearer leaves play. If the bearer of 1 or more keys leaves play, each key they control is set aside, out of play. <i>(Those keys do, however, remain bound to their bearer for future scenarios unless explicitly noted otherwise.)</i>"
+    },
+    {
+      "id": "$keys_3",
+      "text": "While a key is attached to an investigator, that investigator may trigger its shift ability during any player window as a [fast] ability. This is called “shifting” the key. As part of this ability’s resolution, it will instruct the investigator to flip the key to its other side, so its other shift ability is active. The investigator will then have to perform the shift ability on its [[Unstable]] side in order to flip it back over again.",
+      "bullets": [
+        {
+          "text": "While a key is attached to a story asset, it may be shifted by any investigator who controls that asset in the same way."
+        },
+        {
+          "text": "Each key (by title) attached to an investigator or story asset can only be shifted once per round."
+        }
+      ]
+    },
+    {
+      "id": "$keys_4",
+      "text": "While a key is under an enemy’s control, its shift ability only resolves when a card or game effect instructs an investigator to shift that key, after which it remains [[Unstable]] side faceup.",
+      "bullets": [
+        {
+          "text": "A key attached to an enemy cannot be flipped to its [[Stable]] side."
+        },
+        {
+          "text": "There is no limit to the number of times a key attached to an enemy can be shifted."
+        }
+      ]
+    },
+    {
+      "id": "$keys_5",
+      "text": "Some card effects may directly flip a key attached to an investigator or story asset from its [[Stable]] side to its [[Unstable]] side, or vice versa. This is not the same as shifting a key, and does not resolve its shift ability."
+    },
+    {
+      "id": "$red_gloved_man",
+      "type": "rule_reminder",
+      "title": "The Red-Gloved Man",
+      "text": "During <i>The Scarlet Keys</i> campaign, investigators will confront a number of dangerous and mysterious members of the secret society known as the Red Coterie. One such member is the iconic Red-Gloved Man. As a result, while playing <i>The Scarlet Keys</i> campaign, investigators cannot purchase or include The Red-Gloved Man asset <i>(The Dunwich Legacy card #310)</i> in their decks."
+    },
+    {
+      "id": "$concealed_x",
+      "type": "rule_reminder",
+      "title": "Concealed X",
+      "text": "Concealed X is a keyword that appears on some enemy cards in <i>The Scarlet Keys</i> campaign. Concealed enemies represent hidden enemies whose true location is a mystery until the investigators work to expose where—and in some cases, who—they truly are.\nWhen a scenario includes one or more concealed enemies, investigators are instructed to set aside several concealed mini-cards. These mini-cards are double-sided. The facedown side represents the possible location of a concealed enemy. The revealed side reveals the mini-card’s true nature—an enemy’s true location, or simply a decoy.",
+      "images": [
+        {
+          "image": {
+            "ratio": 1.509,
+            "uri": "/guide/tsk/concealed_back.jpg",
+            "alignment": "top"
+          },
+          "width": "quarter",
+          "text": "<i>A facedown concealed mini-card</i>"
+        },
+        {
+          "image": {
+            "ratio": 1.509,
+            "uri": "/guide/tsk/rgm_concealed.jpg",
+            "alignment": "top"
+          },
+          "width": "quarter",
+          "text": "<i>An enemy's mini-card marks the location of an enemy in the shadows.</i>"
+        },
+        {
+          "image": {
+            "ratio": 1.561,
+            "uri": "/guide/tsk/concealed_decoy.jpg",
+            "alignment": "top"
+          },
+          "width": "quarter",
+          "text": "<i>A decoy marks the location of nothing of consequence—a harmless bystander, or perhaps just a trick of the light.</i>"
+        }
+      ]
+    },
+    {
+      "id": "$concealed_x_2",
+      "type": "rule_reminder",
+      "text": "When an investigator draws an enemy with the concealed X keyword (or is instructed to resolve an enemy’s concealed keyword), they spawn that enemy into a game area above the agenda deck, not at any location. This area is called “the shadows,” and represents enemies the investigators know exist somewhere on the map, but are unsure where. Then, that investigator takes the set-aside concealed mini-card that matches that enemy, along with X decoys (where X is defined by that enemy’s concealed X value), shuffles them facedown, and puts them into play distributed as evenly as possible among each location in play, starting with the locations nearest to them. Then, at each of those locations that already had 1 or more concealed mini-cards, they shuffle each of them facedown as well.\n<i>For example: Amina draws Coterie Agent (A), which has “concealed 2.” She first spawns the Coterie Agent into the shadows. Then, she takes the set-aside Coterie Agent (A) mini-card, along with 2 decoys, shuffles them facedown, and places one at each of the three locations nearest to her. Then, if any of those locations already had 1 or more concealed mini-cards, she would shuffle each concealed mini-card at those locations, as well.</i>",
+      "images": [
+        {
+          "image": {
+            "ratio": 0.885,
+            "uri": "/guide/tsk/concealed_example.jpg",
+            "alignment": "top"
+          },
+          "width": "full"
+        }
+      ]
+    },
+    {
+      "id": "$concealed_x_3",
+      "type": "rule_reminder",
+      "text": "Enemies in the shadows observe the following additional rules:",
+      "bullets": [
+        {
+          "text": "Enemies in the shadows are considered to be in play, but not at any particular location. They cannot move until they leave the shadows."
+        },
+        {
+          "text": "Enemies in the shadows can qualify as the “nearest” enemy, but only if there are no other enemies in play at any location."
+        },
+        {
+          "text": "Enemies in the shadows cannot be damaged or leave play via player card effects."
+        }
+      ]
+    },
+    {
+      "id": "$concealed_mini_cards",
+      "type": "rule_reminder",
+      "title": "Concealed Mini-Cards",
+      "text": "While in play, concealed mini-cards represent the possible location of an enemy in the shadows. In order to deal with such an enemy, its true location must first be discovered by exposing its mini-card. This can be done via one of three methods: fighting, evading, or investigating."
+    },
+    {
+      "id": "$concealed_mini_cards_1",
+      "text": "Concealed mini-cards are not enemies and cannot be engaged like enemies. However, any investigator at the same location as a concealed mini-card may attempt to expose it by successfully attacking it or evading it (as if it were an engaged enemy), or by successfully investigating its location. The difficulty to successfully attack or evade a concealed mini-card is equal to the shroud value of its location.",
+      "bullets": [
+        {
+          "text": "An investigator may also use a card effect that automatically evades an enemy, deals damage to an enemy, or discovers a clue at a location in order to instead expose a concealed mini-card."
+        }
+      ]
+    },
+    {
+      "id": "$concealed_mini_cards_2",
+      "text": "If an investigator chooses to expose a concealed mini-card, that effect replaces the standard effects of the action or ability that exposed it. <i>(i.e., if an enemy’s mini-card is exposed by evasion or damage, the matching enemy is not evaded, nor does it take damage. If a mini-card is exposed by discovering clues or investigating, no clues are discovered.)</i>"
+    },
+    {
+      "id": "$concealed_mini_cards_3",
+      "text": "If a concealed mini-card is exposed <i>(via any of the above methods)</i>, flip it to its revealed side.",
+      "bullets": [
+        {
+          "text": "If it is a decoy, set it aside, out of play, with no effect."
+        },
+        {
+          "text": "If it is an enemy’s mini-card, that enemy is now exposed. Place the matching enemy in the shadows at that mini-card’s location, then set that mini-card aside, out of play. <i>(That enemy is no longer in the shadows, and is now at the location where its mini-card was located).</i> Then, if there are no other enemies in the shadows, set all remaining concealed mini-cards in play aside, out of play."
+        }
+      ]
+    },
+    {
+      "id": "$concealed_mini_cards_4",
+      "text": "Only one concealed mini-card may be exposed per effect unless explicitly stated. <i>(i.e., an effect that deals 3 damage to each enemy at a location does not expose all concealed mini-cards at that location; only one.)</i>"
+    },
+    {
+      "id": "$concealed_mini_cards_5",
+      "type": "rule_reminder",
+      "text": "<i>For example: There is a Coterie Agent and a Coterie Assassin in the shadows. There is a concealed mini-card at Kymani’s location and another concealed mini-card at a connecting location. (1) First, Kymani plays an event that discovers a clue at their location, but instead of discovering a clue, they choose to expose the concealed mini-card at their location, flipping it over. That mini-card is a decoy, and is set aside without effect. (2) Next, they move to the connecting location with the other concealed mini-card and attempt to expose it using an evade action. They succeed and flip the mini-card over… revealing the Coterie Assassin’s mini-card! (3) The Coterie Assassin’s mini-card is set aside, and the Coterie Assassin in the shadows is moved to Kymani’s location, engaging them. Because there is another enemy in the shadows, they do not remove any of the other concealed mini-cards from play.</i>",
+      "images": [
+        {
+          "image": {
+            "ratio": 0.752,
+            "uri": "/guide/tsk/expose_1.jpg",
+            "alignment": "top"
+          },
+          "width": "full"
+        },
+        {
+          "image": {
+            "ratio": 0.445,
+            "uri": "/guide/tsk/expose_2.jpg",
+            "alignment": "top"
+          },
+          "width": "full"
+        },
+        {
+          "image": {
+            "ratio": 0.572,
+            "uri": "/guide/tsk/expose_3.jpg",
+            "alignment": "top"
+          },
+          "width": "full"
+        }
+      ]
+    },
+    {
+      "id": "$alert_rule",
+      "type": "rule_reminder",
+      "title": "Alert",
+      "text": "Each time an investigator fails a skill test while attempting to evade an enemy with the alert keyword, after applying all results for that skill test, that enemy performs an attack against the evading investigator. An enemy does not exhaust after performing an alert attack. This attack occurs whether the enemy is engaged with the evading investigator or not."
+    },
+    {
+      "id": "$patrol_rule",
+      "title": "Patrol",
+      "type": "rule_reminder",
+      "text": "Some enemies have the patrol keyword. During the enemy phase (in framework step 3.2), each ready, unengaged enemy with the patrol keyword moves to a connecting location along the shortest path toward the designated location (as described in parentheses next to the word patrol).",
+      "bullets": [
+        {
+          "text": "If there are multiple locations that qualify as the designated location, the lead investigator may choose which location the enemy moves toward."
+        },
+        {
+          "text": "If an enemy with patrol would be compelled to move to a location which is blocked by a card ability, the enemy does not move."
+        }
+      ]
+    },
+    {
+      "id": "$maybe_tracking_time_rule",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
+        "type": "campaign_data",
+        "campaign_data": "scenario_completed",
+        "scenario": "the_foundation",
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": ["$tracking_time_rule"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "$tracking_time_rule",
+      "type": "rule_reminder",
+      "title": "Tracking Time",
+      "text": "Throughout this campaign, tracking the passage of time is of crucial importance. As time marches on, these paranormal events will grow more and more dangerous, and machinations beyond your understanding will progress. Additionally, some opportunities may only be open to you during certain windows of time. When you are instructed to mark one or more time in your Campaign Log, fill in that many boxes under the “Time Passed” header.\nIf you fill in a box that has a symbol (in the form of a Greek letter), proceed to the Status Reports section of the Campaign Guide, find the status report matching that letter, and read the text that follows.",
+      "example": "Note: The app will show you the appropriate Status Reports automatically after time is marked."
+    },
+    {
+      "id": "$maybe_embark_rule",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
+        "type": "campaign_data",
+        "campaign_data": "scenario_completed",
+        "scenario": "the_foundation",
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": [
+              "$embark_rule",
+              "$embark_rule_1",
+              "$embark_rule_2"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "$embark_rule",
+      "type": "rule_reminder",
+      "title": "Embarking and Travel",
+      "text": "Whenever you <b>embark</b>, you may travel wherever you wish using the map included in <i>The Scarlet Keys</i> campaign expansion. Each space on the map is connected to one or more other spaces by paths. When you are ready to embark, travel along the paths to reach whichever destination you wish (as a group). For each path you use to reach your destination, you must mark 1 <b>time</b> in your Campaign Log (to a minimum of 1).\nAt each space on the map, there is a number and letter combination that will guide you to a particular page in this Campaign Guide. You do not have to stop at every space you travel through; however, if you wish to stop traveling and see what is at that space, turn to the page of the Campaign Guide that matches the indicated number and follow the story text there. This might lead you to an interlude or to a scenario. There is no perfect path to follow, so follow your gut… just be wary of how much time you spend (see “Tracking Time” in Campaign Setup).\n<i>For example: Shelley wishes to travel from Alexandria to Marrakesh. She first marks 1 <b>time</b> to use the path to Rome, but chooses not to stop there, and marks 1 more <b>time</b> to travel to Marrakesh, where she stops. Marrakesh is marked as “11–B,” so she opens the Campaign Guide to page 11 and reads File #11–B: Dead Heat.</i>",
+      "bullets": [
+        {
+          "text": "Some locations are marked by a red border and the lack of a letter. You can only travel to such a location once you are permitted to do so by a Campaign Log entry."
+        }
+      ]
+    },
+    {
+      "id": "$embark_rule_1",
+      "text": "Some locations, marked by a green border, represent the sites of possible side stories <i>(found in other Arkam Horror: The Card Game standalone products)</i>. If you wish to incorporate a side story into this campaign, simply travel to the appropriate location on the map and spend additional time equal to the normal experience cost for playing that side story (instead of spending the experience cost).",
+      "bullets": [
+        {
+          "text": "If you are not stopping at one of these locations to embark on a side-story, you may skip it and continue traveling along the path. If so, count it as one contiguous path, not as two separate paths."
+        }
+      ]
+    },
+    {
+      "id": "$embark_rule_2",
+      "text": "Once you have stopped at a location, you cannot stop there again for the remainder of the campaign unless instructed otherwise."
+    },
+    {
+      "id": "$embark_note",
+      "text": "Note: this app will automatically calculate the shortest path when you choose a city and <b>embark</b>."
+    },
+    {
+      "id": "$maybe_dossiers_rule",
+      "hidden": true,
+      "type": "branch",
+      "condition": {
+        "type": "campaign_data",
+        "campaign_data": "scenario_completed",
+        "scenario": "the_foundation",
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": [ "$dossiers_rule" ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "$dossiers_rule",
+      "type": "rule_reminder",
+      "title": "The Foundation Dossiers",
+      "text": "Throughout this Campaign Guide, there are a number of Foundation Dossier sidebars. Investigators are allowed to peek at the Foundation Dossier sidebar for any space on the map, at any time. Use these sidebars to help guide your actions and plan your route. While reading a dossier, investigators are not allowed to peek at any other text on that page until they travel to that location.",
+      "bullets": [
+        {
+          "text": "Note: These Foundation Dossiers, along with any information or leads your investigators may have learned in their travels, are accessible in the app when browsing the map. This can be accessed while you are taking an <b>embark</b> action, or on the main campaign screen at any time."
+        }
+      ]
+    },
     {
       "id": "$travel_time",
       "type": "travel_cost"

--- a/i18n/ko/campaigns/tskc/campaign.po
+++ b/i18n/ko/campaigns/tskc/campaign.po
@@ -663,6 +663,9 @@ msgstr "전 지구를 누비며"
 msgid "New Cardtype: Keys"
 msgstr "새로운 카드 종류: 열쇠"
 
+msgid "The Red-Gloved Man"
+msgstr "붉은 장갑을 낀 남자"
+
 msgid "Concealed X"
 msgstr "은신 X"
 


### PR DESCRIPTION
This PR contains the followings:

- Move the content for campaign common references to the core.json file.
- Added conditional unlocking for some campaign common references: maybe_tracking_time_rule, maybe_embark_rule, maybe_dossiers_rule, ... **(※ Caution: not tested yet!!!)**
