### PR TITLE
fix: consternation typos, Create of Goods asset → Crate of Goods assets

### DIFF
--- a/campaigns/side/consternation_on_the_constellation.json
+++ b/campaigns/side/consternation_on_the_constellation.json
@@ -502,7 +502,7 @@
       "text": "Set the 5 \"Crate of Goods\" assets aside.",
       "bullets": [
         {
-          "text": "Shuffle the Tablet of Dagon and 2 other random Crate of Goods assets together. Remove the remaining Create of Goods asset from the game."
+          "text": "Shuffle the Tablet of Dagon and 2 other random Crate of Goods assets together. Remove the remaining Crate of Goods assets from the game."
         },
         {
           "text": "All 3 cards should be showing only the unrevealed Crate of Goods side, so that players do not known which Crate of Goods is the Tablet of Dagon."


### PR DESCRIPTION
From a report on Discord.