### PR TITLE
Onigawa investigators

### DIFF
--- a/cards/zgoo.json
+++ b/cards/zgoo.json
@@ -579,7 +579,7 @@
     "version": 6
   },
   {
-    "code": "zgoo_00014",
+    "code": "zgoo_00099",
     "cost": 3,
     "deck_limit": 1,
     "faction_code": "neutral",

--- a/cards/zgoo.json
+++ b/cards/zgoo.json
@@ -1,0 +1,658 @@
+[
+  {
+    "back_flavor": "Bred from birth to take on the mantle of shrine maiden of her village, Yuki endured all manner of grueling 'training' as a young girl in pursuit of her ultimate vocation. Unfortunately, the final rite to 'purify' her soul involved an arcane ritual which went haywire and left Yuki stricken by a sort of trauma-induced amnesia. That fateful night, Yuki fled the village in a panic and managed to steal away to Arkham, where she eventually cultivated a life of service tending to the city's poverty-stricken and dispossessed masses. Her kind and patient demeanor draws the tormented to her like a lodestone, and as her good works multiply so too have the memories of what she left behind started to resurface...",
+    "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Guardian cards ([guardian]) level 0-5, Mystic cards ([mystic]) level 0-1, <b>Blessed</b> cards level 0-5, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Apotheosis, The Succession, 1 random basic weakness.\n<b>Deckbuilding restrictions</b>: No [[Weapon]] assets.",
+    "code": "zgoo_00001",
+    "deck_limit": 1,
+    "deck_options": [
+      {
+        "faction": [
+          "guardian"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "mystic"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
+        "faction": [
+          "neutral"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "trait": [
+          "blessed"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "not": true,
+        "trait": [
+          "weapon"
+        ]
+      }
+    ],
+    "deck_requirements": "size:30, card:zgoo_00002, card:zgoo_00003, random:subtype:basicweakness",
+    "double_sided": true,
+    "faction_code": "guardian",
+    "flavor": "\"I must perform my sacred duty...\nNo matter the cost.\"",
+    "gender": "f",
+    "health": 7,
+    "is_unique": true,
+    "name": "Yuki Yagami",
+    "pack_code": "zgoo",
+    "position": 1,
+    "quantity": 1,
+    "sanity": 7,
+    "skill_agility": 3,
+    "skill_intellect": 4,
+    "skill_combat": 1,
+    "skill_willpower": 4,
+    "subname": "The Priestess",
+    "text": "[reaction] After you resolve at least one [bless] token during a successful skill test: Draw 1 card.\n[elder_sign] effect: +1. You may search the chaos bag for a curse token and return it to the token pool.",
+    "traits": "Believer. Cursed.",
+    "type_code": "investigator",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00002",
+    "cost": 3,
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "The sacred bloodline of the goddess Amaterasu was carefully preserved until a suitable vessel for her essence could be found.",
+    "health": 2,
+    "name": "Apotheosis",
+    "pack_code": "zgoo",
+    "position": 6,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00001",
+    "sanity": 2,
+    "skill_wild": 1,
+    "skill_willpower": 1,
+    "slot": "body",
+    "text": "Yuki Yagami deck only.\n[reaction] When your turn begins: Add 1 [bless] token to the chaos bag.\n[reaction] After your turn ends: Search the chaos bag for 1 [curse] token and return it to the token pool.",
+    "traits": "Avatar. Blessed.",
+    "type_code": "asset",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00003",
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "Many who undergo the shrine mained 'training' are unable to speak of it.",
+    "illustrator": "Audrius Mitkus",
+    "is_unique": true,
+    "name": "The Succession",
+    "pack_code": "zgoo",
+    "position": 7,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00001",
+    "subtype_code": "weakness",
+    "slot": "body",
+    "subname": "That August Night",
+    "text": "<b>Revelation</b> - Put Baron Samedi into play and seal all [bless] tokens in the chaos bag on it.\n<b>Forced</b> - When a [bless] token would be added tot he chaos bag: Seal it on this and add a [curse] token to the chaos bag, instead.\n[action]: Test [will] (4). if you succeed, release all tokens sealed on The Succession and discard it.",
+    "traits": "Avatar.",
+    "type_code": "asset"
+  },
+  {
+    "back_flavor": "Makoto has amassed a small fortune renting out her services as a 'consort' to Arkham's well-paying elite. Though her expertise in massage therapy and exotic musical instruments are considerable, she is most recommended by far for her insight as a counselor and empathic confidant. But her uncanny ability to see into the minds of the rich and powerful and divine their hearts' true desires is no mere parlor trick; when her grandmother passed away, Makoto inherited a number of family heirlooms, including a strange ornamental headdress… The first time she tried it on, Makoto discovered that she was suddenly capable of perceiving a level of reality that lies hidden to most. So many long nights she has spent gazing into that abyss that it has begun to gaze back into her, as well...",
+    "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Seeker cards ([seeker]) level 0-5, Survivor cards ([survivor]) level 0-1, <b>Patron</b> cards level 0-5, <b>Gambit</b> cards level 0-5, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): The Infinite Oculus, Porcelain Mirage, 1 random basic weakness.\n<b>Deckbuilding restrictions</b>: No non-[[Patron]] assets that take up an ally slot.",
+    "code": "zgoo_00004",
+    "deck_limit": 1,
+    "deck_options": [
+      {
+        "faction": [
+          "seeker"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "survivor"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
+        "faction": [
+          "neutral"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "trait": [
+          "patron"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "trait": [
+          "gambit"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    ],
+    "deck_requirements": "size:30, card:zgoo_00005, card:zgoo_00006, random:subtype:basicweakness",
+    "double_sided": true,
+    "faction_code": "seeker",
+    "flavor": "\"The truth will set you free.\"",
+    "gender": "f",
+    "health": 6,
+    "illustrator": "G. Host Lee",
+    "is_unique": true,
+    "name": "Makoto Miyazaki",
+    "pack_code": "zgoo",
+    "position": 2,
+    "quantity": 1,
+    "sanity": 8,
+    "skill_agility": 4,
+    "skill_intellect": 4,
+    "skill_combat": 2,
+    "skill_willpower": 2,
+    "subname": "The Courtesan",
+    "text": "Reduce the difficult of skill tests you perform during parley actions by 1. \n[reaction] After a non-[[Elite]] enemy enters play: Disengage from that enemy if able. That enemy cannot engage you until the end of the round. <i>(Limit once per round)</i>\n[elder_sign] effect: +X. X is the number of enemies in play.",
+    "traits": "Performer. Socialite.",
+    "type_code": "investigator",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00005",
+    "cost": 2,
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "All secrets are laid bare beneath the mask's withering gaze.",
+    "name": "The Infinite Oculus",
+    "pack_code": "zgoo",
+    "position": 8,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00003",
+    "skill_intellect": 1,
+    "skill_wild": 1,
+    "skill_willpower": 1,
+    "text": "Makoto Miyazaki deck only.\nLimit 1 [[Headgear]] per investigator.\nYou get +1 [intellect] for each enemy at your location.\n[reaction] When the investigation phase begins, if there is at least one enemy at your location: Gain 1 resource.",
+    "traits": "Item. Headgear. Relic. Occult.",
+    "type_code": "asset",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00006",
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "Whatever truth there may be in beauty, it remains only skin deep.",
+    "illustrator": "Othon Nikolaidis",
+    "name": "Porcelain Mirage",
+    "pack_code": "zgoo",
+    "position": 9,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00003",
+    "subtype_code": "weakness",
+    "text": "<b>Revelation</b> - Put Porcelain Mirage into play in your threat area.\nYour location gets +1 shroud.\n[action] Spend 4 resources: Discard Porcelain Mirage.",
+    "traits": "Flaw.",
+    "type_code": "treachery"
+  },
+  {
+    "back_flavor": "The sole surviving member of an ancient order of clandestine assassins that was driven to near extinction following a failed 'hostile takeover' by the Syndicate, Hideki was given the choice of a slow and painful death or a life of indentured servitude to his new criminal overlords. While he considers the types of contracts the Syndicate typically assigns him to be beneath both his honor and his talent, Arkham has proven to be a valuable training ground to better hone his craft. While he bides his time, Hideki has ultimately grown to view his new patrons as a means to a very particular end; while he builds his reputation for ruthless efficiency, so too does his clan grow closer to being restored to its former glory...",
+    "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Rogue cards ([rogue]) level 0-5, Guardian cards ([guardian]) level 0-1, <b>Tactic</b> cards level 0-5, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Apotheosis, The Succession, 1 random basic weakness.\n<b>Deckbuilding restrictions</b>: No [[Firearm]] assets.",
+    "code": "zgoo_00007",
+    "deck_limit": 1,
+    "deck_options": [
+      {
+        "faction": [
+          "rogue"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "guardian"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
+        "faction": [
+          "neutral"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "trait": [
+          "tactic"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "not": true,
+        "trait": [
+          "firearm"
+        ]
+      }
+    ],
+    "deck_requirements": "size:30, card:zgoo_00008, card:zgoo_00009, random:subtype:basicweakness",
+    "double_sided": true,
+    "faction_code": "rogue",
+    "flavor": "\"Though I may strike from the shadows, do not think I lack the courage to stand in the light.\"",
+    "gender": "m",
+    "health": 8,
+    "illustrator": "Anarch Fox",
+    "is_unique": true,
+    "name": "Hideki Honda",
+    "pack_code": "zgoo",
+    "position": 3,
+    "quantity": 1,
+    "sanity": 6,
+    "skill_agility": 4,
+    "skill_intellect": 2,
+    "skill_combat": 4,
+    "skill_willpower": 2,
+    "subname": "The Shinobi",
+    "text": "[fast] Deal 1 damage to an enemy at your location that is not engaged with you. <i>(Limit once per round.)</i>.\n[elder_sign] effect: +2. You may automatically evade 1 non-[[Elite]] enemy at your location.",
+    "traits": "Hunter. Syndicate.",
+    "type_code": "investigator",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00008",
+    "cost": 0,
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "Only one of Hideki's pupils has ever shown real promise.",
+    "health": 2,
+    "is_unique": true,
+    "illustrator": "Allen Hseih",
+    "name": "Nabiki Nagata",
+    "pack_code": "zgoo",
+    "position": 10,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00007",
+    "sanity": 2,
+    "skill_wild": 1,
+    "skill_willpower": 1,
+    "slot": "ally",
+    "text": "Hideki Honda deck only.\nYou get +1 [agility]\n[fast] Discard Nabiki Nagata: <b>Evade.</b> Automatically evade all non-<b>Elite</b> enemies at your location.",
+    "traits": "Ally. Hunter.",
+    "type_code": "asset",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00009",
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "He couldn't save anyone. He can't even save himself.",
+    "illustrator": "Omid Goudarzi",
+    "name": "Survivor's Guilt",
+    "pack_code": "zgoo",
+    "position": 11,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00007",
+    "subtype_code": "weakness",
+    "text": "<b>Revelation</b> - Put this into play in your threat area.\n<b>Forced</>: After you succeed at a skill test: Take 1 direct horror.\n[action][action]: Discard Survivor's Guilt. You may activate this ability only if you control an [[Ally]] asset.",
+    "traits": "Madness.",
+    "type_code": "treachery"
+  },
+  {
+    "back_flavor": "As a practitioner of the ancient art of Onmyōdō, Akira has devoted his life to research and mastery of the boundary between life and death. He prefers, whenever possible, to spend his time communicating with the spirits of the deceased, in order to learn arcane secrets that are simply beyond the reach of most modern occult practitioners. The natural ease with which he is able to draw upon knowledge and power from the antecedent magi in his bloodline via a highly developed 'genetic memory' has made him somewhat arrogant and detached from the affairs of our world, but he is beloved by common folk for his ability to banish vengeful apparitions and help still-living souls find closure by making contact with the spirits of their deceased loved ones. Despite his already considerable power, Akira still finds himself hungering for answers to ever more dangerous questions...",
+    "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Mystic cards ([mystic]) level 0-5, Seeker cards ([seeker]) level 0-1, <b>Practiced</b> cards level 0-5, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Living Memory, Liminal Breach, 1 random basic weakness.\n<b>Deckbuilding restrictions</b>: No [[Tarot]] assets.",
+    "code": "zgoo_00010",
+    "deck_limit": 1,
+    "deck_options": [
+      {
+        "faction": [
+          "mystic"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "seeker"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
+        "faction": [
+          "neutral"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "trait": [
+          "practiced"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "not": true,
+        "trait": [
+          "tarot"
+        ]
+      }
+    ],
+    "deck_requirements": "size:30, card:zgoo_00011, card:zgoo_00012, random:subtype:basicweakness",
+    "double_sided": true,
+    "faction_code": "mystic",
+    "flavor": "\"A thousand generations live on in me.\"",
+    "gender": "m",
+    "health": 5,
+    "is_unique": true,
+    "name": "Akira Arisato",
+    "pack_code": "zgoo",
+    "position": 4,
+    "quantity": 1,
+    "sanity": 9,
+    "skill_agility": 1,
+    "skill_intellect": 4,
+    "skill_combat": 2,
+    "skill_willpower": 5,
+    "subname": "The Medium",
+    "text": "[reaction] When a non-weakness skill card would be placed in the discard pile of an investigator at your location: Shuffle that card into its owner's deck instead. <i>(Limit once per round)</i>\n[elder_sign] effect: +1. You may return a card from your discard pile to your hand.",
+    "traits": "Sorcerer. Dreamer.",
+    "type_code": "investigator",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00011",
+    "cost": 0,
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "\"Nothing is truly lost until it is forgotten.\"",
+    "is_unique": true,
+    "illustrator": "Vera Velichko",
+    "name": "Living Memory",
+    "pack_code": "zgoo",
+    "position": 12,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00010",
+    "sanity": 2,
+    "skill_wild": 1,
+    "skill_willpower": 1,
+    "slot": "body",
+    "text": "Akira Arisato deck only.\nYou may commit the top-most skill card in your discard pile as though it were in your hand. If that card would be discarded when the test ends, placei ton the bottom of your deck, isntead. <i>(Limit once per turn.)</i>",
+    "traits": "Talent. Occult.",
+    "type_code": "asset",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00012",
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "Many souls that have passed from our world would do anything to return to it.",
+    "illustrator": "HeeDo Park",
+    "is_unique": true,
+    "name": "Liminal Breach",
+    "pack_code": "zgoo",
+    "position": 12,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00010",
+    "subtype_code": "weakness",
+    "slot": "body",
+    "subname": "The Sundered Veil",
+    "text": "<b>Revelation</b> - Put this into play with 1 doom on it.\n[action] If there is no doom on Liminal Breach: Discard it.\n[action]: Test [will] (5). If you succeed, remove 1 doom from liminal breach.",
+    "traits": "Blunder. Omen.",
+    "type_code": "asset"
+  },
+  {
+    "back_flavor": "Orphaned at an early age under mysterious circumstances, Sakura was adopted and raised by a superstitious blacksmith living in a remote village outside of Arkham. One day, the smith became despondent after catching his young ward 'playing' with a blade he had forged, and soon abandoned his craft. Suspecting the influence of evil spirits, Sakura left the village when the smith died but took the sword with her, vowing to ensure her foster father's magnum opus would be put to good use against the forces of darkness that threaten the lives of innocents, wherever they may lurk.",
+    "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Survivor cards ([survivor]) level 0-5, Rogue cards ([rogue]) level 0-1, [[Spirit]] cards level 0-5, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Live By the Sword, Die By the Sword, 1 random basic weakness.\n<b>Deckbuilding restrictions</b>: No [[Firearm]] assets.",
+    "code": "zgoo_00013",
+    "deck_limit": 1,
+    "deck_options": [
+      {
+        "faction": [
+          "guardian"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "mystic"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
+        "faction": [
+          "neutral"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "trait": [
+          "spirit"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "not": true,
+        "trait": [
+          "firearm"
+        ]
+      }
+    ],
+    "deck_requirements": "size:30, card:zgoo_00014, card:zgoo_00015, random:subtype:basicweakness",
+    "double_sided": true,
+    "faction_code": "survivor",
+    "flavor": "\"You won't live long enough to remember my name.\"",
+    "gender": "f",
+    "health": 9,
+    "illustrator": "Puppeteer Lee",
+    "is_unique": true,
+    "name": "Yuki Yagami",
+    "pack_code": "zgoo",
+    "position": 5,
+    "quantity": 1,
+    "sanity": 5,
+    "skill_agility": 2,
+    "skill_intellect": 2,
+    "skill_combat": 5,
+    "skill_willpower": 3,
+    "subname": "The Wanderer",
+    "text": "[reaction] When you play a [[Spirit]] card: Reduce its resource cost by 1 or gain 1 resource.\n[elder_sign] effect: +1. You may shuffle a [[Spirit]] card from your discard pile back into your deck.",
+    "traits": "Drifter. Wayfarer.",
+    "type_code": "investigator",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00014",
+    "cost": 4,
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "\"Anyone can die. It's living that requires courage.\"",
+    "name": "Live By the Sword",
+    "pack_code": "zgoo",
+    "position": 14,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00013",
+    "skill_willpower": 1,
+    "skill_combat": 1,
+    "subname": "The Warrior's Code",
+    "text": "Sakura Sanada deck only.\nYou gain an additional action during your turn which can only be used to engage or fight an enemy.",
+    "traits": "Spirit. Pact.",
+    "type_code": "asset",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00015",
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "flavor": "Death before dishonor.",
+    "illustrator": "Rachid Lotf",
+    "name": "Die By the Sword",
+    "pack_code": "zgoo",
+    "position": 15,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00013",
+    "subtype_code": "weakness",
+    "text": "<b>Revelation</b> - Put this into play in your threat area\nEnemies in your threat area get +1 fight and you deal +1 damage when you fail a skill test while fighting an enemy engaged with another investigator.\n[action] Take 2 damage or discard an [[Ally]] asset from your hand or play area: Discard Die By the Sword.",
+    "traits": "Pact.",
+    "type_code": "treachery"
+  },
+  {
+    "back_flavor": "Mayu grew up in the country outside of Arkham, in the remote farming hamlet of Minakami Village, along with her sister Miyu. The death of the twins' mother left them orphaned at a young age, but the civic-minded townsfolk all pitched in to ensure the girls were well taken care of, allowing them to grow up happy and carefree. Everything changed on the night of their thirteenth birthday, however, when the twins found themselves drawn into a mysterious portal hidden in the forest outside of town and became trapped within a terrifying 'time loop'. Mayu eventually managed to escape unharmed, but Miyu was never seen again. Mayu moved to Arkham to put some distance between herself and the memories of that day, but recently has found herself visited by a mysterious crimson butterfly that seems to be calling her home...",
+    "back_text": "<b>Deck Size</b>: 30.\n<b>Secondary Class Choice:</b> At deck creation, choose either Seeker ([seeker]) or Survivor ([survivor]).\n<b>Deckbuilding Options</b>: Mystic cards ([survivor]) level 0-5, Neutral cards level 0-5, and cards level 0-2 of your chosen secondary class.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Camera Obscura, Molochean Usurper, 1 random basic weakness.\n<b>Deckbuilding restrictions</b>: No [[Composure]] assets.",
+    "code": "zgoo_00098",
+    "deck_limit": 1,
+    "deck_options": [
+      {
+        "faction": [
+          "mystic"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "neutral"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "not": true,
+        "trait": [
+          "composure"
+        ]
+      },
+      {
+        "name": "Secondary Class",
+        "faction_select": [
+          "seeker",
+          "survivor"
+        ],
+        "level": {
+          "min": 0,
+          "max": 2
+        }
+      }
+    ],
+    "deck_requirements": "size:30, card:zgoo_00099, card:zgoo_00100, random:subtype:basicweakness",
+    "double_sided": true,
+    "faction_code": "mystic",
+    "flavor": "\"I made a promise to my syster...\"",
+    "gender": "f",
+    "health": 7,
+    "illustrator": "Kuvshinov Ilya",
+    "is_unique": true,
+    "name": "Mayu Tachibana",
+    "pack_code": "zgoo",
+    "position": 98,
+    "quantity": 1,
+    "sanity": 7,
+    "skill_agility": 4,
+    "skill_intellect": 2,
+    "skill_combat": 2,
+    "skill_willpower": 4,
+    "subname": "The Twin",
+    "text": "[reaction] After an enemy at your location is evaded: Draw a card\n[fast]: Move 1 charge from Camera Obscura to another asset you control with \"uses (chargeds)\". <i>(Limit once per round.)</i>\n[elder_sign] effect: +1. If you succeed, you may placde 1 charge on Camera Obscura.",
+    "traits": "Miskatonic. Student.",
+    "type_code": "investigator",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00014",
+    "cost": 3,
+    "deck_limit": 1,
+    "faction_code": "neutral",
+    "name": "Camera Obscura",
+    "pack_code": "zgoo",
+    "position": 99,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00098",
+    "skill_willpower": 1,
+    "skill_intellect": 1,
+    "slot": "hand",
+    "subname": "Ethereal Viewfinder",
+    "text": "Manu Tachibana deck only.\nYou get +1 [will]\nUses (4 charges.)\n[action]: <b>Evade.</b> Add your [will] to your skill value for this test. If you succeed by 2 or more, you may spend 1 charge from this to deal 1 damage to the evaded enemy.",
+    "traits": "Item. Tool. Relic. Occult.",
+    "type_code": "asset",
+    "version": 6
+  },
+  {
+    "code": "zgoo_00100",
+    "deck_limit": 1,
+    "enemy_damage": 0,
+    "enemy_evade": 3,
+    "enemy_fight": 3,
+    "enemy_horror": 1,
+    "faction_code": "neutral",
+    "flavor": "Trapped within the perpetual twilight of Onigawa, Manu's twin sister had aeons to realize the power of their sacred bloodline...and reclaim the fallen empire as her own.",
+    "health": 3,
+    "illustrator": "Celestial Fang",
+    "name": "Moclean Usurper",
+    "pack_code": "zgoo",
+    "position": 100,
+    "quantity": 1,
+    "restrictions": "investigator:zgoo_00098",
+    "subtype_code": "weakness",
+    "text": "Hunter 2.\n<b>Prey</b> - Bearer only",
+    "traits": "Avatar. Extradimensional.",
+    "type_code": "enemy"
+  }
+]

--- a/cards/zgoo.json
+++ b/cards/zgoo.json
@@ -6,8 +6,15 @@
     "deck_limit": 1,
     "deck_options": [
       {
+        "not": true,
+        "trait": [
+          "weapon"
+        ]
+      },
+      {
         "faction": [
-          "guardian"
+          "guardian",
+          "neutral"
         ],
         "level": {
           "min": 0,
@@ -24,15 +31,6 @@
         }
       },
       {
-        "faction": [
-          "neutral"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
-      },
-      {
         "trait": [
           "blessed"
         ],
@@ -40,12 +38,6 @@
           "min": 0,
           "max": 5
         }
-      },
-      {
-        "not": true,
-        "trait": [
-          "weapon"
-        ]
       }
     ],
     "deck_requirements": "size:30, card:zgoo_00002, card:zgoo_00003, random:subtype:basicweakness",
@@ -117,44 +109,8 @@
     "deck_limit": 1,
     "deck_options": [
       {
-        "faction": [
-          "seeker"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
-      },
-      {
-        "faction": [
-          "survivor"
-        ],
-        "level": {
-          "min": 0,
-          "max": 1
-        }
-      },
-      {
-        "faction": [
-          "neutral"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
-      },
-      {
         "trait": [
           "patron"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
-      },
-      {
-        "trait": [
-          "gambit"
         ],
         "level": {
           "min": 0,
@@ -172,11 +128,27 @@
         }
       },
       {
-        "slot": [
-          "ally"
+        "faction": [
+          "seeker",
+          "neutral"
         ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "faction": [
+          "survivor"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
+        }
+      },
+      {
         "trait": [
-          "patron"
+          "gambit"
         ],
         "level": {
           "min": 0,
@@ -249,8 +221,15 @@
     "deck_limit": 1,
     "deck_options": [
       {
+        "not": true,
+        "trait": [
+          "firearm"
+        ]
+      },
+      {
         "faction": [
-          "rogue"
+          "rogue",
+          "neutral"
         ],
         "level": {
           "min": 0,
@@ -267,15 +246,6 @@
         }
       },
       {
-        "faction": [
-          "neutral"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
-      },
-      {
         "trait": [
           "tactic"
         ],
@@ -283,12 +253,6 @@
           "min": 0,
           "max": 5
         }
-      },
-      {
-        "not": true,
-        "trait": [
-          "firearm"
-        ]
       }
     ],
     "deck_requirements": "size:30, card:zgoo_00008, card:zgoo_00009, random:subtype:basicweakness",
@@ -360,8 +324,15 @@
     "deck_limit": 1,
     "deck_options": [
       {
+        "not": true,
+        "trait": [
+          "tarot"
+        ]
+      },
+      {
         "faction": [
-          "mystic"
+          "mystic",
+          "neutral"
         ],
         "level": {
           "min": 0,
@@ -378,15 +349,6 @@
         }
       },
       {
-        "faction": [
-          "neutral"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
-      },
-      {
         "trait": [
           "practiced"
         ],
@@ -394,12 +356,6 @@
           "min": 0,
           "max": 5
         }
-      },
-      {
-        "not": true,
-        "trait": [
-          "tarot"
-        ]
       }
     ],
     "deck_requirements": "size:30, card:zgoo_00011, card:zgoo_00012, random:subtype:basicweakness",
@@ -472,30 +428,28 @@
     "deck_limit": 1,
     "deck_options": [
       {
-        "faction": [
-          "guardian"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
+        "not": true,
+        "trait": [
+          "firearm"
+        ]
       },
       {
         "faction": [
-          "mystic"
-        ],
-        "level": {
-          "min": 0,
-          "max": 1
-        }
-      },
-      {
-        "faction": [
+          "survivor",
           "neutral"
         ],
         "level": {
           "min": 0,
           "max": 5
+        }
+      },
+      {
+        "faction": [
+          "rogue"
+        ],
+        "level": {
+          "min": 0,
+          "max": 1
         }
       },
       {
@@ -506,12 +460,6 @@
           "min": 0,
           "max": 5
         }
-      },
-      {
-        "not": true,
-        "trait": [
-          "firearm"
-        ]
       }
     ],
     "deck_requirements": "size:30, card:zgoo_00014, card:zgoo_00015, random:subtype:basicweakness",
@@ -579,16 +527,14 @@
     "deck_limit": 1,
     "deck_options": [
       {
-        "faction": [
-          "mystic"
-        ],
-        "level": {
-          "min": 0,
-          "max": 5
-        }
+        "not": true,
+        "trait": [
+          "composure"
+        ]
       },
       {
         "faction": [
+          "mystic",
           "neutral"
         ],
         "level": {
@@ -597,13 +543,8 @@
         }
       },
       {
-        "not": true,
-        "trait": [
-          "composure"
-        ]
-      },
-      {
         "name": "Secondary Class",
+        "id": "secondary_class",
         "faction_select": [
           "seeker",
           "survivor"

--- a/cards/zgoo.json
+++ b/cards/zgoo.json
@@ -160,6 +160,28 @@
           "min": 0,
           "max": 5
         }
+      },
+      {
+        "not": true,
+        "slot": [
+          "ally"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
+      },
+      {
+        "slot": [
+          "ally"
+        ],
+        "trait": [
+          "patron"
+        ],
+        "level": {
+          "min": 0,
+          "max": 5
+        }
       }
     ],
     "deck_requirements": "size:30, card:zgoo_00005, card:zgoo_00006, random:subtype:basicweakness",


### PR DESCRIPTION
Adding 5 base investigators from Onigawa fan-made expansion (see https://github.com/ArkhamDotCards/theghostsofonigawa)

Also added "reward" investigator - Mayu (not playable in the campaign)