### PR TITLE
Update German translation

### DIFF
--- a/rules/de/rules.json
+++ b/rules/de/rules.json
@@ -1,1130 +1,1832 @@
 [
-  {
-    "id": "Golden_Rule",
-    "title": "Die Goldenen Regeln",
-    "text": "Falls der Text dieses Referenzhandbuches im direkten Widerspruch zum Text der Spielregel steht, hat der Text des Referenzhandbuches Vorrang. \nFalls der Text einer Karte im direkten Widerspruch zum Text des Referenzhandbuches oder der Spielregel steht, gilt der Text der Karte."
-  },
-  {
-    "id": "Grim_Rule",
-    "title": "Die Galgenregel",
-    "text": "Falls die Spieler nicht in der Lage sind, mithilfe dieses Referenzhandbuches eine Regel zu finden oder einen Timing-Konflikt zu lösen, wird der Konflikt auf die für das Gewinnen des Szenarios ungünstigste Alternative aufgelöst. Dann geht das Spiel weiter.\nSobald die Ermittler gezwungen werden eine Wahl zu treffen für die es mehrere gültige Optionen gibt, entscheidet sich der Ermittlungsleiter für eine der Optionen. Die Galgenregel spielt bei einer Wahl der Optionen keine Rolle.\n<i>Beispiel: Die Verschlossene Tür (Grundspiel 147) hat den Text: „Hänge diese Karte an den Ort mit den meisten Hinweisen an, der noch keine Verschlossene Tür angehängt hat.“ Falls es 3 Orte gibt, die alle gleich viele Hinweise haben und keine davon schon eine Verschlossene Tür angehängt hat, entscheidet sich der Ermittlungsleiter für einen der 3 Orte. Die Spieler müssen sich bei der Wahl der 3 Optionen nicht für die ungünstigste Alternative entscheiden.</i>\nDie Galgenregel tritt nur in Kraft, falls die Spieler nicht in der Lage sind, eine Antwort auf eine Regelfrage oder einen Timing-Konflikt zu finden, und deshalb nicht in der Lage wären, das Spiel fortzuführen. Die Regel ist dafür entwickelt worden, weiterspielen zu können, ohne zeitintensive Recherchen betreiben zu müssen. Die Galgenregel soll keine erschöpfende Antwort für Regelfragen und Timing-Konflikte sein."
-  },
-  {
-    "id": "A_An",
-    "title": "Ein, eine",
-    "text": "Sobald eine Bedingung beschrieben wird, gilt diese im Hinblick auf die Worte „ein“ oder „eine“ als erfüllt, falls 1 oder mehr der Elemente, auf die sich die Bedingung bezieht, vorhanden sind. <i>So erfüllt zum Beispiel ein Ermittler mit 3 Ressourcen die Bedingung „Jeder Ermittler mit einer Ressource“.</i>"
-  },
-  {
-    "id": "Ability",
-    "title": "Fähigkeiten",
-    "text": "Eine Fähigkeit ist der spezielle Spieltext, der angibt, wie eine Karte das Spiel beeinflusst.\n- Kartenfähigkeiten interagieren nur mit dem Spiel, falls die Karte mit der Fähigkeit im Spiel ist, es sei denn, die Fähigkeit (oder die Regel für den entsprechenden Kartentyp) bezieht sich ausdrücklich auf die Verwendung aus einer Zone heraus, die sich nicht im Spiel befindet.\n- Kartenfähigkeiten interagieren nur mit anderen Karten, die im Spiel sind, es sei denn die Fähigkeit bezieht sich ausdrücklich auf eine Interaktion mit Karten in einer Zone außerhalb des Spiels.\n- Falls sich mehrere Instanzen derselben Fähigkeit im Spiel befinden, interagiert jede Instanz individuell mit dem Spielstatus (oder darf individuell mit ihm interagieren).\nFolgende Typen von Kartenfähigkeiten gibt es: anhaltende Fähigkeiten, erzwungene Fähigkeiten, Enthüllungsfähigkeiten, ausgelöste Fähigkeiten, Schlüsselwörter und Anweisungen für Gegner (Erscheinen und Beute). Jeder dieser Fähigkeitstypen wird im Folgenden detailliert beschrieben.\nSiehe auch: \"[Kosten](#Costs)\", \"[Effekte](#Effects)\", \"[Adjektive](#Qualifiers)\", \"[Selbstreferenzieller Text](#Self_Referential_Text)\".",
-    "rules": [
-      {
-        "id": "Abilities_Constant_Abilities",
-        "title": "Anhaltende Fähigkeiten",
-        "text": "Anhaltende Fähigkeiten sind ohne besondere Formatierung auf der Karte angegeben. Anhaltende Fähigkeiten interagieren immer mit dem Spielstatus, solange sich die Karte im Spiel befindet. (Einige anhaltende Fähigkeiten überprüfen dauerhaft eine bestimmte Bedingung; dies ist an Wörtern wie „während“ oder „solange“ zu erkennen. Die Effekte einer solchen Fähigkeit sind zu jeder Zeit aktiv, wenn die angegebene Bedingung erfüllt ist.) Anhaltende Fähigkeiten haben keinen Initiierungszeitpunkt."
-      },
-      {
-        "id": "Abilities_Forced_Abilities",
-        "title": "Erzwungene Fähigkeiten",
-        "text": "Eine erzwungene Fähigkeit erkennt man an der fettgedruckten Anweisung „<b>Erzwungen</b> –“. Erzwungene Fähigkeiten werden automatisch initiiert und interagieren automatisch zu einem festgelegten Zeitpunkt mit dem Spielstatus. Diesen Zeitpunkt kann man normalerweise an Wörtern wie „sobald“, „nachdem“, „falls“ oder „zu“ erkennen.\n- Falls eine erzwungene Fähigkeit nicht die Möglichkeit hat, den Spielstatus zu verändern, wird sie nicht initiiert.\n- Die Initiierung einer erzwungenen Fähigkeit, welche die Möglichkeit hat, den Spielstatus zu verändern, ist jedes Mal verpflichtend, wenn der vorgegebene Zeitpunkt erfüllt ist.\n- Eine erzwungene Fähigkeit mit einer Timing-Vorgabe, die mit dem Wort „sobald …“ beginnt, wird automatisch initiiert, sobald die angegebene Timing-Vorgabe eintritt, aber noch bevor ihre Auswirkungen auf den Spielstatus abgehandelt werden.\n- Eine erzwungene Fähigkeit mit einer Timing-Vorgabe, die mit dem Wort „nachdem …“ beginnt, wird automatisch initiiert, nachdem die Auswirkungen der Timing-Vorgabe auf den Spielstatus abgehandelt worden sind.\n- Zu jeder Timing-Vorgabe müssen alle erzwungenen Fähigkeiten, die sich auf diese Timing-Vorgabe beziehen, abgehandelt werden, bevor [reaction]-Fähigkeiten (siehe unten), die sich auf dieselbe Timing-Vorgabe beziehen, initiiert werden dürfen.\nSiehe \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
-      },
-      {
-        "id": "Abilities_Revelation_Abilities",
-        "title": "Enthüllungsfähigkeiten",
-        "text": "Eine Enthüllungsfähigkeit, zu erkennen an einem fettgedruckten \"<b>Revelation</b> – \" auf einer Begegnungskarte oder Schwäche, wird initiiert, wenn ein Ermittler diese Karte zieht (siehe \"[Enthüllung](#Revelation)\"."
-      },
-      {
-        "id": "Abilities_Triggered_Abilities",
-        "title": "Ausgelöste Fähigkeiten",
-        "text": "Vor einer ausgelösten Fähigkeit steht entweder ein [free]-Symbol, ein [reaction]-Symbol, oder ein [action]-Symbol. Falls die Fähigkeit eine oder mehrere Voraussetzungen hat (Kosten und/oder Bedingungen), werden diese im Text direkt hinter diesem Symbol angegeben. Spieler müssen diese Voraussetzungen für ausgelöste Fähigkeiten immer erfüllen, um diese Fähigkeit auslösen zu können. Es gibt drei Arten ausgelöster Fähigkeiten:\nFreie ausgelöste Fähigkeiten ([free])\n– Eine freie ausgelöste Fähigkeit ([free]) darf in jedem Spielerfenster als Spielerfähigkeit ausgelöst werden. (Siehe „Anhang II: Timing und Spiel“ auf Seite 22 für eine vollständige Liste der Spielerfenster.)\nReaktionsausgelöste Fähigkeiten ([reaction])\n– Eine reaktionsausgelöste Fähigkeit ([reaction]) mit einer festgelegten Auslösebedingung darf zu jedem Zeitpunkt ausgelöst werden, an dem die Auslösebedingung erfüllt ist. <i>Beispiel: „[reaction] Nachdem du einen Gegner besiegt hast:“</i>\n- Eine [reaction]󲆍-Fähigkeit mit einer Auslösebedingung, die mit dem Wort „sobald …“ beginnt, darf verwendet werden, nachdem die angegebene Auslösebedingung initiiert worden ist, aber noch bevor ihre Auswirkungen auf den Spielstatus abgehandelt werden.\n- Eine [reaction] -Fähigkeit mit einer Auslösebedingung, die mit dem Wort „nachdem …“ beginnt, darf verwendet werden, sofort nachdem die Auswirkungen ihrer Auslösebedingung auf den Spielstatus abgehandelt worden sind.\n- Jede [reaction]-Fähigkeit darf jedes Mal, wenn ihre angegebene Bedingung erfüllt ist, nur ein Mal ausgelöst werden. <i>Beispiel: Eine Fähigkeit die ausgelöst wird, „nachdem X passiert ist“, darf jedes Mal, wenn X passiert ist, nur ein Mal ausgelöst werden.</i>\nAktionsausgelöste Fähigkeiten ([action])\n– Eine aktionsausgelöste Fähigkeit ([action]) darf nur während eines Spielerzuges in der Ermittlungsphase durch eine Aktivieren-Aktion ausgelöst werden, und nur wenn der Ermittler 1 Aktion für jedes in den Kosten der Fähigkeit angegebene [action]-Symbol verwendet.\nFür alle ausgelösten Fähigkeiten gelten folgende Regeln:\n- Ausgelöste Fähigkeiten auf einer Karte, die ein Spieler kontrolliert, werden von diesem Spieler entsprechend der Timing-Vorgabe, die in der Fähigkeit angegeben ist, freiwillig ausgelöst.\n- Eine ausgelöste Fähigkeit kann nur initiiert werden, falls ihr Effekt die Möglichkeit hat, den Spielstatus zu ändern, und ihre Kosten (falls vorhanden) vollständig gezahlt werden können, wobei aktive Modifikatoren für Kosten beachtet werden müssen. Ob diese Möglichkeit besteht, wird überprüft, ohne die Konsequenzen der Zahlung der Kosten oder die Interaktion mit anderen Fähigkeiten in Betracht zu ziehen.\n- Sobald eine Fähigkeit initiiert worden ist, müssen die Spieler ihre Effekte soweit möglich abhandeln, außer wenn der Effekt das Wort „darf“ enthält (siehe \"[Dürfen](#May)\").\nEinem Ermittler ist es erlaubt, ausgelöste Fähigkeiten ([fast], [reaction], und [action]-Fähigkeiten) von folgenden Quellen zu verwenden:\n- Von einer Karte im Spiel, die er kontrolliert. Das beinhaltet seine Ermittlerkarte.\n- Von einer Szenariokarte, die im Spiel und am selben Ort wie der Ermittler ist. Das beinhaltet den Ort selbst, Begegnungskarten, die an den Ort angelegt sind, und alle Begegnungskarten in der Bedrohungszone jedes Ermittlers, der sich an diesem Ort befindet.\n- Von der aktuellen Szenen- oder Agendakarte.\n- Von jeder Karte, die dem Ermittler ausdrücklich erlaubt ihre Fähigkeit zu aktivieren."
-      },
-      {
-        "id": "Abilities_Keywords",
-        "title": "Schlüsselwörter",
-        "text": "Ein Schlüsselwort ist eine Kartenfähigkeit, die eine Karte mit speziellen Regeln versieht (siehe \"[Schlüsselwörter](#Keywords)\")."
-      },
-      {
-        "id": "Spawn_Instructions_and_Prey_Instructions",
-        "title": "Erscheinen- und Beute-Anweisungen",
-        "text": "Erscheinen-Anweisungen enthalten Informationen darüber, wo ein Gegner erscheint, wenn er ins Spiel kommt (siehe \"[Erscheinen](#Spawn)\")\nBeute-Anweisungen enthalten Informationen darüber, welchen Ermittler ein Gegner verfolgt und/oder in einen Kampf verwickelt, falls er die Wahl hat (siehe \"[Beute](#Prey)\")."
-      },
-      {
-        "id": "Action_Designators",
-        "title": "Aktionskennzeichen",
-        "text": "Einige Fähigkeiten enthalten fett gedruckte Aktionskennzeichen (wie <b>Kampf</b>, <b>Entkommen</b>, <b>Ermitteln</b> oder <b>Bewegen</b>). Durch die Aktivierung einer solchen Fähigkeit wird die bezeichnete Aktion wie in den Regeln beschrieben durchgeführt, allerdings wird sie auf die in der Fähigkeit angegebene Weise modifiziert."
-      }
-    ]
-  },
-  {
-    "id": "Act_Deck_and_Agenda_Deck",
-    "title": "Szenendeck und Agendadeck",
-    "text": "Das Szenendeck steht für den Fortschritt, den die Ermittler in einem Szenario machen können. Das Agendadeck steht für den Fortschritt und die Ziele der finsteren Mächte, denen die Ermittler in einem Szenario gegenüberstehen. Das Vorrücken im Szenendeck ist normalerweise gut für die Ermittler, ein Vorrücken im Agendadeck hingegen schlecht.\n- Im Szenendeck rücken die Ermittler vor, falls sie als Gruppe die erforderliche Anzahl Hinweise ausgeben (die auf der Szenenkarte angegeben ist). Eine Szenenkarte kann hierfür einen festen Wert (wie zum Beispiel „4“) oder einen Wert pro Ermittler (erkennbar an dem [per_investigator]-Symbol) angeben. Dies passiert normalerweise als [free]-Spielerfähigkeit. Ein oder alle Ermittler können eine beliebige Anzahl Hinweise zur Gesamtzahl der Hinweise beitragen, die benötigt werden, um von einer Szene aus vorzurücken. Falls die Szene eine „<b>Ermittlungsziel</b> –“-Anweisung enthält, überschreibt diese das Ausgeben von Hinweisen oder fügt zusätzliche Voraussetzungen hinzu.\n- Das Agendadeck rückt vor, falls sich die erforderliche Anzahl Verderbensmarker im Spiel befindet (Verderbensmarker auf der Agendakarte und Verderbensmarker auf anderen Karten im Spiel), die auf der Agendakarte angegeben ist. Eine Agendakarte kann einen festen Wert oder einen Wert pro Ermittler angeben. Falls die Agendakarte eine „<b>Ermittlungsziel</b> –“-Anweisung enthält, überschreibt diese die Verderbensmarker-Voraussetzung oder sie fügt zusätzliche Voraussetzungen hinzu.\n- Die oberste Szenen-/Agendakarte des Szenen-/Agendadecks bezeichnet man als „aktuelle“ Szene/„aktuelle“ Agenda.\nUm im Szenendeck oder Agendadeck vorzurücken, werden folgende Schritte in der angegebenen Reihenfolge befolgt: \n1. Alle Marker werden von der Karte, von der aus vorgerückt werden soll, entfernt. Falls im Agendadeck vorgerückt wird, werden alle Verderbensmarker von jeder Karte im Spiel entfernt. \n2. Die Karte, von der aus vorgerückt wird, wird umgedreht und man folgt den Anweisungen auf der Rückseite („b“-Seite). \n-Falls die Rückseite der Szenen- oder Agendakarte eine Begegnungskarte ist, folgt man den Regeln für das Ziehen des entsprechenden Begegnungskartentyps. Ansonsten folgt man einfach den Anweisungen auf der Karte. \n3. Manchmal gibt die Szenen-/Agendakarte, von der aus vorgerückt wird, an, welche Karte zur nächsten Szene/Agenda wird. Falls sie dies nicht tut, wird die nächste Karte im Deck automatisch zur „aktuellen“ Szene/Agenda. Wenn eine neue Karte zur aktuellen Szene/Agenda wird, wird die Karte, von der aus vorgerückt wird, gleichzeitig aus dem Spiel entfernt. \n-Einige Anweisungen im Szenen- oder Agendadeck (sowie auf anderen Begegnungskartentypen) enthalten Auflösungspunkte in folgendem Format: \"**(→A#)**.\" Falls ein Auflösungspunkt erreicht wird, endet das Szenario. Im Kampagnenleitfaden wird dann die entsprechende Auflösung nachgelesen.\nSiehe auch: \"[Hinweise](#Clues)\", \"[Verderben](#Doom)\"."
-  },
-  {
-    "id": "Action",
-    "title": "Aktion",
-    "text": "Während seines Zuges darf ein Ermittler bis zu **drei** Aktionen nehmen.Sobald eine Aktion durchgeführt wird, werden zunächst sämtliche Kosten der Aktion gezahlt. Dann werden die Konsequenzen der Aktion abgehandelt.\n- Falls ein Ermittler die Anweisung erhält, dass er 1 oder mehr Aktionen verliert, hat er in dieser Runde entsprechend weniger Aktionen zur Verfügung.\nManche Kartenfähigkeiten gewähren Ermittlern „zusätzliche Aktionen“. Falls ein Ermittler während seines Zuges eine oder mehrere zusätzliche Aktionen hat, verbraucht die erste Aktion, die er nimmt die sich als zusätzliche Aktion qualifiziert, jene zusätzliche Aktion. \n<i>Beispiel: Daisy Walker hat den Text: „Du darfst in deinem Zug eine zusätzliche Aktion nehmen, die nur für Buch-[action]-Fähigkeiten verwendet werden kann.“Wenn Daisy das erste Mal eine Buch-[action]-Fähigkeit in jedem Zug durchführt, wird automatisch diese zusätzliche Aktion verwendet und nicht eine von Daisys 3 Standardaktionen. </i> \nFalls sich eine Aktion als eine von mehreren zusätzlichen Aktionen eines Ermittlers qualifiziert, darf dieser wählen, welche zusätzliche Aktion verwendet wird. \nFalls ein Effekt bewirkt, dass ein Ermittler eine oder mehrere Aktionen verliert, hat der Ermittler entsprechend viele Standardaktionen weniger in jenem Zug, die er nehmen kann (die 3 Standardaktionen sind die, welche als Erste „verloren“ gehen). Falls dem Ermittler nur noch zusätzliche Aktionen verbleiben, gehen diese nun in einer vom Ermittler gewählten Reihenfolge verloren. \n<i>Beispiel: Ein Effekt bewirkt, dass Daisy 2 Aktionen verliert. Sie hat dadurch 2 Standardaktionen weniger die sie in ihrem Zug nehmen kann. Sie kann nicht wählen ihre zusätzliche Aktion zu verlieren, es sei denn, es wäre ihre einzige verbleibende Aktion. </i>\nEine vollständige Liste der zur Verfügung stehenden Aktionen befindet sich unter Punkt \"[2.2.1 Der Ermittler nimmt eine Aktion, falls möglich.](#Investigation_Phase)\"."
-  },
-  {
-    "id": "Activate_Action",
-    "title": "Activate Action",
-    "text": "„Aktivieren“ ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. \nSobald diese Aktion genommen wird, initiiert der Ermittler eine Fähigkeit, die eine oder mehrere [action]-Symbole als Teil der Kosten der Fähigkeit enthält. Die Anzahl der [action]-Symbole in den Kosten der Fähigkeit legt fest, wie viele Aktionen der Ermittler für diese Aktivieren-Aktion ausgeben muss. Sobald eine Aktivieren-Aktion durchgeführt wird, werden zunächst sämtliche Kosten der Aktion gleichzeitig bezahlt. Dann werden die Konsequenzen der Aktion abgehandelt.\nEin Ermittler darf Aktionen von folgenden Quellen aktivieren: \n-Eine Karte, die sich im Spiel und unter seiner Kontrolle befindet. Dies umfasst auch seine Ermittlerkarte. \n-Eine Szenariokarte, die sich im Spiel und am selben Ort wie der Ermittler befindet. Darunter fällt auch der Ort selbst, Begegnungskarten, die an diesen Ort platziert worden sind, und alle Begegnungskarten in der Bedrohungszone jedes Ermittlers, der sich an diesem Ort befindet. \n-Die aktuelle Szenen- oder Agendakarte."
-  },
-  {
-    "id": "Active_Player",
-    "title": "Aktiver Spieler",
-    "text": "Der aktive Spieler ist der Spieler, der gerade während der Ermittlungsphase seinen Zug nimmt."
-  },
-  {
-    "id": "After",
-    "title": "Nachdem",
-    "text": "Das Wort „nachdem“ bezieht sich auf den Zeitpunkt direkt nachdem die angegebene Timing-Vorgabe oder auslösende Bedingung vollständig abgehandelt worden ist.\n<i>(Beispiel: Eine Fähigkeit mit dem Text: „Nachdem du eine Gegnerkarte gezogen hast“ wird sofort initiiert, nachdem alle Schritte für das Ziehen einer Gegnerkarte abgehandelt worden sind – seine Enthüllungsfähigkeit abgehandelt worden ist, Monster erschienen sind, u. s. w.)</i>\nSiehe auch: \"[Fähigkeit](#Ability)\", \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
-  },
-  {
-    "id": "Additional_Costs",
-    "title": "Zusätzliche Kosten",
-    "text": "Manche Karten haben zusätzliche Kosten, die gezahlt werden müssen, um bestimmte Effekte oder Aktionen durchführen zu können. Diese werden in der Form von „als zusätzliche Kosten um (spezieller Effekt/Aktion) musst du (zusätzliche Kosten)“ oder „Du musst (als zusätzliche Kosten) um (speziellen Effekt/eine Aktion)“ angegeben. \nZusätzliche Kosten sind Kosten, die außerhalb des normalen Zeitpunkts zum Zahlen von Kosten gezahlt werden können (z. B. während des Abhandels eines Effekts). Falls ein Effekt, der zusätzliche Kosten voraussetzt, abgehandelt werden würde, müssen die zusätzlichen Kosten zu diesem Zeitpunkt gezahlt werden. Falls die zusätzlichen Kosten nicht gezahlt werden können, misslingt das Abhandeln dieses Teils des Effekts. \nZusätzliche Kosten müssen nicht gezahlt werden, sobald ein <b>Erzwungen</b>- Effekt oder eine verpflichtende Anweisung (wie etwa im Kampagnenleitfaden oder auf der Rückseite einer Szenen-oder Agendakarte) einen Ermittler dazu auffordert, einen Effekt abzuhandeln.\n<i>Beispiel: „Ashcan“ Pete befindet sich auf dem Miskatonic-Freigelände (Dunwich 48) und aktiviert Dukes zweite Fähigkeit, die lautet: „[action] Erschöpfe Duke: <b>Ermitteln.</b> Du ermittelst mit einem Grund-[intellect]-Fertigkeitswert von 4. Du darfst dich sofort auf einen verbundenen Ort bewegen, bevor du mit diesem Effekt ermittelst.“ Pete zahlt die Kosten, um die Fähigkeit zu aktivieren, indem er eine Aktion ausgibt und Duke erschöpft. Dann handelt Pete die Fähigkeit ab, indem er sich zuerst zur Orne-Bibliothek (Dunwich 50) bewegt und daraufhin ermittelt. Der Text der Orne-Bibliothek aber lautet: „Du musst eine zusätzliche Aktion ausgeben, um in der Orne-Bibliothek zu ermitteln.“ Das fügt zusätzliche Kosten hinzu, die gezahlt werden müssen, um in der Orne-Bibliothek zu ermitteln. Diese zusätzlichen Kosten werden gezahlt, sobald die Ermitteln-Aktion abgehandelt werden würde, außerhalb des Zeitpunkts zum Zahlen von Kosten. Falls Pete die zusätzliche Aktion nicht zahlen kann, misslingt das Abhandeln dieses Teils von Petes Effekt und er kann nicht ermitteln.</i>"
-  },
-  {
-    "id": "Agenda_Deck",
-    "title": "Agendadeck",
-    "text": "\"[Szenendeck und Agendadeck](#Act_Deck_and_Agenda_Deck)\"."
-  },
-  {
-    "id": "Alert",
-    "cycle": ["tfa", "tcu", "tde"],
-    "title": "Alarmiert",
-    "text": "Immer wenn einem Ermittler eine Fertigkeitsprobe misslingt, während er versucht, einem Gegner mit dem Schlüsselwort „Alarmiert“ zu entkommen, führt jener Gegner nach der Anwendung aller Ergebnisse jener Fertigkeitsprobe einen Angriff gegen den entkommenden Ermittler durch. Ein Gegner wird nicht erschöpft, nachdem er einen Alarmiert- Angriff durchgeführt hat. Dieser Angriff wird durchgeführt, egal ob der Gegner mit dem entkommenden Ermittler in einen Kampf verwickelt ist oder nicht."
-  },
-  {
-    "id": "Aloof",
-    "title": "Zurückhaltend",
-    "text": "Zurückhaltend ist eine Schlüsselwortfähigkeit. Ein Gegner mit dem Schlüsselwort Zurückhaltend verwickelt Ermittler am selben Ort nicht automatisch in einen Kampf. \n-Sobald ein Gegner mit Zurückhaltend erscheint, erscheint dieser, ohne in einen Kampf verwickelt zu sein. \n-Ein Ermittler darf die Aktion „In einen Kampf verwickeln“ oder eine Kartenfähigkeit verwenden, um einen Gegner mit Zurückhaltend in einen Kampf zu verwickeln. \n-Ein Ermittler kann einen Gegner mit Zurückhaltend nicht angreifen, solange dieser Gegner nicht mit einem Ermittler in einen Kampf verwickelt ist."
-  },
-  {
-    "id": "As_if",
-    "title": "As if…",
-    "text": "Some card effects allow an investigator to resolve an ability or perform an action as if a certain aspect of the game state were altered, using the text \"as if…\" to indicate the difference. The indicated ability or action is resolved with the altered game state in mind, but the actual game state remains unchanged.\n- The game state is considered to be altered throughout the duration of the indicated ability or action, from its initiation (including the paying of its costs, attacks of opportunity, etc) through the resolution of each aspect of its effect, and up until its completion.\n- Other card abilities or game effects resolved during this duration are also resolved with the altered game state in mind.\n- The game state is not physically altered in any way. (e.g. if you are considered to be at a location, you do not move your mini-card to that location, enemies at that location do not automatically move to your threat area, etc.)\n<i>For example: [Luke Robinson](/card/06004) wants to play [Preposterous Sketches](/card/02186), but is at a location with no clues. One of the locations next to him has a clue on it, so he uses his ability to play Preposterous Sketches as if he were at that location and engaged with each enemy at that location. The game state is considered to be altered in this way throughout the playing of Preposterous Sketches, from its initiation to its resolution. Among other things, this might mean: (a) if there is an enemy at that location, playing Preposterous Sketches would provoke an attack of opportunity, (b) if that location has an ability that would alter the cost of playing the card, it would do so, and (c) other card abilities that might trigger from Luke drawing 1 or more cards would do so as if he were at that connecting location and engaged with that enemy, and so on and so forth. Once Preposterous Sketches has finished resolving and is placed in the discard pile, Luke is no longer considered to be at that location and engaged with each enemy at that location.</i>"
-  },
-  {
-    "id": "Asset_Cards",
-    "title": "Vorteilskarten",
-    "text": "AVorteilskarten stehen für Gegenstände, Verbündete, Talente, Zauber und andere Dinge, die dem Ermittler helfen oder von ihm in einem Szenario verwendet werden dürfen.\n- Sobald man eine Vorteilskarte spielt, platziert man sie in seine Spielzone. Normalerweise bleiben Vorteilskarten im Spiel, wenn sie nicht durch eine Kartenfähigkeit oder einen Spielschritt abgelegt werden.\n- Einige Vorteilskarten haben Werte für Ausdauer und/oder Geistige Gesundheit. Sobald einem Ermittler Schaden oder Horror zugefügt wird, darf dieser Ermittler einen Teil davon oder den kompletten Schaden oder Horror einer gültigen Vorteilskarte zuweisen, die er kontrolliert (siehe \"[Schaden/Horror zufügen](#Dealing_Damage_Horror)\").\n- Die meisten Vorteilskarten benötigen einen oder mehrere Slots, solange sie sich im Spiel befinden (siehe \"[Slots](#Slots)\").\n- Einige Vorteilskarten haben ein Begegnungssetsymbol und keine Stufenanzeige. Solche Vorteilskarten nennt man Storyvorteile. Storyvorteile sind Teil eines Begegnungssets und dürfen nicht zu Spielerdecks hinzugefügt werden, es sei denn, die Auflösung oder die Vorbereitung eines Szenarios erlaubt dies dem Spieler."
-  },
-  {
-    "id": "At",
-    "title": "At",
-    "text": "Some abilities have triggering conditions that use the words \"at\" or \"if\" instead of specifying \"when\" or \"after,\" such as \"at the end of the round,\" or \"if the Ghoul Priest is defeated.\" These abilities trigger in between any \"when…\" abilities and any \"after…\" abilities with the same triggering condition.\nSee also: \"[If](#If)\"."
-  },
-  {
-    "id": "Anhängen an",
-    "title": "Attach To",
-    "text": "Falls eine Karte den Begriff „hänge diese Karte … an“ verwendet, muss sie an das angegebene Spielelement angehängt werden, sobald sie ins Spiel kommt (sie wird teilweise überlappend darunter platziert). Sobald eine Karte angehängt ist, wird sie als Verstärkung bezeichnet.\n- Der Begriff „anhängen an“ wird immer auf Zulässigkeit des Ziels überprüft, sobald eine Karte an ein Spielelement angehängt wird, aber nach dem Anhängen wird diese nicht erneut überprüft. Falls die ursprüngliche Überprüfung beim Anhängen ungültig ist, ist die Karte nicht in der Lage, angehängt zu werden, und bleibt in ihrem vorherigen Status oder ihrer vorherigen Spielzone. Falls eine solche Karte nicht in ihrem vorherigen Spielstatus oder ihrer vorherigen Spielzone bleiben kann, wird sie abgelegt. \n- Ist eine Verstärkung einmal im Spiel, bleibt sie angehängt, bis entweder die Verstärkung oder das Spielelement, an das sie angehängt ist, das Spiel verlässt (die Verstärkung wird in diesem Fall abgelegt), oder bis eine Kartenfähigkeit die Karte ausdrücklich löst. \n- Eine Verstärkung wird unabhängig von dem Spielelement, an das sie angehängt ist, erschöpft oder spielbereit gemacht.",
-    "rules": [
-      {
-        "id": "Control_of_Attachments",
-        "title": "Control of Attachments",
-        "text": "An attachment may change control depending on the card it is attached to.\n- If an investigator attaches a player card to a player card he or she controls, he or she retains control of the attachment.\n- If an investigator attaches a player card to a player card another investigator controls, that other investigator takes control of the attachment.\n- If a player card with 1 or more player attachments changes control, the card’s new controller takes control of those player attachments.\n- If an investigator attaches a player card to an encounter card, he or she retains control of the attachment (but does not gain control of the attached encounter card)."
-      }
-    ]
-  },
-  {
-    "id": "Attacker_Attacked",
-    "title": "Angreifer, angegriffen",
-    "text": "Ein „Angreifer“ ist eine Entität (normalerweise ein Gegner oder Ermittler), die ihren Angriff gegen eine andere Entität ausführt. Die angegriffene Entität nennt man den „angegriffenen Gegner“ oder „angegriffenen Ermittler“.\""
-  },
-  {
-    "id": "Attack_of_Opportunity",
-    "title": "Gelegenheitsangriff",
-    "text": "Jedes Mal wenn ein Ermittler mit einem oder mehreren spielbereiten Gegnern in einen Kampf verwickelt ist und eine andere Aktion nimmt als <b>Kampf</b> oder <b>Entkommen</b> oder eine <b>Verhandeln</b>- oder <b>Aufgeben</b>-Fähigkeit aktiviert, führt jeder dieser Gegner einen Gelegenheitsangriff gegen den Ermittler durch; die Reihenfolge der Angriffe bestimmt dabei der Ermittler. Jeder Angriff fügt dem Ermittler den Schaden und Horror des Gegners zu.\n- Ein Gelegenheitsangriff wird sofort, nachdem alle Kosten für das Initiieren der Aktion, die diesen Angriff provoziert hat, gezahlt worden sind, aber bevor die Effekte dieser Aktion angewendet werden, durchgeführt. \n- Eine Fähigkeit, die mehr als eine Aktion kostet, provoziert nur einen Gelegenheitsangriff von jedem Gegner, der in einen Kampf verwickelt ist. \n- Ein Gegner wird nicht erschöpft, solange er einen Gelegenheitsangriff macht. \n- Nachdem alle Gelegenheitsangriffe gemacht worden sind, wird das Spiel mit der Abhandlung der Aktion, welche die Angriffe initiiert hat, fortgesetzt. \n- Im Bezug auf Kartenfähigkeiten zählen Gelegenheitsangriffe als Gegnerangriffe.\nEin Gelegenheitsangriff wird nur dann ausgelöst, sobald 1 oder mehrere der Aktionen eines Ermittlers dazu ausgegeben oder verwendet werden, um eine Fähigkeit oder Aktion auszulösen. [free]-Fähigkeiten mit fettgedruckten Aktionskennzeichen provozieren keinen Gelegenheitsangriff."
-  },
-  {
-    "id": "Automatic_Failure_Success",
-    "title": "Automatic Failure/Success",
-    "text": "Some card or token abilities may cause a skill test to automatically fail or to automatically succeed. If a skill test automatically fails or automatically succeeds, it does so during step \"ST.6\" of the \"[Skill Test Timing](#Skill_Test_Timing)\" process outlined.\n- If a skill test automatically fails, the investigator's total skill value for that test is considered 0.\n- If a skill test automatically succeeds, the total difficulty of that test is considered 0.\nSome card effects make an investigator automatically succeed or automatically fail a skill test. If this occurs, depending on the timing of such an effect, certain steps of the skill test may be skipped in their entirety.\n- If it is known that an investigator automatically succeeds or fails at a skill test before Step 3 (\"Reveal chaos token\") occurs, that step is skipped, along with Step 4. No chaos token(s) are revealed from the chaos bag, and the investigator immediately moves to Step 5. All other steps of the skill test resolve as normal.\n- If a chaos token effect causes an investigator to automatically succeed or fail at a skill test, continue with Steps 3 and 4, as normal.\n- If an ability \"automatically evades\" 1 or more enemies, this is not the same as automatically succeeding at an evasion attempt. As per the entry on \"Evade\" in the Rules Reference (see \"[Evade](#Evade)\"), if an ability automatically evades 1 or more enemies, no skill test is made for the evasion attempt whatsoever. Consequentially, because no skill test is made, it is not considered a \"successful\" evasion. The investigator simply follows the steps for evading an enemy (exhausting it and breaking its engagement).\n<i>For example: Patrice uses the ability on Hope, which reads: \"[action] If Hope is ready, exhaust or discard him: <b>Evade.</b> Attempt to evade with a base [agility] value of 5. (If you discarded Hope, this test is automatically successful.)\" If Patrice chooses to discard Hope, the skill test automatically succeeds before chaos tokens are revealed; therefore Steps 3 and 4 of the skill test are skipped. However, the skill test still takes place. Cards may still be committed to the test, and the investigator’s total modified skill value is still determined, as it may have some bearing on other card abilities. However, if Patrice instead uses the ability on Stray Cat, which reads: \"[fast] Discard Stray Cat: Automatically evade a non-<b>Elite</b> enemy at your location,\" no skill test is made whatsoever.</i>"
-  },
-  {
-    "id": "Base_Value",
-    "title": "Grundwert",
-    "text": "Der Grundwert ist der Wert eines Elementes, bevor Modifikatoren angewendet werden. Wenn nicht anders angegeben, ist der Grundwert eines Elementes, das von einer Karte abgeleitet ist, der auf dieser Karte aufgedruckte Wert."
-  },
-  {
-    "id": "Bearer",
-    "title": "Träger",
-    "text": "Der Träger einer Schwäche ist der Ermittler, der das Spiel mit dieser Schwäche in seinem Deck oder seiner Spielzone begonnen hat.\nSiehe \"[Schwäche](#Weakness)\"."
-  },
-  {
-    "id": "Blank",
-    "title": "Leer",
-    "text": "Falls das aufgedruckte Textfeld einer Karte durch eine Fähigkeit behandelt wird, als ob es „leer“ wäre, wird dieses Textfeld behandelt, als ob es keinen aufgedruckten Inhalt hätte. Text und/oder Symbole, die aus anderen Quellen stammen, werden dadurch nicht geleert. \n- Das Textfeld einer Karte enthält Merkmale, Schlüsselwörter, Kartentexte und Fähigkeiten."
-  },
-  {
-    "id": "Bonded",
-    "cycle": ["tcu", "tde"],
-    "title": "Bonded",
-    "text": "Cards with the bonded keyword are linked to another player card. They have no level and therefore are not available as deckbuilding options. Instead, the card to which they are bonded (which is listed in parentheses next to this keyword) brings the bonded card into the game.\nIf your deck contains a card that summons one or more bonded cards, those bonded cards are set aside at the start of each game.\nIf a weakness with the bonded keyword is added to an investigator's deck, hand, threat area, or play area, it does not remain a part of that investigator's deck for the rest of the campaign (unlike other weaknesses). It starts each game set aside with that investigator's other bonded cards.\n<i>For example: Hope, Zeal, and Augur all have the \"bonded (Miss Doyle)\" keyword. This means each of those cards is bonded to the card Miss Doyle. Hope, Zeal, and Augur each have no level and are therefore not available as options to include when building your deck. However, Miss Doyle summons each of these cards when she is played. Therefore, a player with Miss Doyle in their deck should set aside Hope, Zeal, and Augur at the start of each game. These cards are not part of that investigator's deck and do not count towards their deck size.</i>\nIf an investigator’s deck contains a card that summons one or more bonded cards, those bonded cards are set aside at the start of each game. The number of copies of each different bonded card that are set aside in this way is equal to the number of copies of that were included in the product in which that bonded card was introduced. The number of cards in your deck that summon the bonded card in question does not factor into this limit.\n<i>For example: An investigator may only have 3 copies of Soothing Melody set aside at the start of the game. Similarly, an investigator may only have 1 Essence of the Dream set aside at the start of the game, regardless of how many copies of Dream Diary they include in their deck.</i>"
-  },
-  {
-    "id": "Campaign_Play",
-    "title": "Kampagnenspiel",
-    "text": "Eine Kampagne ist eine Reihe von miteinander verbundenen Szenarien, in denen jeder Spieler von einem Szenario zum nächsten denselben Ermittler spielt. Im Verlauf der Kampagne erhält der Ermittler Erfahrungspunkte und Traumata, was sich durch Veränderungen seines Decks widerspiegelt. Jede Entscheidung, die in einer Kampagne getroffen worden ist, kann in späteren Szenarien Auswirkungen haben. \nSobald man eine Kampagne beginnt, werden die Anweisungen für die Vorbereitung der Kampagne im Kampagnenleitfaden befolgt. Nachdem man ein Szenario in einer Kampagne durchgespielt hat, werden die Ergebnisse im Kampagnenlogbuch notiert.",
-    "rules": [
-      {
-        "id": "Experience",
-        "title": "Erfahrung",
-        "text": "Nachdem die Ermittler die Ergebnisse eines Szenarios notiert haben, können sie mit ihrer gewonnenen Erfahrung neue Karten für ihre Decks erwerben. Dazu werden die folgenden Schritte in angegebener Reihen- folge durchgeführt:\n1. <b>Erfahrungspunkte zählen:</b> Jeder Ermittler verdient Erfahrungspunkte in Höhe der Summe der Siegpunktewerte auf allen Karten im Siegpunktestapel, modifiziert durch Boni und Mali, die im Kampagnenleitfaden für diese Auflösung angegeben sind. Diese Summe wird zu eventuell noch nicht ausgegebenen Erfahrungspunkten des Ermittlers addiert, die er in vorherigen Szenarien dieser Kampagne gewonnen hat.\n2. <b>Neue Karten erwerben:</b> Nun dürfen neue Karten erworben und dem Deck des Spielers hinzugefügt werden, indem man Erfahrungspunkte in Höhe der Kartenstufe ausgibt (erkennbar an der Anzahl der weißen Punkte oben links auf der Karte). Beim Erwerben neuer Karten beachtet man folgende Regeln: \n- Die Deckbaurichtlinien des Ermittlers (auf der Rückseite der Ermittlerkarte) müssen beim Erwerb neuer Karten beachtet werden. Man darf nur Karten erwerben, auf die der Ermittler Zugriff hat. Die Anforderungen für die Deckgröße müssen ebenfalls beachtet werden, indem für jede (nicht dauerhafte) Karte, die erworben und dem Deck hinzugefügt worden ist, eine andere Karte aus dem Deck entfernt wird. Schwächekarten und Karten, die dem Deck eines Ermittlers hinzugefügt werden müssen, dürfen nicht für neu erworbene Karten entfernt werden. \n- Jede Karte kostet Erfahrungspunkte in Höhe der Kartenstufe, <i>bis zu einem Minimum von 1</i> (der Kauf einer Karte der Stufe Null kostet trotzdem 1 Erfahrungspunkt). Die Anzahl der weißen Punkte unter den Kosten einer Karte gibt die Stufe der Karte an. \n- Sobald man eine Karte erwirbt, die eine höherstufige Version einer Karte mit demselben Kartennamen ist, darf der Ermittler diese Karte „verbessern“, indem er nur die Differenz der Erfahrung zwischen den beiden Karten zahlt (bis zu einem Minimum von 1) und die niedrigerstufige Version aus seinem Deck entfernt. \n- Neue Karten werden einzeln erworben (oder verbessert). Falls ein Ermittler mehr als 1 Kopie einer neuen Karte erwerben möchte, muss er für jede Kopie einzeln zahlen und für jede erworbene Kopie eine Karte aus seinem Deck entfernen. \n- Ein Spieler kann sein Deck im Verlauf einer Kampagne nur durch die oben angegebenen Schritte und durch besondere Anweisungen im Kampagnenleitfaden verändern.\n3. <b>Nicht ausgegebene Erfahrungspunkte notieren:</b> Jeder Ermittler notiert seine nicht ausgegebenen Erfahrungspunkte im Kampagnenlogbuch. Diese Erfahrungspunkte können zu einem späteren Zeitpunkt in der Kampagne ausgegeben werden."
-      },
-      {
-        "id": "Trauma",
-        "title": "Trauma",
-        "text": "Trauma steht für dauerhaften Schaden an der Ausdauer oder der Psyche eines Ermittlers. \nFalls ein Ermittler in einem Szenario besiegt wird, scheidet dieser Ermittler aus dem Szenario, aber nicht unbedingt aus der Kampagne aus. \nFalls ein Ermittler durch Schaden in Höhe seiner Ausdauer besiegt worden ist, erleidet er 1 körperliches Trauma (wird im Kampagnenlogbuch notiert). Für jedes körperliche Trauma des Ermittlers beginnt dieser jedes künftige Szenario mit 1 Schaden. Falls ein Ermittler körperliche Traumata in Höhe seiner aufgedruckten Ausdauer hat, wird der Ermittler <b>getötet</b>. \nFalls ein Ermittler durch Horror in Höhe seiner geistigen Gesundheit besiegt worden ist, erleidet er 1 seelisches Trauma (wird im Kampagnenlogbuch notiert). Für jedes seelische Trauma des Ermittlers, beginnt dieser jedes künftige Szenario mit 1 Horror. Falls ein Ermittler seelische Traumata in Höhe seiner aufgedruckten geistigen Gesundheit hat, ist der Ermittler <b>wahnsinnig</b> geworden. \nFalls ein Ermittler besiegt worden ist, indem er gleichzeitig Schaden in Höhe seiner Ausdauer *und* Horror in Höhe seiner geistigen Gesundheit erhalten hat, wählt er, welches Trauma er erleidet. \nFalls ein Ermittler getötet oder wahnsinnig geworden ist, muss der Spieler einen neuen Ermittler für das nächste Szenario wählen und für diesen ein neues Deck erstellen. Getötete oder wahnsinnige Ermittler können für den Rest der Kampagne nicht verwendet werden (siehe \"[Getötete/Wahnsinnige Ermittler](#Killed_Insane_Investigators)\").\nFalls ein Spieler einen neuen Ermittler wählen möchte und sich keine weiteren Ermittler im Kartenpool befinden, haben die Spieler verloren und die Kampagne endet."
-      },
-      {
-        "id": "Defeat_by_Card_Ability",
-        "title": "Besiegt durch eine Kartenfähigkeit",
-        "text": "Ein Ermittler kann durch eine Kartenfähigkeit besiegt werden. Ein besiegter Ermittler scheidet aus dem Spiel aus (siehe \"[Ausscheiden](#Elimination)\"). Sollte dies eintreten, befolgt man die Anweisungen der Kartenfähigkeit, um festzustellen, ob dies langfristige Konsequenzen zur Folge hat.\n"
-      },
-      {
-        "id": "Advancing_to_Next_Scenario",
-        "title": "Zum nächsten Szenario vorrücken",
-        "text": "Nachdem man ein Szenario abgeschlossen hat, die Auflösung durchgeführt, das Kampagnenlogbuch auf den neusten Stand gebracht und neue Karten erworben hat, rückt man zum nächsten Szenario (in der Reihenfolge) der Kampagne vor, falls die Auflösung des Szenarios die Ermittler nicht direkt zu einem anderen Szenario leitet."
-      },
-      {
-        "id": "Joining_or_Leaving_a_Campaign",
-        "title": "Einer Kampagne beitreten oder sie verlassen",
-        "text": "Hat eine Kampagne erst einmal begonnen, können die Spieler zwischen zwei Szenarien der Kampagne beitreten oder sie verlassen. \nFalls ein Spieler eine Kampagne verlässt, werden die Informationen über diesen Spieler nicht aus dem Kampagnenlogbuch gelöscht, da er zu einem späteren Zeitpunkt wieder zwischen zwei Szenarien einsteigen darf. \nFalls ein neuer Spieler einer Kampagne beitritt, muss er einen Ermittler wählen, der in dieser Kampagne zuvor noch nicht verwendet worden ist. Dieser Spieler beginnt das Spiel, als ob es sich für ihn um das erste Szenario der Kampagne handeln würde, ohne Erfahrung und ohne Traumata."
-      },
-      {
-        "id": "Transferring_Investigators_to_a_New_Campaign",
-        "title": "Transferring Investigators to a New Campaign",
-        "text": "This section expands on the ability for investigators to transfer from a completed campaign to another campaign, as originally described in the section \"The End…or Is It?\" in the Night of the Zealot campaign guide.\n<i>Note: The standard rules of the game dictate that players start each campaign with a clean state (new decks and 0 experience). The following is an optional variant that is likely to affect the game’s balance. Only intrepid investigators who wish to embrace the chaos should choose this option.</i>\nWhen transferring one or more investigators from a completed campaign to a new campaign, players should observe the following rules:\n- Not all surviving investigators in the original campaign need to be transferred. It is okay to transfer some and start fresh with others.\n- Investigator decks remain the same. This includes all story assets and weaknesses earned in the original campaign, as well as experience gained and trauma suffered. Everything recorded in the campaign log under that investigator’s \"Earned Story Assets / Weaknesses\" should be transferred to the new campaign, as well.\n- All other notes in the Campaign Log should be wiped clean and do not transfer to the new campaign.\n- The chaos bag is reset. This includes all additional chaos tokens that were added to the chaos bag throughout the original campaign.\n- Cards and Campaign Guides are written with the assumption that investigators are not being transferred from one campaign to another. For this reason, campaigns are sometimes referred to as \"the campaign.\" <i>(For example, \"for the remainder of the campaign…\")</i> In general, when interpreting such effects, treat each campaign as being separate from one another. However, some effects should be interpreted as if each campaign played is part of one continuous uninterrupted campaign. This includes rules that dictate how an earned weakness or story asset operates, or additional rules that a specific investigator must follow. <i>(For example, \"for the remainder of the campaign, the bearer of X weakness must only speak in French.\")</i>"
-      }
-    ]
-  },
-  {
-    "id": "Cancel",
-    "title": "Aufheben",
-    "text": "Einige Kartenfähigkeiten können andere Karteneffekte oder Spieleffekte „aufheben“. Aufheben-Fähigkeiten unterbrechen die Initiierung eines Effektes und verhindern, dass der Effekt initiiert wird. \n- Jedes Mal wenn man die Effekte einer Fähigkeit aufhebt, gilt diese Fähigkeit immer noch als initiiert (mit Ausnahme ihrer Effekte) und ihre Kosten sind immer noch bezahlt. Das Initiieren der Effekte der Fähigkeit wird allerdings verhindert und man handelt die Effekte nicht ab. \n- Falls die Effekte einer Ereigniskarte aufgehoben werden, gilt die Karte immer noch als gespielt und die Karte wird weiterhin auf den Ablagestapel ihres Besitzers gelegt. \n- Falls die Effekte einer Verratskarte aufgehoben werden, gilt die Karte immer noch als gezogen und die Karte wird weiterhin auf den Begegnungs-Ablagestapel gelegt."
-  },
-  {
-    "id": "Cannot",
-    "title": "Kann nicht/Können nicht",
-    "text": "Der Begriff „kann nicht“ hat absolute Gültigkeit und kann nicht von anderen Fähigkeiten widerrufen werden."
-  },
-  {
-    "id": "Cardtypes",
-    "title": "Kartentypen",
-    "text": "Informationen über die Kartentypen des Spiels und ihren genauen Aufbau befinden sich in Anhang IV (siehe \"[Anhang IV: Aufbau der Karten](#Appendix_IV_Card_Anatomy)\").\n- Falls eine Fähigkeit dafür sorgt, dass eine Karte ihren Kartentyp ändert, verliert sie alle anderen Kartentypen, die sie möglicherweise hat, und funktioniert genau wie andere Karten des neuen Kartentyps.\nSiehe auch: \"[Vorteilskarten](#Asset_Cards)\", \"[Gegnerkarten](#Enemy_Cards)\", \"[Ereigniskarten](#Event_Cards)\", \"[Ortskarten](#Location_Cards)\", \"[Fertigkeitskarten](#Skill_Cards)\", \"[Verratskarten](#Treachery_Cards)\"."
-  },
-  {
-    "id": "Chaos_Tokens",
-    "title": "Chaos Tokens",
-    "text": "Chaos tokens are revealed from the chaos bag during skill tests, to modify or influence the results of the skill test.\n[skull] [cultist] [elder_thing] [tablet] – If any of these tokens are revealed for a skill test, resolve the effect for that symbol as indicated on the scenario reference card for the current scenario.\n[auto_fail] – This is the auto-fail token. If this token is revealed for a skill test, it indicates the investigator automatically fails the test (see \"[Automatic Failure/Success](#Automatic_Failure_Success)\").\n[elder_sign] – This is the elder sign token. If this token is revealed for a skill test, resolve the [elder_sign] effect on the investigator card belonging to the player performing the skill test.\nIf a revealed chaos token (or the effect referenced by a chaos token) has a numerical modifier, that modifier is applied to the investigator's skill value for this test.\nSee \"[ST.3 Reveal chaos token](#Skill_Test_Timing)\".",
-    "rules": [
-      {
-        "id": "Resolving_Multiple_Revealed_Chaos_Tokens",
-        "title": "Resolving Multiple Revealed Chaos Tokens",
-        "text": "If an investigator is instructed to \"resolve\" multiple revealed chaos tokens, any game or card effects which refer to \"the revealed chaos token\" in the singular should be construed to apply to each of the revealed chaos tokens. For example, when applying chaos symbol effects during Step 4 of a skill test or applying modifiers to an investigator’s skill value during Step 5 of a skill test, the effects and modifiers of all of the resolved chaos tokens should be applied, even though the rules state \"the revealed chaos token.\" Similarly, any card effects that refer to \"the revealed chaos token\" refer to all of the resolved tokens.\n<i>For example: An investigator plays Premonition, which reads: \"Put Premonition into play, reveal a random chaos token from the chaos bag, and seal it on Premonition.\" That investigator then uses Olive McBride to \"reveal 3 chaos tokens instead of 1, choose 2 of those tokens to resolve, and ignore the other.\" In this case, both of the resolved tokens would be sealed on Premonition, even though Premonition only refers to the revealed token as a singular token. Likewise, when Premonition instructs that investigator to \"Resolve the token sealed here as if it were just revealed from the chaos bag,\" the investigator should resolve both of the tokens sealed on it.</i>\nAdditionally, when resolving multiple chaos tokens, any game or card effects which trigger if a certain chaos token is revealed - such as the text \"If the named chaos token is revealed during this skill test…\" on Recall the Future - will trigger if any of the resolved chaos tokens meet the specified conditions. Such an effect will not trigger twice if two of the designated tokens are resolved.\nNote that this entry only applies when multiple chaos tokens are \"resolved.\" If multiple chaos tokens are revealed and all but 1 of them are canceled or ignored, this entry does not apply."
-      }
-    ]
-  },
-  {
-    "id": "Choices_and_the_Grim_Rule",
-    "title": "Choices, and the Grim Rule",
-    "text": "When investigators are forced to make a choice and there are multiple valid options, the lead investigator decides between those options. The Grim Rule does not play a part in these choices.\n<i>For example: Locked Door reads \"Attach to the location with the most clues,and without a Locked Door attached.\" If there are 3 locations that are tied for the most clues, and none of them already have a Locked Door attached, the lead investigator decides between those 3 locations. Players are not forced to decide which of those 3 options would be the objectively worst option.</i>\nThe Grim Rule only comes into effect if players are unable to find the answer to a rules or timing conflict, and are thus unable to continue playing the game. It is designed to keep the game moving when looking up the correct answer would be too time-consuming or inconvenient for the players. The Grim Rule is not an exhaustive answer to rules/timing conflicts."
-  },
-  {
-    "id": "Clues",
-    "title": "Clues",
-    "text": "Clues represent the progress the investigators can make towards solving a mystery, unraveling a conspiracy, and/or advancing in a scenario.\n- The first time an investigator enters a location, that location is revealed (turned face-up) and a number of clues equal to that location's clue value are placed on that location (from the token pool). Most clue values are conveyed as a \"per investigator ([per_investigator])\" value. This may occur during setup.\n- A clue at a location can be discovered by successfully investigating the location (see \"[Investigate Action](#Investigate_Action)\" on page 13), or by a card ability. If an investigator discovers a clue, he or she takes the clue from the location and places it on his or her investigator card, under his or her control.\n- If there are no \"<b>Objective</b> – \" requirements for advancing the current act, during any investigator's turn the investigators may, as a group, spend the requisite number of clues (usually conveyed as a \"per investigator\" value) from their investigator cards to advance the act deck. This is normally done as a [free] player ability. Any or all investigators may contribute any number of clues towards the total number of clues required to advance the act.\n- A card ability that refers to clues \"at a location\" is referring to the undiscovered clues that are currently on that location.\nSee also: \"[Act Deck and Agenda Deck](#Act_Deck_and_Agenda_Deck)\", \"[Tokens, Running out of](#Tokens)\"."
-  },
-  {
-    "id": "Collection",
-    "title": "Collection",
-    "text": "If an ability refers to a player's collection <i>(for example, \"search the collection\")</i>, the collection of cards from which that player's deck was assembled is used.\n<i>Example: Sean and Etienne are each using a deck built from Sean's collection. If Etienne is instructed to \"search the collection,\" he searches Sean's collection.</i>"
-  },
-  {
-    "id": "Constant_Abilities",
-    "title": "Constant Abilities",
-    "text": "See \"[Ability](#Abilities_Constant)\"."
-  },
-  {
-    "id": "Control",
-    "title": "Kontrolle",
-    "text": "See \"[Besitz und Kontrolle](#Ownership_and_Control)\"."
-  },
-  {
-    "id": "Copy",
-    "title": "Kopie",
-    "text": "Eine Kopie einer Karte wird durch ihren Kartennamen bestimmt. Eine zweite Kopie einer Karte ist eine andere Karte mit demselben Kartennamen, unabhängig von Kartentyp, Text, Bild oder anderen Eigenschaften der Karte."
-  },
-  {
-    "id": "Costs",
-    "title": "Kosten",
-    "text": "Es gibt zwei Arten von Kosten im Spiel: Ressourcenkosten und Fähigkeitskosten. \nDie Ressourcenkosten einer Karte entsprechen ihrem numerischen Wert, der (in Ressourcen) bezahlt werden muss, um diese Karte von der Hand zu spielen. Um die Ressourcenkosten zu bezahlen, nimmt ein Ermittler eine bestimmte Anzahl Ressourcen aus seinem Ressourcenvorrat und legt sie in den Markervorrat zurück. \nEinige ausgelöste Kartenfähigkeiten haben das Format „Kosten: Effekt“. In diesem Fall gibt der Teil vor dem Doppelpunkt die Kosten der Fähigkeit an, die bezahlt werden müssen, sowie Auslösebedingungen, die erfüllt sein müssen, um die Fähigkeit auszulösen. Der Teil nach dem Doppelpunkt ist der Effekt. \n- Falls mehrere Kosten für eine einzelne Karte oder Fähigkeit bezahlt werden müssen, müssen diese Kosten gleichzeitig bezahlt werden. \n- Nur der Spieler, der eine Karte oder Fähigkeit kontrolliert, darf ihre Kosten bezahlen. Es dürfen keine Spielelemente verwendet werden, die andere Spieler kontrollieren, um Kosten zu bezahlen. \n- Sobald Karten erschöpft, geopfert oder anderweitig verwendet werden, um Kosten zu bezahlen, dürfen nur Karten im Spiel und unter der Kontrolle ihres Besitzers verwendet werden, falls die Kosten nicht ausdrücklich den Status außerhalb des Spiels angeben. \n- Falls zum Bezahlen von Kosten ein Spielelement benötigt wird, das nicht im Spiel ist, darf der Spieler, der die Kosten bezahlt, nur Spielelemente verwenden, die sich in seinen Spielzonen befinden (wie seine Hand oder sein Deck), um die Kosten zu bezahlen. \n- Falls die Ermittler angewiesen werden Kosten als Gruppe zu bezahlen, darf jeder Ermittler (oder jeder Ermittler der durch die von der Fähigkeit definierten Gruppe) zu den Kosten beitragen. \n- Eine Fähigkeit kann nicht initiiert werden und ihre Kosten nicht bezahlt werden, falls das Abhandeln ihrer Effekte den Spielstatus nicht ändern. \n- Falls ein Ermittler als Kosten Schaden oder Horror nimmt und einen Teil davon auf eine Vorteilskarte umverteilt, gelten die Kosten trotzdem als bezahlt."
-  },
-  {
-    "id": "Dealing_Damage_Horror",
-    "title": "Dealing Damage/Horror",
-    "text": "There are two types of afflictions that may beset an investigator in the game: damage and horror. Damage afflicts an investigator's health, and horror afflicts an investigator's sanity.\nWhen an investigator or enemy is dealt damage and/or horror, follow these steps, in order:\n1. <b>Assign Damage/Horror:</b> Determine the amount of damage and/or horror being dealt. Place damage and/or horror tokens equal to the amount of damage and horror being dealt next to the cards that will be taking the damage/horror.\n- When an investigator is dealt damage or horror, that investigator may assign it to eligible asset cards he or she controls. To be eligible, an asset card must have health in order to be assigned damage, and it must have sanity in order to be assigned horror.\n- An asset cannot be assigned damage beyond the amount of damage it would take to defeat the card, and cannot be assigned horror beyond the amount of horror it would take to defeat the card.\n- All damage/horror that cannot be assigned to an asset must be assigned to the investigator.\n2. <b>Apply Damage/Horror:</b> Any assigned damage/horror that has not been prevented is now placed on each card to which it has been assigned, simultaneously. If no damage/horror is applied in this step, no damage/horror has been successfully dealt.\n- Abilities that prevent, reduce, or reassign damage and/or horror that is being dealt are resolved between steps 1 and 2.\n- After applying damage/horror, if an investigator has damage equal to or higher than his or her health or horror equal to or higher than his or her sanity, he or she is defeated. When an investigator is defeated, he or she is eliminated from the scenario (see \"[Elimination](#Elimination)\").\n- After applying damage/horror, if an enemy has damage equal to or higher than its health, it is defeated and placed in the encounter discard pile (or in its owner's discard pile if it is a weakness).\n- fter applying damage/horror, if an asset has damage equal to or higher than its health or horror equal to or higher than its sanity, it is defeated and placed in its owner's discard pile."
-  },
-  {
-    "id": "Deck",
-    "title": "Deck",
-    "text": "There are 4 main types of decks that appear in any game: the Investigator Deck, the Encounter Deck, the Act Deck, and the Agenda Deck.\n- The order of cards within a deck may not be altered unless a player is instructed to do so by a card ability.\nSee also: \"[Investigator Deck](#Investigator_Deck)\", \"[Encounter Deck](#Encounter_Deck)\", \"[Act Deck and Agenda Deck](#Act_Deck_and_Agenda_Deck)\"."
-  },
-  {
-    "id": "Deckbuilding",
-    "title": "Deckbuilding",
-    "text": "When building a custom deck, the following guidelines must be observed:\n- A player must choose exactly 1 investigator card.\n- A player's investigator deck must include the exact number of player cards indicated on the back of his or her investigator card as the \"Deck Size.\" Weaknesses, investigator-specific cards, and scenario cards that are added to a player's deck do not count towards this number.\n- A player's investigator deck may not include more than 2 copies (by title) of any given player card.\n- Each standard player card in a player's investigator deck must be chosen from among the \"Deckbuilding Options\" available on the back of his or her investigator card.\n- Most investigators have 0 experience to spend at the beginning of a campaign, which means that they may only include level 0 cards in their decks. Some investigators, and/or some campaigns, may provide a player with additional experience at the beginning of a campaign, which can be used immediately to purchase higher level cards (see \"[Campaign Play](#Campaign_Play)\").\n- All other \"Deckbuilding Requirements\" listed on the back of a player's investigator card must be observed.\n- Each required random basic weakness is added to a player's deck at the end of the deckbuilding process.\n- Story Assets may not be included in a player's deck unless the setup or resolution of a scenario grants that player permission to do so. These assets are indicated by the lack of a card level and the presence of an encounter set symbol (see \"[Asset Cards](#Asset_Cards)\").\n- During a campaign, players build a deck before playing the first scenario. In between scenarios, players can purchase new cards or upgrade cards in their deck following the rules found under \"[Campaign Play](#Campaign_Play)\".\nIf 1 or more cards are forcibly removed from an investigator’s deck and returned to the collection (such as when a card is exiled, or when a campaign effect forces an investigator to remove cards from their deck), that investigator must purchase cards so that a legal deck size is maintained. When purchasing cards in this manner, that investigator may purchase level 0 cards at 0 experience cost until a legal deck size is reached.\n- This rule also applies if an effect alters an investigator’s deck size, deckbuilding restrictions, or deckbuilding options such that 1 or more cards must be removed from or added to their deck as a result.",
-    "rules": [
-      {
-        "id": "Classes",
-        "title": "Classes",
-        "text": "Most player cards, including investigators, belong to one of 5 classes. Each class has its own distinct flavor and identity, as described below.\nGuardians ([guardian]) feel compelled to defend humanity, and thus go out of their way to combat the forces of the Mythos. They have a strong sense of duty and selflessness that drives them to protect others, and to hunt monsters down.\nMystics ([mystic]) are drawn to and influenced by the arcane forces of the Mythos. Many have spell-casting abilities, able to manipulate the forces of the universe through magical talent.\nRogues ([rogue]) are self-serving and out for themselves. Wily and opportunistic, they are always eager for a way to exploit their current situation.\nSeekers ([seeker]) are primarily concerned with learning more about the world and about the Mythos. They wish to research forgotten lore, map out uncharted areas, and study strange creatures.\nSurvivors ([survivor]) are everyday people in the wrong place at the wrong time, simply trying to survive. Ill-prepared and ill-equipped, Survivors are the underdogs, who rise to the occasion when their lives are threatened.\nSome cards are not affiliated with any class; these cards are neutral. Generally, investigators only have access to cards from their class.\nSome investigators have access to cards from other classes. Refer to the \"Deckbuilding Options\" on the back of an investigator card to view which cards an investigator has access to."
-      },
-      {
-        "id": "Deckbuilding_Options",
-        "title": "Deckbuilding Options",
-        "text": "The following section clarifies how certain investigators’ deckbuilding options function.\n- If one of the categories of an investigator’s deckbuilding options contains the word \"other\" in it, cards only fall into this category if they fall into no other category. <i>(For example, if an investigator’s deckbuilding options reads: \"Guardian cards level 0–5, up to 10 other <b>Weapon</b> cards,\" then a Guardian card with the <b>Weapon</b> trait would not occupy one of those 10 limited slots, because it first falls into the unlimited Guardian category).</i>\n- If one of the categories of an investigator’s deckbuilding options lists card text in it, cards fall into this category if the listed text appears in the card in any capacity, even if it is circumstantial. <i>(For example, if an investigator’s deckbuilding options reads: \"cards that 'heal horror' level 0–5,\" any card with an ability that heals any amount of horror will fall into this category, even if it only heals horror under specific circumstances.)</i>"
-      }
-    ]
-  },
-  {
-    "id": "Defeat",
-    "title": "Defeat",
-    "text": "Taking damage and/or horror may cause an investigator, enemy, or asset to be defeated.\n- If an investigator has as much or more damage on it as it has health (or as much or more horror on it as it has sanity), that investigator is defeated. An investigator might also be defeated by a card ability. When an investigator is defeated, he or she is eliminated from the scenario (see \"[Elimination](#Elimination)\").\n- In campaign play, an investigator that is defeated by taking damage equal to his or her health suffers 1 physical trauma. An investigator that is defeated by taking horror equal to his or her sanity suffers 1 mental trauma. Taking trauma may cause an investigator to be **killed** or driven **insane** (see \"[Campaign Play](#Campaign_Play)\" for more information).\n- If an enemy has as much or more damage on it as it has health, that enemy is defeated and placed on the encounter discard pile (or on its owner's discard pile if it is a weakness).\n- If an asset with a health value has as much or more damage than it has health, it is defeated. If an asset with a sanity value has as much or more horror than it has sanity, it is defeated. A defeated asset is placed on its owner's discard pile."
-  },
-  {
-    "id": "Delayed_Effects",
-    "title": "Delayed Effects",
-    "text": "Some abilities create delayed effects. Such abilities specify a future timing point, or indicate a future condition that may arise, and dictate an effect that will happen at that time.\n- Each delayed effect initiates automatically and immediately (as a forced ability) if its future timing point or future condition occurs.\n- A delayed effect affects all specified entities that are in the specified game area and eligible at the time the delayed effect resolves."
-  },
-  {
-    "id": "Difficulty_level",
-    "title": "Difficulty (level)",
-    "text": "There are four levels of difficulty in *Arkham Horror: The Card Game*: Easy, Standard, Hard, and Expert. At the beginning of a campaign or standalone scenario, the players choose which difficulty level to use. The campaign setup section of that campaign or scenario's Campaign Guide indicates which chaos tokens should be placed into the chaos bag when playing on each difficulty level.\n- When playing in Easy or Standard mode, use the \"Easy/Standard\" side of each scenario's reference card. When playing in Hard or Expert mode, use the \"Hard/Expert\" side of each scenario's reference card instead."
-  },
-  {
-    "id": "Difficulty_skill_tests",
-    "title": "Difficulty (skill tests)",
-    "text": "The difficulty of a skill test is the target number an investigator is trying to equal or exceed with his or her modified skill value to pass that test.\n- When attacking an enemy, the base difficulty of the skill test is the enemy's fight value.\n- When investigating a location, the base difficulty of the skill test is the location's shroud value.\n- When attempting to evade an enemy, the base difficulty for the skill test is the enemy's evade value.\n- When resolving a skill test created by a card ability, the base difficulty is indicated as a parenthetical value following the indication of which skill is being tested. <i>For example: Intellect (3).</i>\nSee \"[Skill Test Timing](#Skill_Test_Timing)\" or the full rules on skill tests."
-  },
-  {
-    "id": "Direct_Damage_Direct_Horror",
-    "title": "Direct Damage, Direct Horror",
-    "text": "If an ability causes a card to take direct damage or direct horror, that damage or horror must be assigned directly to the specified card, and cannot be assigned or re-assigned elsewhere."
-  },
-  {
-    "id": "Discard_Piles",
-    "title": "Discard Piles",
-    "text": "Any time a card is discarded, it is placed faceup on top of its owner's discard pile. Encounter cards are owned by the encounter deck.\n- Each discard pile is an out-of-play area.\n- Each investigator has his or her own discard pile, and the encounter deck has its own discard pile.\n- Each discard pile is open information, and may be looked at by any player at any time.\n- The order of cards in a discard pile may not be altered unless a player is instructed to do so by a card ability.\n- If multiple cards are discarded simultaneously, the owner of the cards may physically place them on top of his or her discard pile one at a time, in any order. If multiple encounter cards are discarded simultaneously, they are placed on top of the encounter discard pile in any order (determined by lead investigator).\n- Any ability that would shuffle a discard pile of zero cards back into a deck does not shuffle the deck.\n- A single card cannot be shuffled into an empty player deck or encounter deck via card effect. If this shuffling would occur during the playing or revelation of a card that is typically discarded after it is resolved, such as an event or treachery card, it is discarded. Otherwise, the card remains in its current game area."
-  },
-  {
-    "id": "Doom",
-    "title": "Doom",
-    "text": "Doom represents the progress the forces of the Mythos make towards completing foul rituals, summoning cosmic entities, and/or advancing a scenario's agenda.\n- During each Mythos phase, 1 doom is placed on the current agenda (see \"[I. Mythos phase](#Mythos_Phase)\").\n- If there are no \"<b>Objective</b> – \" requirements for advancing the current agenda and the requisite amount of doom is in play (among the agenda and all cards in play), the agenda advances during the \"Check doom threshold\" step of the Mythos phase. Unless a card otherwise specifies that it can advance the agenda, this is the only time at which the agenda can advance.\n- Doom on cards other than the agenda (such as enemies, allies, locations, etc.) counts towards the amount of doom in play.\nSee also: \"[Act Deck and Agenda Deck](#Act_Deck_and_Agenda_Deck)\", \"[Tokens, Running out of](#Tokens)\"."
-  },
-  {
-    "id": "Doubt_and_Conviction",
-    "title": "Doubt and Conviction",
-    "cycle": ["ptc"],
-    "text": "Some story resolutions and interludes in <i>The Path to Carcosa</i> campaign instruct the players to \"Mark one <b>Doubt</b>\" or \"Mark one <b>Conviction</b>\" in their Campaign Log. This is done by filling in one of the boxes next to \"<b>Doubt</b>\" or \"<b>Conviction</b> at the bottom of the Campaign Log.\nLater in the campaign, some scenarios may be changed or altered depending on whether the investigators \"have more <b>Doubt</b> than <b>Conviction</b>\" or \"have more <b>Conviction</b> than <b>Doubt</b>.\" The investigators have more <b>Doubt</b> than <b>Conviction</b> if the number of boxes filled in next to <b>Doubt</b> is greater than the number of boxes filled in next to <b>Conviction</b> (and vice versa). <b>Doubt</b> and <b>Conviction</b> are shared among all of the investigators, and they are not tied to any specific investigator. <b>Doubt</b> and <b>Conviction</b> have no game effect except when explicitly referenced by the Campaign Guide or by a card effect."
-  },
-  {
-    "id": "Draw_Action",
-    "title": "Ziehen (Aktion)",
-    "text": "„Ziehen“ ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. Sobald ein Ermittler diese Aktion nimmt, zieht er eine Karte von seinem Deck."
-  },
-  {
-    "id": "Drawing_Cards",
-    "title": "Karten ziehen",
-    "text": "Sobald ein Spieler angewiesen wird eine oder mehrere Karten zu ziehen, zieht er diese Karten oben von seinem Ermittlerdeck und fügt sie seiner Hand hinzu. \nSobald ein Spieler angewiesen wird eine oder mehrere Begegnungskarten zu ziehen, zieht er diese Karten oben vom Begegnungsdeck und handelt diese nach den Regeln für das Ziehen von Begegnungskarten im Rahmenereignisschritt \"[1.4 Jeder Ermittler zieht 1 Begegnungskarte](#Mythos_Phase)\".\n- Sobald ein Spieler zwei oder mehr Karten als Ergebnis einer einzigen Fähigkeit oder eines Spielschrittes zieht, werden diese Karten gleichzeitig gezogen. Falls ein Deck währenddessen leer wird, wird es zunächst neu gemischt und dann werden die restlichen Karten gezogen. \n- Es gibt kein Limit, wie viele Karten ein Spieler in jeder Runde ziehen darf. \n- Falls ein Ermittler mit einem leeren Ermittlerdeck eine Karte ziehen muss, mischt er seinen Ablagestapel zurück in sein Deck und zieht dann die Karte. Nachdem das Ziehen vollständig abgeschlossen ist, nimmt er 1 Horror."
-  },
-  {
-    "id": "Effects",
-    "title": "Effects",
-    "text": "A card effect is any effect that arises from the resolution of ability text printed on, or gained by, a card. A framework effect is any effect that arises from the resolution of a framework event (see \"[Framework Event Details](#Framework_Event_Details)\").\n- Card effects may be preceded by costs, triggering conditions, play restrictions, and/or play permissions; such elements are not considered effects (see \"[Ability](#Ability)\").\n- Once initiated, players must resolve as much of each aspect of the effect as they are able, unless the effect uses the word \"may.\"\n- When a non-targeting effect attempts to interact with a number of entities (such as \"draw 3 cards\" or \"search the top 5 cards of your deck\") that exceeds the number of entities that currently exist in the specified game area, the effect interacts with as many entities as possible.\n- The expiration of a lasting effect (or the cessation of a constant ability) is not considered to be generating a game state change by a card effect.\n- All aspects of an effect have timing priority over all \"after…\" triggering conditions that might arise as a consequence of that effect. <i>(For example, if an effect reads \"Gain 3 resources and draw 3 cards,\" resolve both aspects of the effect (gaining resources and drawing cards) before initiating an ability that reads \"After drawing a card…\")</i>\nSee also: \"[Delayed Effects](#Delayed_Effects)\", \"[Lasting Effects](#Lasting_Effects)\", \"[Priority of Simultaneous Resolution](#Priority_of_Simultaneous_Resolution)\"."
-  },
-  {
-    "id": "Elimination",
-    "title": "Elimination",
-    "text": "A player is eliminated from a scenario any time his or her investigator is defeated, or if he or she resigns. The only manner in which eliminated investigators interact with the game is when establishing \"per investigator\" values (see \"[Per Investigator](#Per_Investigator)\"). Any time a player is eliminated:\n1. For the purpose of resolving weakness cards, the game has ended for the eliminated investigator. Trigger any “when the game ends” abilities on each weakness the eliminated investigator owns that is in play. Then, remove those weaknesses from the game.\n2. The cards he or she controls in play and all of the cards in his or her out-of-play areas (such as hand, deck, discard pile) are removed from the game.\n- Any card that player owns but does not control that is in play remains in play, but if that card leaves play it is removed from the game.\n3. All clue tokens that player possesses are placed at the location the investigator was at when he or she was eliminated, and all of that player's resource tokens are returned to the token pool.\n4. All enemies engaged with that player are placed at the location the investigator was at when he or she was eliminated, unengaged but otherwise maintaining their current game state.\n5. All other cards in the eliminated investigator's threat area are placed in the appropriate discard pile.\n6. If the lead investigator is eliminated, the remaining players (if any) choose a new lead investigator.\n7. If there are no remaining players, the scenario ends. Refer to \"no resolution was reached\" entry for that scenario in the campaign guide."
-  },
-  {
-    "id": "Empty_Location",
-    "title": "Leerer Ort",
-    "text": "Ein leerer Ort ist ein Ort, an dem sich keine Gegner oder Ermittler befinden."
-  },
-  {
-    "id": "Encounter_Deck",
-    "title": "Begegnungsdeck",
-    "text": "Das Begegnungsdeck enthält die Begegnungskarten (Gegner-, Verratsund Storyvorteilskarten), auf welche die Ermittler in einem Szenario treffen können. \n- Falls das Begegnungsdeck leer ist, wird der Begegnungs-Ablagestapel zurück in das Begegnungsdeck gemischt."
-  },
-  {
-    "id": "Encounter_Set",
-    "title": "Begegnungsset",
-    "text": "Ein Begegnungsset ist eine Gruppe von Begegnungskarten, erkennbar an dem gemeinsamen Begegungssetsymbol neben dem Kartentyp."
-  },
-  {
-    "id": "Enemy_Cards",
-    "title": "Enemy Cards",
-    "text": "Enemies represent villains, cultists, ne'er-do-wells, terrible monsters, and unfathomable entities from alternate dimensions or the cosmos beyond. When an enemy card is drawn by an investigator, that investigator must spawn it following any spawn direction the card bears (see \"[Spawn](#Spawn)\"). If the encountered enemy has no spawn direction, the enemy spawns engaged with the investigator encountering the card and is placed in that investigator's threat area.\nSee \"[1.4 Each investigator draws 1 encounter card](#Mythos_Phase)\".\n- A ready, unengaged enemy engages any time it is at the same location as an investigator (see \"[Enemy Engagement](#Enemy_Engagement)\").\n- If an investigator is engaged with a ready enemy and takes an action other than to **fight**, to **evade**, or to activate a **parley** or **resign** ability, that enemy makes an attack of opportunity (see \"[Attack of Opportunity](#Attack_of_Opportunity)\").\n- Enemies with the hunter keyword move during the Enemy Phase (see \"[III. Enemy phase](#Enemy_Phase)\").\n- Engaged enemies attack during the Enemy Phase (see \"[III. Enemy phase](#Enemy_Phase)\")."
-  },
-  {
-    "id": "Enemy_Engagement",
-    "title": "Enemy Engagement",
-    "text": "While an enemy card is in play, it is either engaged with an investigator (and placed in that investigator's threat area), or it is unengaged and at a location (and placed at that location). Each enemy in an investigator's threat area is considered to be at the same location as that investigator, and should the investigator move, the enemy remains engaged and moves to the new location simultaneously with the investigator.\nAny time a ready unengaged enemy is at the same location as an investigator, it engages that investigator, and is placed in that investigator's threat area. If there are multiple investigators at the same location as a ready unengaged enemy, follow the enemy's prey instructions to determine which investigator is engaged. There is no limit on the number of enemies that can be engaged with a single investigator.\n<i>For example, a ready unengaged enemy immediately engages if:</i>\n- <i>It spawns at the same location as an investigator,</i>\n- <i>It moves into the same location as an investigator,</i>\n- <i>An investigator moves into the same location as it.</i>\nAn exhausted unengaged enemy does not engage, but if an exhausted enemy at the same location as an investigator becomes ready, it engages as soon as it is readied.\n- <i>Note: An enemy with the [Aloof](#Aloof) keyword does not engage in the manner described above.</i>See \"[Engage Action](#Engage_Action)\"."
-  },
-  {
-    "id": "Enemy_Phase_Placeholder",
-    "title": "Enemy Phase",
-    "text": "See \"[III. Enemy phase](#Enemy_Phase)\"."
-  },
-  {
-    "id": "Engage_Action",
-    "title": "Engage Action",
-    "text": "\"Engage\" is an action an investigator may take during his or her turn in the investigation phase.\nTo engage an enemy at the same location <i>(for example, this could be done to engage an exhausted enemy, an aloof enemy, or an enemy engaged with another investigator)</i>, an investigator places the chosen enemy in his or her threat area. The investigator and the enemy are now engaged.\n- An investigator may perform the engage action to engage an enemy that is engaged with a different investigator at the same location. The enemy simultaneously disengages from the previous investigator and engages the investigator performing the action.\n- An investigator cannot use the engage action to engage an enemy he or she is already engaged with.\nWhen an investigator engages an enemy, that enemy has also engaged that investigator, and vice-versa. There is no difference between engaging an enemy and being engaged by an enemy. Effects that trigger \"after an enemy engages you\" will trigger at the same time as effects that trigger \"after you engage an enemy.\""
-  },
-  {
-    "id": "Enters_Play",
-    "title": "Enters Play",
-    "text": "The phrase \"enters play\" refers to any time a card makes a transition from an out-of-play area into a play area (see \"[In Play and Out of Play](#In_Play_and_Out_of_Play)\").\n- If an ability (either on the card itself or from another card) causes a card to enter play in a state different from that specified by the rules, there is no transition to that state. It merely enters play in that state."
-  },
-  {
-    "id": "Evade",
-    "title": "Entkommen, Entkommen (Aktion)",
-    "text": "„Entkommen“ ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. \nUm einem Gegner zu entkommen, mit dem man in einen Kampf verwickelt ist, legt ein Ermittler eine Beweglichkeitsprobe gegen den Entkommenwert dieses Gegners ab (siehe \"[Fertigkeitsproben](#Skill_Tests)\").\nFalls die Probe gelingt, entkommt der Ermittler diesem Gegner (siehe unten). (Dies geschieht in Schritt 7 der Fertigkeitsprobe \"[FP.7 Ergebnis der Fertigkeitsprobe anwenden](#Skill_Test_Timing)\".)\nFalls die Probe misslingt, entkommt der Ermittler dem Gegner nicht und bleibt mit ihm in einen Kampf verwickelt. \n- Falls eine Fähigkeit „automatisch“ 1 oder mehreren Gegnern entkommt, wird für diesen Entkommen-Versuch keine Fertigkeitsprobe abgelegt. \n- Immer wenn ein Ermittler einem Gegner entkommt (ob durch eine Entkommen-Aktion oder durch eine Kartenfähigkeit), wird der Gegner erschöpft (falls er vorher spielbereit war) und der Ermittler löst sich aus dem Kampf. Der Gegner wird aus der Bedrohungszone des Ermittlers an den derzeitigen Ort des Ermittlers verschoben, um anzuzeigen, dass er nicht länger mit dem Ermittler in einen Kampf verwickelt ist. \n- Anders als bei den Aktionen „Kampf“ und „in einen Kampf verwickeln“ kann ein Ermittler eine Entkommen-Aktion nur gegen einen mit ihm in einen Kampf verwickelten Gegner durchführen."
-  },
-  {
-    "id": "Event_Cards",
-    "title": "Ereigniskarten",
-    "text": "Ereigniskarten stehen für taktische Aktionen, Manöver, Zaubersprüche, Tricks und andere spontane Effekte, die einem Spieler zur Verfügung stehen. \n- Falls eine Ereigniskarte nicht das Schlüsselwort Schnell hat, darf sie nur durch eine Spielen-Aktion während des Zuges eines Spielers von dessen Hand durchgeführt werden. Sämtliche Berechtigungen und Einschränkungen für das Spielen der Karte müssen dabei beachtet werden. \n- Eine Ereigniskarte mit Schnell darf jederzeit nach den Anweisungen zum Spielen der Karte von der Hand eines Spielers gespielt werden (siehe \"[Schnell](#Fast)\").\n- Immer wenn ein Spieler eine Ereigniskarte spielt, werden ihre Kosten bezahlt, ihre Effekte abgehandelt (oder aufgehoben) und die Karte wird auf den Ablagestapel des Besitzers gelegt, nachdem diese Effekte abgehandelt (oder aufgehoben) worden sind. \n- Falls die Effekte einer Ereigniskarte aufgehoben werden, gilt die Karte immer noch als gespielt und ihre Kosten als bezahlt. Nur die Effekte werden aufgehoben. \n- Das Spielen (oder Nichtspielen) einer Ereigniskarte von der Hand ist für einen Spieler immer optional, falls das Ereignis in den Spielanweisungen nicht das Wort „muss“ verwendet. \n- Eine Ereigniskarte kann nicht gespielt werden, falls ihre Abhandlung keine Möglichkeit hat, den Spielstatus zu verändern."
-  },
-  {
-    "id": "Exceptional",
-    "title": "Außergewöhnlich",
-    "text": "Außergewöhnlich ist eine Schlüsselwortfähigkeit für den Deckbau. \n- Um eine Karte mit dem Schlüsselwort Außergewöhnlich zu kaufen, muss man das Doppelte ihrer aufgedruckten Erfahrungspunkte bezahlen. \n- Ein Ermittlerdeck eines Spielers kann nicht mehr als 1 Kopie (nach Name) einer Karte mit Außergewöhnlich enthalten."
-  },
-  {
-    "id": "Exhaust",
-    "title": "Erschöpfen, erschöpft",
-    "text": "Gelegentlich bewirkt eine Kartenfähigkeit oder ein Spielschritt, dass eine Karte erschöpft wird, um anzuzeigen, dass sie verwendet worden ist, um eine Funktion durchzuführen. Sobald eine Karte erschöpft wird, wird sie um 90° gedreht. Eine Karte in diesem Zustand nennt man erschöpft. \n- Eine erschöpfte Karte kann nicht erneut erschöpft werden, bis sie wieder spielbereit ist (normalerweise durch einen Spielschritt oder eine Kartenfähigkeit).."
-  },
-  {
-    "id": "Exile",
-    "title": "Exile",
-    "text": "Some player cards must be exiled when they are used. When a card is exiled, it is removed from the game and returned to your collection. During campaign play, a card that has been exiled must be purchased again with experience points (between scenarios) if you wish to re-include it in your deck. If exiling 1 or more cards would reduce your deck below your investigator's deck size, when purchasing cards between scenarios, you must purchase cards so that a legal deck size is maintained (when purchasing cards in this manner, you may purchase level 0 cards for 0 experience cost until a legal deck size is reached)."
-  },
-  {
-    "id": "Experience_Placeholder",
-    "title": "Erfahrungspunkte",
-    "text": "See \"[Kampagnenspiel](#Experience)\"."
-  },
-  {
-    "id": "Explore",
-    "cycle": ["tfa"],
-    "title": "Explore",
-    "text": "Some abilities in this campaign (and others) are identified with an \"Explore\" action designator. Such abilities are generally used to find new locations to put into play, and are initiated using the \"activate\" action.\n\"Explore\" abilities instruct you to draw the top card of the \"exploration deck,\" which is a separate deck that is constructed during the setup of some scenarios. This deck consists of several single-sided locations and treachery cards.\n- Each \"Explore\" ability indicates a particular type of location that you are seeking to draw. <b>If a location of that type is drawn, it is put into play, and you move to that location.</b> This is considered a \"successful\" exploration.\n- If any other location is drawn, place it next to the exploration deck, and draw the next card from the exploration deck. Repeat this process until a location of the indicated type is drawn, or a treachery is drawn. After this action has ended, shuffle each location next to the exploration deck back into the exploration deck.\n- If a treachery card is drawn, it is resolved as normal. If it is discarded, place it in the encounter discard pile as you would normally. There is no discard pile for the exploration deck. This is considered an \"unsuccessful\" exploration.\n- As a single-sided location is put into play from the exploration deck, place clues on that location equal to its clue value.\n<i>Example: Agenda 1a — “Expedition into the Wild” has the following ability: “[action]: <b>Explore.</b> Draw the top card of the exploration deck. If it is a connecting location, put it into play and move to it.” Ursula Downs is at the Expedition Camp and wishes to find a new location to travel to. She spends her first action to explore, drawing the top card of the exploration deck. The card she draws is Circuitous Trail. Because Circuitous Trail is a location that is not connected to the Expedition Camp, it is placed next to the exploration deck, and Ursula draws the next card in the exploration deck. This time, she draws the Low on Supplies treachery card, which she resolves as normal and places in the encounter discard pile. Her exploration is unsuccessful, and she must shuffle the Circuitous Trail that she drew previously back into the exploration deck. Ursula decides to explore one more time, spending a second action. This time, she draws Path of Thorns, which is connected to the Expedition Camp. Her exploration is successful. Path of Thorns is put into play with clues on it equal to its clue value, and Ursula immediately moves from the Expedition Camp to the Path of Thorns.</i>"
-  },
-  {
-    "id": "Fast",
-    "title": "Fast",
-    "text": "Fast is a keyword ability. A fast card does not cost an action to be played and is not played using the \"Play\" action.\n- A fast event card may be played from a player's hand any time its play instructions specify. If the instructions specify when/after a timing point, the card may be played as if the described timing point were a triggering condition for playing the card. If the instructions specify a duration or period of time, the card may be played during any player window within that period. If the instructions specify both a when/after timing point and a duration or period of time, the card may be played in reference to any instance of the specified triggering condition within that time period.\n- A fast asset may be played by an investigator during any player window on his or her turn.\n- Because fast cards do not cost actions to play, they do not provoke attacks of opportunity (see \"[Attack of Opportunity](#Attack_of_Opportunity)\")."
-  },
-  {
-    "id": "Fight_Action",
-    "title": "Fight Action",
-    "text": "\"Fight\" is an action an investigator may take during his or her turn in the investigation phase.\nTo fight an enemy at his or her location, an investigator resolves an attack against that enemy by making a combat test against the enemy's fight value (see \"[Skill Tests](#Skill_Tests)\").\nIf the test is successful, the attack succeeds and damage is dealt to the attacked enemy. The default damage dealt by an attack is 1. Some weapons, spells, or other special attacks may modify this damage. (This occurs during step 7 of the skill test, per \"[ST.7 Apply skill test results](#Skill_Test_Timing)\".)\nIf the test fails, no damage is dealt to the attacked enemy. However, if an investigator fails this test against an enemy that is engaged with another single investigator, the damage of the attack is dealt to the investigator engaged with that enemy.\n- An investigator may fight any enemy at his or her location, including: an enemy he or she is engaged with, an unengaged enemy at the same location, or an enemy engaged with another investigator who is at the same location."
-  },
-  {
-    "id": "Flavor_Text",
-    "title": "Stimmungstext",
-    "text": "Stimmungstext ist zusätzlicher Text auf einer Karte, der thematischen Kontext zu der Karte und/oder ihrer Fähigkeit bietet. Stimmungstext interagiert in keiner Weise mit dem Spiel."
-  },
-  {
-    "id": "Forced_Abilities",
-    "title": "Forced Abilities",
-    "text": "See \"[Ability](#Abilities_Forced)\"."
-  },
-  {
-    "id": "Gains",
-    "title": "Gains",
-    "text": "The word \"gains\" is used in multiple contexts.\n- If a player gains one or more resources, the player takes the specified number of resources from the token pool and adds them to his or her resource pool.\n- If an investigator gains an action, that investigator is permitted one additional action to spend during the specified time period.\n- If a card gains a characteristic (such as an icon, a trait, a keyword, or ability text), the card functions as if it possesses the gained characteristic.\n- \"Gained\" characteristics are not considered to be \"printed\" on the card. If an ability refers to the printed characteristics of a card, it does not refer to gained characteristics."
-  },
-  {
-    "id": "Game",
-    "title": "Spiel",
-    "text": "Ein „Spiel“ besteht aus einem einzelnen Szenario, nicht aus einer gesamten Kampagne. In einer Kampagne bedeutet der Beginn eines neuen Szenarios auch den Beginn eines neuen Spiels."
-  },
-  {
-    "id": "Hand_Size",
-    "title": "Handkartenlimit",
-    "text": "See \"[IV. Unterhaltsphase](#Upkeep_Phase)\"."
-  },
-  {
-    "id": "Heal",
-    "title": "Heilen",
-    "text": "„Heilen“ ist eine Anweisung, die eine angegebene Menge Schaden oder eine angegebene Menge Horror von einer Karte entfernt. \n- Falls eine Karte um mehr Schaden oder Horror geheilt wird, als sie aktuell auf sich hat, wird so viel von der angegebenen Menge wie möglich entfernt."
-  },
-  {
-    "id": "Haunted",
-    "title": "Haunted",
-    "cycle": ["tcu"],
-    "text": "Haunted is a new ability that appears on some locations. Each time an investigator fails a skill test while investigating a location, after applying all results for that skill test, that investigator must resolve all \"<b>Haunted</b> –\" abilities on that location.\nA location is \"haunted\" for the purposes of other card effects if it has at least one \"<b>Haunted</b> –\" ability (printed or otherwise)."
-  },
-  {
-    "id": "Health_and_Damage",
-    "title": "Health and Damage",
-    "text": "Health represents a card's physical fortitude. Damage tracks the physical harm that has been done to a card during a scenario.\n- Any time a card takes damage, place a number of damage tokens equal to the amount of damage just taken on the card (see \"[Dealing Damage/Horror](#Dealing_Damage_Horror)\").\n- If an investigator has damage on him or her equal to or greater than his or her health, that investigator is defeated. When an investigator is defeated, he or she is eliminated from the scenario (see \"[Elimination](#Elimination)\").\n- In campaign play, an investigator that is defeated by taking damage equal to his or her health suffers 1 physical trauma. Taking physical trauma may cause an investigator to be **killed** (see \"[Campaign Play](#Campaign_Play)\" for more information).\n- If an enemy has damage on it equal to or greater than its health, that enemy is defeated and placed in the encounter discard pile.\n- If an asset with a health value has damage on it equal to or greater than its health, it is defeated and placed on its owner's discard pile.\n- An asset card without a health value is not considered to have a health of 0, cannot gain health, and cannot have damage assigned to it.\n- A card's \"remaining health\" is its base health minus the amount of damage on it, plus or minus any active health modifiers.\nSee also: \"[Direct Damage, Direct Horror](#Direct_Damage_Direct_Horror)\"."
-  },
-  {
-    "id": "Hidden",
-    "cycle": ["tcu", "tde"],
-    "title": "Hidden",
-    "text": "An encounter card or weakness with the hidden keyword has a revelation ability that secretly adds that card to your hand. This should be done without revealing that card or its text to the other investigators.\n- While a hidden treachery is in your hand, treat it as if it were in your threat area. Its constant abilities are active, and abilities on it can be triggered, but only by you.\n- While a hidden enemy is in your hand, it is not considered to be engaged with you or in your threat area, and it does not attack unless otherwise specified. However, its constant abilities are active, and abilities on it can be triggered, but only by you.\n- A hidden card counts toward your hand size, but it cannot be discarded from your hand by any means except those described on the card. When discarded, a hidden card is placed in its appropriate discard pile.\nFor the best experience, players are encouraged to stay \"in character\" and not share information about hidden cards in their hand."
-  },
-  {
-    "id": "Hunter",
-    "title": "Hunter",
-    "text": "Hunter is a keyword ability.\nDuring the enemy phase (in [framework step 3.2](#Enemy_Phase)), each ready, unengaged enemy with the hunter keyword moves to a connecting location, along the shortest path towards the nearest investigator. Enemies at a location with one or more investigators do not move.\n- If there are multiple equidistant investigators who qualify as \"the nearest investigator,\" the enemy moves towards the one of those who best meets its prey instructions. If none do, or if the enemy has no prey instructions, the lead investigator may choose an investigator for the enemy to move towards.\n- If a hunter enemy would be compelled to a location to which the move is blocked by a card ability, the enemy does not move.\nSee also: \"[Prey](#Prey)\"."
-  },
-  {
-    "id": "If",
-    "title": "If",
-    "text": "Some abilities have triggering conditions that use the words \"at\" or \"if\" instead of specifying \"when\" or \"after,\" such as \"at the end of the round,\" or \"if the Ghoul Priest is defeated.\" These abilities trigger in between any \"when…\" abilities and any \"after…\" abilities with the same triggering condition.\nSee also: \"[At](#At)\"."
-  },
-  {
-    "id": "Immune",
-    "title": "Immun",
-    "text": "Falls eine Karte immun gegen bestimmte Effekt-Arten ist (<i>zum Beispiel „Immun gegen Verratskarteneffekte“ oder „Immun gegen Spielerkarteneffekte“</i>), kann sie nicht für Effekte dieser Art gewählt oder von ihnen betroffen werden. Nur die Karte selbst ist geschützt; Spielelemente, die in direktem Zusammenhang mit der immunen Karte stehen (wie angehängte Vorteilskarten, Marker auf der Karte oder Fähigkeiten, deren Quelle die immune Karte ist), sind selbst nicht immun. \n- Falls eine Karte eine Immunität gegen einen Effekt erhält, werden bestehende andauernde Effekte, die bereits vorher auf die Karte angewendet worden sind, nicht entfernt. Falls eine Karte eine Immunität gegen einen Effekt verliert, werden bestehende andauernde Effekte dieser Art nicht auf die Karte angewendet. \n- Immunität beschützt eine Karte nur vor Effekten. Sie beschützt eine Karte nicht vor Kosten."
-  },
-  {
-    "id": "In_Play_and_Out_of_Play",
-    "title": "In Play and Out of Play",
-    "text": "The cards that a player controls in his or her play area are considered in play.\nThe current act, the current agenda, each location in the play area, and each encounter card in a investigator's threat area or at a location, are all considered in play.\nOut of play refers to the cards in a player's hand, in any deck, in any discard pile, in the victory display, and those that have been set aside and/or removed from the game.\n- A card enters play when it transitions from an out-of-play origin to an in play area.\n- A card leaves play when it transitions from a in play area to an out-of-play destination.\n- Tokens on in play cards are considered in play. Resources in each investigator's resource pool are also considered in play."
-  },
-  {
-    "id": "In_Player_Order",
-    "title": "In Spielerreihenfolge",
-    "text": "Falls die Spieler angewiesen werden eine Reihe von Handlungen „in Spielerreihenfolge“ durchzuführen, führt der Ermittlungsleiter seinen Teil der Handlungen zuerst durch und die anderen Spieler sind im Uhrzeigersinn danach an der Reihe. Der Begriff „der nächste Spieler“ bezieht sich in diesem Zusammenhang auf den nächsten Spieler, der (im Uhrzeigersinn) in Spielerreihenfolge handelt."
-  },
-  {
-    "id": "Instead",
-    "title": "Instead",
-    "text": "The word \"instead\" is indicative of a replacement effect. A replacement effect is an effect that replaces the resolution of a triggering condition with an alternate means of resolution.\n- If multiple replacement effects are initiated against the same triggering condition and create a conflict in how to resolve the triggering condition, the most recent replacement effect is the one that is used for the resolution of the triggering condition.\n- The word \"would\" is used to define the triggering condition of some abilities, and establishes a higher priority for those abilities than abilities referencing the same triggering condition without the word \"would.\" (For instance, \"When X would occur\" resolves before \"When X occurs.\")\n- If a replacement effect that uses the word \"would\" changes the nature of a triggering condition, the original triggering condition is replaced with the new triggering condition. No further abilities referencing the original triggering condition may be used."
-  },
-  {
-    "id": "Investigate_Action",
-    "title": "Investigate Action",
-    "text": "\"Investigate\" is an action an investigator may take during his or her turn in the investigation phase.\nEach time an investigator takes this action, he or she makes an intellect test against the shroud value of that location (see \"[Skill Tests](#Skill_Tests)\").\nIf the test is successful, the investigator has succeeded in investigating the location, he or she discovers one clue at the location. (This occurs during step 7 of the skill test, per \"[ST.7 Apply skill test results](#Skill_Test_Timing)\".)\nAny time an investigator discovers a clue from a location, that player takes the clue from the location and places it on his or her investigator card, under his or her control.\nIf the test is failed, the investigator has failed in investigating the location. No clues are discovered during step 7 of the skill test."
-  },
-  {
-    "id": "Investigation_Phase_Placeholder",
-    "title": "Investigation Phase",
-    "text": "See \"[II. Investigation phase](#Investigation_Phase)\"."
-  },
-  {
-    "id": "Investigator_Deck",
-    "title": "Investigator Deck",
-    "text": "A player's \"investigator deck\" is the deck that contains that player's asset, event, skill, and weakness cards. A reference to \"your deck\" refers to the investigator deck under your control."
-  },
-  {
-    "id": "Joes_Hunch_Deck",
-    "title": "Joe's \"Hunch Deck\"",
-    "cycle": ["tcu"],
-    "text": "As a private eye, Joe Diamond has learned to follow his instincts, and therefore he has a separate hunch deck, which is constructed during step 4 of the setup of each scenario. The cards in this hunch deck are chosen from Joe's 40-card deck and therefore count toward his total deck size. With the exception of these setup instructions, all references to Joe's \"deck\" refer to Joe's standard investigator deck and not his hunch deck. Joe's hunch deck has no discard pile; cards from your hunch deck are discarded to your standard discard pile when played."
-  },
-  {
-    "id": "Keywords",
-    "title": "Keywords",
-    "text": "A keyword is a card ability which conveys specific rules to its card. Each keyword has its own rules which can be found in the keyword's own section of the glossary. The keywords in this game are: [aloof](#Aloof), [fast](#Fast), [hunter](#Hunter), [massive](#Massive), [peril](#Peril), [retaliate](#Retaliate), [surge](#Surge), [uses](#Uses).\n- There are also two deckbuilding keywords: [exceptional](#Exceptional) and [permanent](#Permanent). Deckbuilding keywords affect deck customization while building and/or leveling up a deck. They have no effect during gameplay. There are no exceptional or permanent cards in the core set – each of these keywords will be presented in future expansions.\n- A single card that has and/or is gaining the same keyword from multiple sources functions as if it has one instance of that keyword.\n- The initiation of any keyword which uses the word \"may\" in its keyword description is optional. The application of all other keywords is mandatory.\nSee \"[Ability](#Ability)\"."
-  },
-  {
-    "id": "Killed_Insane_Investigators",
-    "title": "Killed/Insane Investigators",
-    "text": "During campaign play, investigators who are killed or driven insane must be recorded in your campaign log and cannot be used for the remainder of the campaign.\n- An investigator with physical trauma equal to or higher than his or her printed health is killed.\n- An investigator with mental trauma equal to or higher than his or her printed sanity is driven insane.\n- An investigator may also be killed or driven insane by card ability, or during a scenario's resolution.\n- When playing a standalone scenario, there is no practical difference between being killed, driven insane, or defeated.\nSee \"[Campaign Play](#Campaign_Play)\"."
-  },
-  {
-    "id": "Lasting_Effects",
-    "title": "Lasting Effects",
-    "text": "Some card abilities create conditions that affect the game state for a specified duration *(for example, \"until the end of the phase\" or \" for this skill test\")*. Such effects are known as lasting effects.\n- A lasting effect persists beyond the resolution of the ability that created it, for the duration specified by the effect. The effect continues to affect the game state for the specified duration regardless of whether the card that created the lasting effect is or remains in play.\n- If a lasting effect affects in-play cards (or cards in a specified area), it is only applied to cards that are in play (or the specified area) when the lasting effect is established. Cards that enter play (or the specified area) after its establishment are not affected by the lasting effect.\n- A lasting effect expires as soon as the timing point specified by its duration is reached. This means that an \"until the end of the phase\" lasting effect expires before an \"at the end of the phase\" ability or delayed effect may initiate.\n- A lasting effect that expires at the end of a specific time period can only be initiated during that time period."
-  },
-  {
-    "id": "Lead_Investigator",
-    "title": "Lead Investigator",
-    "text": "The lead investigator is sometimes required to make important scenario decisions. At the beginning of a scenario, the investigators choose a lead investigator. If they cannot agree on a choice, a lead investigator is chosen at random.\n- If there are ever multiple valid options for a choice or decision that must be made *(for example, a hunter enemy that could move in two different directions)*, the lead investigator is the final arbiter in choosing among those options.\n- If the lead investigator is eliminated, the remaining players (if any) choose a new lead investigator."
-  },
-  {
-    "id": "Leaves_Play",
-    "title": "Leaves Play",
-    "text": "The phrase \"leaves play\" refers to any time a card makes a transition from an in-play state to an out-of-play state (see \"[In Play and Out of Play](#In_Play_and_Out_of_Play)\").\nIf a card leaves play, the following consequences occur simultaneously with the card leaving play:\n- All tokens on the card are returned to the token pool.\n- All attachments on the card are discarded.\n- All lasting effects and/or delayed effects affecting the card while it was in play expire for that card."
-  },
-  {
-    "id": "Limits_and_Maximums",
-    "title": "Limits and Maximums",
-    "text": "<b>\"Limit X per [period]\"</b> is a limit that appears on cards that remain in play through the resolution of an ability's effect. Each instance of an ability with such a limit may be initiated X times during the designated period. If a card leaves play and re-enters play during the same period, the card is considered to be bringing a new instance of the ability to the game.\n<b>\"Limit X per (card/game element)\"</b> is a limit that appears on attachment cards, and restricts the number of copies of that card (by title) that can be attached to each designated card or game element.\n- Unless stated otherwise, limits are player specific.\n- A \"group limit,\" however, applies to the entire group of investigators. <i>(For example, if an investigator triggers an ability that is \"group limit once per game,\" no other investigator may trigger that ability during that game.)</i>\n<b>\"Max X per [period]\"</b> imposes a maximum across all copies of a card (by title) for all players. Generally, this phrase imposes a maximum number of times that copies of that card can be played during the designated time period. If a maximum includes the word \"committed\" <i>(For example, \"Max 1 committed per skill test\")</i>, it imposes a maximum number of copies of that card that can be committed to skill tests during the designated period. If a maximum appears as part of an ability, it imposes a maximum number of times that ability can be initiated from all copies (by title) of cards bearing that ability (including itself), during the designated period.\nIf the effects of a card or ability with a limit or maximum are canceled, it is still counted against the limit/maximum, because the ability has been initiated.",
-    "rules": [
-      {
-        "id": "Limits_Pertaining_to_Play_Areas",
-        "title": "Limits Pertaining to Play Areas",
-        "text": "Some limits may pertain to a particular play area, such as \"Limit 1 per deck,\" \"Limit 1 in the victory display,\" or \"Limit 1 in play.\" This limit restricts the number of copies of that card (by title) that can exist in the specified play area. Another copy of that card cannot enter the specified play area if this limit has already been reached. Remember that limits are player specific unless otherwise noted. For example, a card with \"Limit 1 per deck\" can exist in two different investigator decks.\n<i>Note: \"Limit X per investigator\" is a limit that pertains to an investigator’s play area.</i>"
-      }
-    ]
-  },
-  {
-    "id": "Location_Cards",
-    "title": "Location Cards",
-    "text": "Location cards represent the places the investigators may explore during a scenario.\n- Use each investigator's mini-card to indicate which location he or she is at.\n- While an investigator is at a location, that investigator, each of his or her assets, and each card in that investigator's threat area is at the same location.\n- Locations enter play in an \"unrevealed\" state, so that the side with no shroud value and/or clue value is faceup. Do not read the \"revealed\" side at this time.\n- The first time a location is entered by an investigator, that location is revealed by turning it to its other side and placing a number of clues on it equal to its clue value (this may occur during setup). Most clue values are conveyed as a \"per investigator\" ([per_investigator]) value.\n- A location with its shroud/clue value side faceup is in the \"revealed\" state."
-  },
-  {
-    "id": "Lola_and_Roles",
-    "cycle": ["ptc"],
-    "title": "Lola and \"Roles\"",
-    "text": "As a renowned actress, Lola Hayes can play many different roles. At the beginning of each scenario, after investigators draw opening hands, Lola Hayes must choose a role (Neutral, Guardian, Seeker, Rogue, Mystic, or Survivor). Lola can only play cards, commit cards to skill tests, or trigger [action], [fast], or [reaction] abilities on Neutral cards or cards whose class matches her role. This restriction only applies to player cards, not to encounter cards or weaknesses. Note that Constant and <b>Forced</b> abilities remain active on cards whose class does not match Lola's role."
-  },
-  {
-    "id": "Massive",
-    "title": "Massive",
-    "text": "Massive is a keyword ability. A ready enemy with the massive keyword is considered to be engaged with each investigator at the same location as it.\n- An exhausted enemy with the massive keyword is not considered to be engaged with any investigators.\n- An enemy with the massive keyword cannot be placed in an investigator's threat area.\n- When an enemy with the massive keyword attacks during the enemy phase, resolve its (full) attack against each investigator it is engaged with, one investigator at a time. The lead investigator chooses the order in which these attacks resolve. The massive enemy does not exhaust until its final attack of the phase resolves.\n- When an enemy with the massive keyword makes an attack of opportunity, that attack only resolves against the investigator who provoked the attack.\n- A massive enemy does not move with an engaged investigator who moves away from the massive enemy's location.\n- If an investigator fails a combat test against a massive enemy, no damage is dealt to the engaged investigators."
-  },
-  {
-    "id": "May",
-    "title": "May",
-    "text": "The word \"may\" indicates that a specified player has the option to do that which follows. If no player is specified, the option is granted to the controller of the card with the ability in question."
-  },
-  {
-    "id": "Modifiers",
-    "title": "Modifiers",
-    "text": "Some abilities cause values or quantities of characteristics to be modified. The game state constantly checks and (if necessary) updates the count of any variable value or quantity that is being modified.\nAny time a new modifier is applied (or removed), the entire quantity is recalculated from the start, considering the unmodified base value and all active modifiers.\n- When calculating a value, treat all modifiers as being applied simultaneously. However, while performing the calculation, all additive and subtractive modifiers are calculated before doubling and/or halving modifiers.\n- Fractional values are rounded up after all modifiers have been applied.\n- A quantity on a card (such as a stat, an icon, a number of instances of a trait or keyword) cannot be reduced so that it functions with a value below zero. Negative modifiers in excess of a value's current quantity can be applied, but, after all active modifiers have been applied, any resultant value below zero is treated as zero. <i>(For example: Danny tests agility and reveals a –8 chaos token. When applied to his agility of 4, this would reduce his skill value to –4. However, his agility cannot be reduced so that it functions with a value below zero. While the –8 modifier still exists, his agility is treated as zero. If Danny were to play \"Lucky!\" to receive a +2 bonus to the test, this bonus would not be applied to the functioning skill value of zero; but rather, it is applied in conjunction with all active modifiers. Danny's agility would then be calculated as follows: base skill 4, –8 from chaos token, +2 from \"Lucky!\" for a total of –2, which is still treated as zero.)</i>"
-  },
-  {
-    "id": "Move",
-    "title": "Move",
-    "text": "Any time an entity (an investigator or enemy) moves, transfer that enemy card or investigator's mini card from its current location to a different location.\n- Unless otherwise specified by the move effect or ability, the moving entity must move to a connecting location. Connecting locations are identified on the location card representing the entity's current location, as shown below.\n- Any time an entity moves, it is considered to leave the previous location, and to enter the new location, simultaneously.\n- If an entity is \"moved to…\" a specific location, the entity is moved directly to that location, and does not pass through other locations en route.\n- If an investigator moves to an unrevealed location, that location is revealed by turning it to its other side, and placing a number of clues on it equal to its clue value. Most clue values are conveyed as a \"per investigator\" ([per_investigator]) value.\n- If an enemy moves to an unrevealed location, that location remains unrevealed.\n- Game elements (tokens or cards) may also be moved by card abilities from one card to another, or from one game area to another game area.\n- When an entity or game element moves, it cannot move to its same (current) placement. If there is no valid destination for a move, the move cannot be attempted."
-  },
-  {
-    "id": "Move_Action",
-    "title": "Move Action",
-    "text": "\"Move\" is an action an investigator may take during his or her turn in the investigation phase.\nWhen an investigator takes this action, move that investigator (using his or her mini card) to any other location that is marked as a connecting location on his or her current location (see \"[Move](#Move)\")."
-  },
-  {
-    "id": "Mulligan",
-    "title": "Mulligan",
-    "text": "After a player draws a starting hand during setup, that player has a single opportunity to declare a mulligan on any number of the drawn cards he or she does not wish to keep in his or her starting hand. These cards are set aside, and an equivalent number of cards are drawn and added to the player's starting hand. The set-aside cards are then shuffled back into the player's deck.\n- Players take or forgo the opportunity to mulligan in player order."
-  },
-  {
-    "id": "Multiclass_Cards",
-    "title": "Multi-class Cards",
-    "text": "A multi-class card is a card which bears multiple class icons instead of one, and is a card of each of those classes. For example, a card with both a Rogue ([rogue]) and a Guardian ([guardian]) icon is both a Rogue card and a Guardian card for all purposes. Generally, a multi-class card can be included in an investigator’s deck if that investigator has access to <i>either</i> of that card’s classes.\nIf an investigator has limited access to one of the classes on a multiclass card and unlimited access to one of the other classes on that card, it will still occupy one of the investigator’s limited slots unless their deckbuilding options contains the word \"other\" in it <i>(see [Deckbuilding Options](#Deckbuilding_Options))</i>.\nThe following section clarifies how multi-class cards operate depending on how an investigator’s deckbuilding options are presented.\n- <b>Investigators with unlimited access to more than one class <i>(i.e. All Core Set investigators, Minh Thi Phan, Sefina Rousseau, William Yorick, Leo Anderson, Joe Diamond, Preston Fairmont, Diana Stanley)</i>:</b> A multi-class card can be included in that investigator’s deck if it falls into <i>either</i> of the listed classes.\n- <b>Investigators from The Dunwich Legacy expansion</b> <i>(i.e. Zoey Samaras, Rex Murphy, Jenny Barnes, Jim Culver, \"Ashcan\" Pete)</i>: A multi-class card will not occupy one of these investigator’s five \"out of class\" slots if one of its classes is the class they have unlimited access to. A card cannot take up more than one \"out of class\" slot, regardless of how many class icons the card bears.\n- <b>Investigators with unlimited access to one class and limited access to one or more \"other\" classes</b> <i>(i.e. Marie Lambeau, Finn Edwards, Carolyn Fern)</i>: A multi-class card will not occupy one of the investigator’s limited slots, because it falls into the unlimited category <i>(see [Deckbuilding Options](#Deckbuilding_Options))</i>.\n- <b>Investigators with unlimited access to one class and limited access to a second class, without using the word \"other\"</b> <i>(i.e. Norman Withers)</i>: A multi-class card will occupy one of the investigator’s limited slots, even if it also falls into the unlimited category.\n- <b>Lola Hayes:</b> A multi-class card will count as a card of each of its classes toward her Deckbuilding Requirement."
-  },
-  {
-    "id": "Must",
-    "title": "Müssen",
-    "text": "Falls ein Ermittler angewiesen wird, dass er zwischen mehreren Optionen wählen „muss“, ist er verpflichtet eine Option zu wählen, welche die Möglichkeit hat, den Spielstatus zu verändern. \n- Falls eine Form des Wortes „müssen“ fehlt, sobald eine Auswahl zwischen mehreren Möglichkeiten getroffen wird, kann man bei der Abhandlung dieses Effektes jede Möglichkeit wählen – selbst eine Möglichkeit, die den Spielstatus nicht ändert."
-  },
-  {
-    "id": "Myriad",
-    "cycle": ["tde"],
-    "title": "Myriad",
-    "text": "An investigator may include up to three copies of a player card with the myriad keyword in their deck (by title), instead of the normal limit of two copies. Additionally, when you purchase a myriad card for your deck, you may purchase up to two additional copies of that card (at the same level) at no experience cost.\nWhen counting the total amount of experience in your deck, each copy of a Myriad card after the first copy does not count towards your experience total."
-  },
-  {
-    "id": "Mythos_Phase_Placeholder",
-    "title": "Mythos Phase",
-    "text": "See \"[I. Mythos phase](#Mythos_Phase)\"."
-  },
-  {
-    "id": "Nearest",
-    "title": "Nächstgelegen",
-    "text": "Einige Karten beziehen sich auf die „nächstgelegene“ Entität. Nächstgelegen bezieht sich auf die Entität der angegebenen Art an dem Ort, der mit den wenigsten Verbindungen erreicht werden kann, selbst wenn eine oder mehrere dieser Verbindungen durch eine andere Kartenfähigkeit blockiert sind. Der Weg zur nächstgelegenen Entität ist der „kürzeste“ Weg zu dieser Entität."
-  },
-  {
-    "id": "Nested_Sequences",
-    "title": "Nested Sequences",
-    "text": "Each time a triggering condition occurs, the following sequence is followed: 1) execute “when…” effects that interrupt that triggering condition, 2) resolve the triggering condition, and then, 3) execute “after…” effects in response to that triggering condition.\nWithin this sequence, if the use of a [reaction] or <b>Forced</b> ability leads to a new triggering condition, the game pauses and starts a new sequence: (1) execute “when…” effects that interrupt the new triggering condition, (2) resolve the new triggering condition, and then, (3) execute “after…” effects in response to the new triggering condition. This is called a <b>nested sequence</b>. Once this nested sequence is completed, the game returns to where it left off, continuing with the original triggering condition’s sequence.\nIt is possible that a nested sequence generates further triggering conditions (and hence more nested sequences). There is no limit to the number of nested sequences that may occur, but each nested sequence must complete before returning to the sequence that spawned it. In effect, these sequences are resolved in a Last In, First Out (LIFO) manner.\n<i>For example: Roland and Agnes are embroiled in a fierce battle. Roland has a Guard Dog in his play area, and is engaged with a Goat Spawn with 2 damage on it. Agnes is engaged with a Ghoul Minion. Roland wishes to play a .45 Automatic, which provokes an attack of opportunity from the Goat Spawn, dealing 1 damage to Roland. Roland assigns this damage to his Guard Dog, which has a [reaction] ability: “When an enemy attack deals damage to Guard Dog: Deal 1 damage to the attacking enemy.” Before resolving the playing of Roland’s .45 Automatic, Guard Dog’s ability resolves, and 1 damage is dealt to the Goat Spawn, which would defeat it. Goat Spawn has the following <b>Forced</b> ability: “When Goat Spawn is defeated: Each investigator at this location takes 1 horror.” Before resolving the damage dealt to the Guard Dog, 1 horror is dealt to each investigator at the location, including Agnes, who has a [reaction] ability: “After 1 or more horror is placed on Agnes Baker: Deal 1 damage to an enemy at your location.” Before resolving the Goat Spawn’s defeat, Agnes deals 1 damage to the Ghoul Minion engaged with her. Now that there are no further [reaction] or <b>Forced</b> abilities to trigger, the players return to the previous triggering condition and resolve the Goat Spawn’s defeat, and resolve any “After…” effects that might occur when it is defeated. Then, the players resolve the damage dealt to the Guard Dog, and resolve any “After…” effects that might occur from that damage. Finally, the players return to the original triggering condition, and Roland is able to put his .45 Automatic into play.</i>"
-  },
-  {
-    "id": "Nested_Skill_Tests",
-    "title": "Nested Skill Tests",
-    "text": "A skill test cannot initiate during another skill test. If during the resolution of a skill test another skill test would initiate, instead the second skill test does not initiate until the first skill test has finished resolving. If the first skill test was part of an action, the second skill test does not initiate until that action has finished resolving.\n<i>For example: Ursula performing an investigate action. As part of this investigate action, she must perform an [intellect] test. During the resolution of that skill test, she plays Expose Weakness, a fast event which initiates another [intellect] test. Instead of resolving the second [intellect] test during the first one, the initiation of the second [intellect] test is delayed until after the first skill test (and therefore the investigate action) has finished resolving.</i>"
-  },
-  {
-    "id": "Ownership_and_Control",
-    "title": "Ownership and Control",
-    "text": "A card's owner is the player whose deck (or game area) held the card at the start of the game.\nA player controls the cards located in his or her out-of-play game areas (such as the hand, deck, discard pile).\nThe scenario controls the cards in its out-of-play game areas (such as the encounter, act, and agenda decks, and the encounter discard pile).\n- Cards by default enter play under their owner's control. Some abilities may cause cards to change control during a game.\n- If a card would enter an out-of-play area that does not belong to the card's owner, the card is physically placed in its owner's equivalent out-of-play area instead. The card is considered to have entered its controller's out-of-play area, and only the physical placement of the card is adjusted."
-  },
-  {
-    "id": "Parley",
-    "title": "Parley",
-    "text": "Some abilities are identified with a **Parley** action designator. Such abilities are initiated using the \"Activate\" action (see \"[Activate Action](#Activate_Action)\")."
-  },
-  {
-    "id": "Per_Investigator",
-    "title": "Per Investigator ([per_investigator])",
-    "text": "When the [per_investigator] symbol appears after a value, that value is multiplied by the number of investigators who started the scenario.\n- The \"per investigator\" multiplication is done before all other modifiers, and the product of this multiplication is treated as the printed value of the card.\n- Text that uses the phrase \"per investigator\" also counts the number of investigators who started the scenario, and is applied before all other modifiers.\n- If investigators have been eliminated from the scenario, they still count toward \"per investigator\" values."
-  },
-  {
-    "id": "Peril",
-    "title": "Peril",
-    "text": "Peril is a keyword ability.\nWhile resolving the drawing of an encounter card with the peril keyword, an investigator cannot confer with the other players. Those players cannot play cards, trigger abilities, or commit cards to that investigator's skill test(s) while the peril encounter is resolving."
-  },
-  {
-    "id": "Permanent",
-    "title": "Permanent",
-    "text": "Permanent is a deckbuilding keyword ability.\n- A card with the permanent keyword does not count towards your deck size\n- A card with the permanent keyword still counts as being part of your deck and must therefore adhere to all other deckbuilding restrictions.\n- A card with the permanent keyword starts each game in play and is not shuffled into your investigator deck during setup.\n- A card with the permanent keyword cannot be discarded by any means.\n- Ruling from Maxine Newman regarding permanent cards: A card with the permanent keyword cannot be shuffled into an investigator's deck during a scenario or used to pay for the cost of any action that requires a card be discarded or returned to an investigator's deck or hand."
-  },
-  {
-    "id": "Play",
-    "title": "Play",
-    "text": "To play a card, an investigator must pay the card's resource cost and meet any applicable play restrictions and conditions. Most cards can only be played by taking a play action (see \"[Play Action](#Play_Action)\").\nA card with the fast keyword is not played during a play action. Such a card may be played any time its specified triggering condition is met or, if it has no triggering condition, during an appropriate player window (see \"[Fast](#Fast)\").\nAny time an event card is played, its effects are resolved and it is then placed in its owner's discard pile.\nAny time an asset is played, it is placed in the investigator's play area and remains in play until an ability or game effect causes it to leave play. Most assets take up one or more slots while in play (see \"[Slots](#Slots)\").\nSkill cards are not \"played.\" These cards are <i>committed</i> to a skill test from a player's hand in order to use their abilities.\nSee also: \"[Appendix I: Initiation Sequence](#Appendix_I_Initiation_Sequence)\", \"[Play Restrictions, Permissions, and Instructions](#Play_Restrictions_Permissions_and_Instructions)\"."
-  },
-  {
-    "id": "Play_Action",
-    "title": "Play Action",
-    "text": "\"Play\" is an action an investigator may take during his or her turn in the investigation phase.\nWhen an investigator takes this action, that investigator selects an asset or event card in his or her hand, pays its resource cost, and plays it (see \"[Play](#Play)\").\n- Cards with the \"fast\" keyword are not played by using this action (see \"[Fast](#Fast)\").\n- Skill cards are not \"played.\" These cards are *committed* to a skill test from a player's hand in order to use their abilities.",
-    "rules": [
-      {
-        "id": "Play_Restrictions_Permissions_and_Instructions",
-        "title": "Play Restrictions, Permissions, and Instructions",
-        "text": "Many cards and abilities contain specific instructions pertaining to when or how they may or may not be used, or to specific conditions that must be true in order to use them. In order to use such an ability or to play such a card, its play restrictions must be observed.\nA permission allows a player to play a card or use an ability outside the timing specifications provided by the game rules.\nA play instruction describes the timing point at which, and/or time period during which, an event card may be played."
-      }
-    ]
-  },
-  {
-    "id": "Prey",
-    "title": "Prey",
-    "text": "Given the opportunity, some enemies will pursue a defined investigator. These enemies are identified with the bold word \"**Prey**\" in their text box, followed by instructions on whom they should engage.\n- If an enemy that is about to automatically engage an investigator at its location has multiple options of whom to engage, that enemy engages the investigator who best meets its \"prey\" instructions (if multiple investigators are tied in meeting these instructions, the lead investigator may decide among them) (see \"[Enemy Engagement](#Enemy_Engagement)\").\n- If an enemy that is moving towards the nearest investigator has a choice between multiple equidistant investigators, that enemy must select among those investigators the one who best meets its \"prey\" instructions. (If multiple equidistant investigators meet the prey criteria, the lead investigator decides among those investigators. See \"[Hunter](#Hunter)\".)\n- If an enemy's prey instructions contain the word \"only,\" that enemy only moves towards and engages that investigator (as if it were the only investigator in play), and ignores all other investigators while moving and engaging. Other investigators may use the engage action or card abilities to engage the enemy.\n- Prey has no immediate effect on where an enemy will spawn (see \"[Spawn](#Spawn)\")."
-  },
-  {
-    "id": "Printed",
-    "title": "Printed",
-    "text": "The word \"printed\" refers to the text, characteristic, icon, or value that is physically printed on the card."
-  },
-  {
-    "id": "Priority_of_Simultaneous_Resolution",
-    "title": "Priority of Simultaneous Resolution",
-    "text": "If an effect affects multiple players simultaneously, but the players must individually make choices to resolve the effect, these choices are made in player order. Once all necessary choices have been made, the effect resolves simultaneously upon all affected entities.\n- If two or more forced abilities (including delayed effects) would resolve at the same time, the lead investigator determines the order in which the abilities resolve.\n- If two or more constant abilities and/or lasting effects cannot be applied simultaneously, the lead investigator determines the order in which they are applied."
-  },
-  {
-    "id": "Prologue_Investigators",
-    "title": "Prologue Investigators",
-    "cycle": ["tcu"],
-    "text": "The four investigator cards depicted here (Gavriella Mizrah, Jerome Davids, Penny White, and Valentino Rivas) are marked with the <i>Disappearance at the Twilight Estate</i> encounter set icon and can only be used in the prologue for <i>The Circle Undone</i>. They cannot be used in other scenarios. Keep them with the rest of the scenario cards for <i>Disappearance at the Twilight Estate</i>, and do not integrate them into your collection of player cards."
-  },
-  {
-    "id": "Put_into_Play",
-    "title": "Put into Play",
-    "text": "Some card abilities cause a card to be \"put into play.\" Such abilities place the card directly into play from an out-of-play state.\n- The resource cost of a card being put into play <b>is not paid</b>.\n- Unless otherwise stated by the put into play ability, cards that enter play in this manner must do so in a play area that satisfies the standard game rules associated with playing or drawing (for encounter cards) that card.\n- A card that has been put into play is not considered to have been played or drawn."
-  },
-  {
-    "id": "Qualifiers",
-    "title": "Qualifiers",
-    "text": "If card text includes a qualifier followed by multiple terms, the qualifier applies to each term in the list. <i>(For example, in the phrase \"each unique ally and item,\" the word \"unique\" is a qualifier that applies both to \"ally\" and to \"item.\")</i>"
-  },
-  {
-    "id": "Reaction_Opportunities",
-    "title": "Reaction Opportunities",
-    "text": "When a triggering condition resolves, investigators are granted the opportunity to resolve [reaction] abilities in response to that triggering condition. It is only after all investigators have passed their reaction opportunity that the game moves forward.\nUsing a [reaction] ability in response to a triggering condition does not prevent other [reaction] abilities from being used in response to that same triggering condition.\n<i>For example: Roland has just defeated an enemy and wishes to trigger his [reaction] ability: “After you defeat an enemy: Discover 1 clue at your location.” He discovers 1 clue at his location. He may then play Evidence! in response to defeating that same enemy. As both cards have the same triggering condition (“After you defeat an enemy”), triggering one of these reactions does not prevent Roland from triggering the other.</i>"
-  },
-  {
-    "id": "Ready",
-    "title": "Ready",
-    "text": "A card that is in an upright state so that its controller can read its text from left to right is considered ready.\n- The default state in which cards enter play is ready.\n- When an exhausted card readies, it is returned to the upright state. It is then said to be in a ready state.\n- A ready card cannot ready again (it must first be exhausted, typically by a game step or card ability)."
-  },
-  {
-    "id": "Record_in_your_Campaign",
-    "title": "“Record in your Campaign Log…”",
-    "text": "Often the players will be instructed to record a key phrase in the Campaign Log. This should be written under “Campaign Notes” unless specified otherwise. Because the players may be instructed to check the Campaign Log for this phrase at a later time in the campaign, the indicated phrase should be recorded as it appears, without alteration.\n<i>For example: If the players are instructed to record in the Campaign Log that “the investigators were four hours late,” this shouldn’t be rewritten as “the investigators were pretty late,” because the exact number of hours might be important in a later scenario.</i>"
-  },
-  {
-    "id": "Remember_that",
-    "title": "“Remember that…”",
-    "text": "Sometimes a scenario card will instruct the investigators to “remember” a key phrase, often based on an action they have taken or a decision they have made within that scenario. This phrase may come up later during that scenario, and may trigger additional or different effects. There is no need to record this phrase in the Campaign Log, because it will only ever matter during that scenario, or during that scenario’s resolution. The players do not need to “remember” any such instruction beyond the end of the scenario in which it appears."
-  },
-  {
-    "id": "Removed_from_Game",
-    "title": "Removed from Game",
-    "text": "A card that has been removed from the game is placed away from the game area and has no further interaction with the game in any manner for the duration of its removal.\nIf there is no specified duration, a card that has been removed from the game is considered removed until the end of the game."
-  },
-  {
-    "id": "Replacing_an_Opening_Hand",
-    "title": "Replacing an Opening Hand",
-    "text": "If an ability replaces an investigator’s opening hand with a different set of cards, that set of cards is considered to be their new opening hand for the purposes of effects which would alter the number of cards in their opening hand.\nIf an ability replaces an investigator’s opening hand with a number of cards \"kept\" from a larger set of cards, an effect which alters the number of cards in that investigator’s opening hand alters both the cards originally drawn to replace that opening hand, and the number of cards \"kept\" from that larger set.\n<i>For example, the ability on Sefina Rousseau reads: \"When you would draw your opening hand: Draw 13 cards,instead. Choose up to 5 events to place beneath this card and keep 8 cards as your opening hand. Discard the rest.\" If a card effect or game effect alters the number of cards in Sefina’s opening hand, it would alter both the number of cards drawn from her ability and the number of cards she keeps as her opening hand.</i>"
-  },
-  {
-    "id": "Resign",
-    "title": "Resign",
-    "text": "Some abilities are identified with a <b>Resign</b> action designator. Such abilities are initiated using the \"Activate\" action (see \"[Activate Action](#Activate_Action)\").\n- When an investigator resigns, the investigator is eliminated by resignation (see \"[Elimination](#Elimination)\".) An investigator who resigns is not considered to have been defeated."
-  },
-  {
-    "id": "Resource_Action",
-    "title": "Resource Action",
-    "text": "\"Resource\" is an action an investigator may take during his or her turn in the investigation phase.\nWhen an investigator takes this action, that investigator gains one resource by taking it from the token pool and adding it to his or her resource pool."
-  },
-  {
-    "id": "Resources",
-    "title": "Resources",
-    "text": "Resources represent the various means of acquiring new cards at an investigator's disposal – supplies, money, tools, knowledge, spell components, etc.\n- In order to play a card or use an ability that costs resources, an investigator must pay that card or ability's resource cost by taking the specified number of resources from his or her resource pool and returning them to the token pool (see \"[Costs](#Costs)\").\n- Resources can be gained by performing the \"Resource\" action (see \"[Resource Action](#Resource_Action)\").\n- Investigators acquire one resource during each Upkeep phase (see \"[4.4 Each investigator draws 1 card and gains 1 resource](#Upkeep_Phase)\").\nIf an ability refers to the number of \"resources you have,\" \"your resources,\" or any variation on the above, it is only referring to the number of resources in that investigator’s resource pool. Resources on other cards that investigator controls do not count toward this total unless explicitly stated.\nSee also: \"[Tokens, Running out of](#Tokens)\"."
-  },
-  {
-    "id": "Retaliate",
-    "title": "Retaliate",
-    "text": "Retaliate is a keyword ability.\nEach time an investigator fails a skill test while attacking a ready enemy with the retaliate keyword, after applying all results for that skill test, that enemy performs an attack against the attacking investigator. An enemy does not exhaust after performing a retaliate attack.\n- This attack occurs whether the enemy is engaged with the attacking investigator or not."
-  },
-  {
-    "id": "Revelation",
-    "title": "Revelation",
-    "text": "A revelation ability may appear on encounter cards or on weakness cards.\n- When an investigator draws an encounter card, that investigator must resolve all \"<b>Revelation</b> – \" abilities on the card. This occurs before the card enters play, or in the case of a treachery card, before it is placed in the discard pile.\n- When a weakness card enters an investigator's hand, that investigator must immediately resolve all revelation abilities on the card as if it were just drawn."
-  },
-  {
-    "id": "Sanity_and_Horror",
-    "title": "Sanity and Horror",
-    "text": "Sanity represents a card's mental and emotional fortitude. Horror tracks the harm that has been done to a card's psyche by exposure to the Mythos.\n- When a card takes horror, place a number of horror tokens equal to the amount of horror just taken on the card (see \"[Dealing Damage/Horror](#Dealing_Damage_Horror)\").\n- If an investigator has horror on him or her equal to or greater than his or her sanity, that investigator is defeated. When an investigator is defeated, he or she is eliminated from the scenario (see \"[Elimination](#Elimination)\").\n- In campaign play, an investigator that is defeated by taking horror equal to his or her sanity suffers 1 mental trauma. Taking mental trauma may cause an investigator to be driven **insane** (see \"[Campaign Play](#Campaign_Play)\" for more information).\n- If an asset with a sanity value has horror on it equal to or greater than its sanity, it is defeated and placed on its owner's discard pile.\n- A card's \"remaining sanity\" is its base sanity minus the amount of horror on that card, plus or minus any active sanity modifiers.\n- An asset card without a sanity value is not considered to have a sanity of 0, cannot gain sanity, and cannot have horror assigned to it.\nSee also: \"[Direct Damage, Direct Horror](#Direct_Damage_Direct_Horror)\"."
-  },
-  {
-    "id": "Seal",
-    "title": "Seal",
-    "cycle": ["tfa"],
-    "text": "As an additional cost for a card with the seal keyword to enter play, its controller must search the chaos bag for the specified chaos token and place it on top of the card, thereby sealing it. If there is a choice of which token to seal, the card's controller chooses. If the specified token is not in the chaos bag, the card cannot enter play. A sealed chaos token is not considered to be in the chaos bag, and therefore cannot be revealed from the chaos bag as part of a skill test or ability.\nWhen a chaos token is \"released,\" it is returned to the chaos bag and is no longer considered sealed. <b>If a card with one or more chaos tokens sealed on it leaves play for any reason, any chaos tokens sealed on it are immediately released.</b>\nSome cards (with or without the seal keyword) may also have abilities that seal one or more chaos tokens as part of their effect. This is done following the same process as above: searching the chaos bag for the specified token, removing it from the chaos bag, and placing it on the card. If the specified token is not in the chaos bag, the effect fails."
-  },
-  {
-    "id": "Search",
-    "title": "Suchen",
-    "text": "Sobald ein Spieler angewiesen wird eine Karte zu suchen, darf dieser Spieler alle Karten in der Zone, in der gesucht wird, ansehen, ohne diese Karten für andere Spieler zu enthüllen. \n- Falls ein Effekt ein ganzes Deck durchsuchen lässt, muss man das Deck nach Abschluss der Suche mischen. \n- Sobald ein Suchen-Effekt abgehandelt wird, ist ein Spieler verpflichtet das gesuchte Objekt zu finden, falls sich ein oder mehrere gültige Objekte in der Zone befinden, in der man sucht. \n- Solange man gerade in einer Anzahl Karten sucht, werden diese Karten nicht als Karten behandelt, die ihre ursprüngliche Spielzone verlassen haben."
-  },
-  {
-    "id": "Self_Referential_Text",
-    "title": "Selbstreferenzieller Text",
-    "text": "Sobald sich der Text einer Kartenfähigkeit auf ihren eigenen Namen bezieht, bezieht er sich nur auf die Karte selbst, nicht auf andere Kopien der Karte (nach Name). \n- Selbstreferenzielle Fähigkeiten, die das Wort „diese(r)“ verwenden (z. B. „diese Karte“) beziehen sich nur auf die Karte mit dieser Fähigkeit, nicht auf andere Kopien dieser Karte."
-  },
-  {
-    "id": "Set_Aside",
-    "title": "Beiseitelegen",
-    "text": "Einige Szenarien weisen die Spieler an bestimmte Karten beiseitezulegen. Beiseitegelegte Karten interagieren nicht mit dem Spiel, bis sich Anweisungen des Szenarios oder einer Kartenfähigkeit auf sie beziehen.\nFalls ein Effekt einen Ermittler dazu anweist, die Kontrolle über eine derzeit beiseitegelegte Karte zu übernehmen, bringt der Effekt jene Karte in der Spielzone jenes Ermittlers ins Spiel."
-  },
-  {
-    "id": "Signature_Cards",
-    "title": "Signature Cards",
-    "text": "An investigator’s “signature cards” are the cards that are only available to that investigator, and cannot be included in another investigator’s deck. This includes player cards with the text “(Investigator Name) deck only,” as well as non-basic weaknesses that are listed under “Deckbuilding Requirements” and therefore can only be included in that investigator’s deck.\nSignature cards are governed by the following additional rules:\n- The number of each signature card listed under an investigator’s “Deckbuilding Requirements” is the exact number of copies of that card that is to be included in that investigator’s deck. If no number is specified, that number is 1.\n<i>For example: Under “Deckbuilding Requirements” for Roland Banks, the following cards are listed: “Roland’s .38 Special, Cover Up, 1 random basic weakness.” Roland Banks must include exactly 1 copy of his signature cards—Roland’s .38 Special and Cover Up. He is not permitted to include more than 1 copy of either of these cards.</i>\n- An investigator’s signature cards cannot be traded or given to other investigators.\n<i>For example: Roland has the Roland’s .38 Special card in play. He has the card “Teamwork” which can allow investigators at the same location to trade or give assets among one another. However, because Roland’s .38 Special is one of Roland’s signature cards, he cannot give it to another investigator.</i>\n- Signature cards need not abide by typical deckbuilding restrictions, and do not count toward any deckbuilding limitations if other cards share the same title."
-  },
-  {
-    "id": "Skill_Cards",
-    "title": "Skill Cards",
-    "text": "Skill cards represent innate or learned attributes or character traits that improve an investigator's skill tests.\nSkill cards are not played from a player's hand. In order to resolve their abilities, skill cards must be committed to a skill test.\nIf a skill card is committed to a skill test, its ability may be used during the resolution of that skill test, as specified on the card.\nSee \"[Skill Test Timing](#Skill_Test_Timing)\"."
-  },
-  {
-    "id": "Skill_Test_Results_and_Advanced_Timing",
-    "title": "Skill Test Results and Advanced Timing",
-    "text": "During Step 7 of Skill Test Timing (\"Apply skill test results\"), all of the effects of the successful skill test are determined and resolved, one at a time. This includes the effects of the test itself (such as the clue discovered while investigating, or the damage dealt during an attack), as well as any \"If this test is successful…\" effects from card abilities or skill cards committed to the test.\n[reaction] or <b>Forced</b> abilities with a triggering condition dependent upon the skill test being successful or unsuccessful (such as \"After you successfully investigate,\" or \"After you fail a skill test by 2 or more\") do not trigger at this time. These abilities are triggered during Step 6, \"Determine success/failure of skill test.\""
-  },
-  {
-    "id": "Skill_Tests",
-    "title": "Skill Tests",
-    "text": "A number of situations in the game require an investigator to make a skill test, using one of his or her four skills: willpower ([willpower]), intellect ([intellect]), combat ([combat]), or agility ([agility]). A skill test pits the investigator's value in a specified skill against a difficulty value that is determined by the ability or game step that initiated the test. The investigator is attempting to match or exceed this difficulty value in order to succeed at the test.\nA skill test is often referred to as a test of the specified skill. <i>(For example: \"agility test,\" \"combat test,\" \"willpower test,\" or \"intellect test.\")</i>\nSee \"[Skill Test Timing](#Skill_Test_Timing)\"."
-  },
-  {
-    "id": "Slots",
-    "title": "Slots",
-    "text": "Jeder Ermittler hat eine Anzahl bestimmter Slots, die mit Karten gefüllt werden können. Jede Vorteilskarte in der Spiel- oder Bedrohungszone eines Ermittlers mit einem Slotsymbol befindet sich auf einem Slot dieser Art. Slots begrenzen die Anzahl der Vorteilskarten, die ein Ermittler gleichzeitig im Spiel haben kann.\nDie Slots, die einem Ermittler normalerweise zur Verfügung stehen, sind:\n- <b>1 Zubehörslot</b>\n- <b>1 Körperslot</b>\n- <b>1 Verbündeter-Slot</b>\n- <b>2 Handslots</b>\n- <b>2 arkane Slots</b>\n- <b>1 Tarotslot</b>\nFalls eine Vorteilskarte kein Slotsymbol hat, benötigt sie keinen der oben genannten Slots. Es gibt keine Begrenzung für die Anzahl von Vorteilskarten ohne Slotsymbol, die ein Ermittler im Spiel haben kann.\nFalls durch das Spielen oder das Kontrolle Erhalten einer Vorteilskarte ein Ermittler sein Limit der Slotart jener Vorteilskarte überschreitet, muss er andere Vorteilskarten, die er kontrolliert, wählen und ablegen. Dies geschieht zum selben Zeitpunkt, zu dem die neue Vorteilskarte ins Spiel kommt."
-  },
-  {
-    "id": "Spawn",
-    "title": "Erscheinen",
-    "text": "Einige Gegner erscheinen an einem speziellen Ort, sobald sie vom Begegnungsdeck gezogen werden. Dieser Ort wird durch eine fettgedruckte „**Erscheinen**“-Anweisung im Textfeld angegeben. \n- Die Erscheinen-Anweisung eines Gegners wird abgehandelt, sobald der Gegner ins Spiel kommt, unabhängig davon, auf welche Weise dies geschieht. \n- Falls ein Gegner keine Erscheinen-Anweisung hat, erscheint er mit dem Ermittler, der ihn gezogen hat, in einen Kampf verwickelt. \n- Falls es keinen legalen Ort gibt, an dem ein Gegner erscheinen kann (z. B. falls in seiner Erscheinen-Anweisung ein spezieller Ort angegeben ist, der aber nicht im Spiel ist, oder kein Ort im Spiel seine Erscheinen-Anweisung erfüllt), erscheint er nicht und wird stattdessen abgelegt. \n- Falls mehrere Orte die Erscheinen-Anweisung erfüllen, entscheidet sich der Ermittler, der den Gegner erscheinen lässt, zwischen diesen Orten. \n- Falls eine Kartenfähigkeit die Spieler anweist einen Gegner an einem bestimmten Ort erscheinen zu lassen (<i>Beispiel: „Durchsuche das Begegnungsdeck nach einer Kopie von Akolyth und lasse sie in der Südstadt erscheinen“</i>), behandelt man die Fähigkeit, welche die Karte ins Spiel bringt, als die Erscheinen-Anweisung dieses Gegners, die jede andere Erscheinen-Anweisungen überschreibt."
-  },
-  {
-    "id": "Standalone_Mode",
-    "title": "Standalone Mode",
-    "text": "When playing a standalone game (i.e., playing a single scenario as a one-off adventure, removed from its campaign), the following rules apply:\n- When building a deck for a standalone game, an investigator may use higher level cards in their deck (so long as they observe the deckbuilding restrictions of the investigator) by counting the total experience of all the higher level cards used in the deck, and taking additional random basic weaknesses based on the following table:\n\n| Experience | Random Basic Weaknesses |\n| --- | --- |\n| 0-9 | 0 additional |\n| 10-19 experience | 1 additional |\n| 20-29 experience | 2 additional |\n| 30-39 experience | 3 additional |\n| 40-49 experience | 4 additional |\n| > 50 experience | Not permitted |\n- After choosing a scenario to play, refer to the Campaign Guide for the campaign that scenario is a part of, starting at the setup for that campaign, and continuing on to the first scenario for that campaign. Read through that scenario's introduction, then skip directly to that scenario's resolution and choose a resolution that is amenable to you. You may choose any resolution you wish. (For an added challenge, choose resolutions that put the investigators in an unfavorable state). If the players are unsure which resolution to choose, or are indifferent, choose <b>Resolution 1</b>. Record the results of the chosen resolution in a Campaign Log as if you were playing through in campaign mode, <b>except do not count experience points</b>.\n- Repeat this process for each scenario up to the scenario you wish to play. Then, setup and play that scenario as normal.\n- If a story decision would occur during gameplay, choose the outcome and record it in your campaign log.\n- Do not apply trauma for having been defeated during gameplay, but if trauma is inflicted during a scenario resolution, apply it.\n- If a scenario weakness or asset is earned that is in an expansion you do not own, simply continue without that card."
-  },
-  {
-    "id": "Story_Cards",
-    "title": "Story Cards",
-    "cycle": ["ptc", "tfa", "tcu", "tde"],
-    "text": "Story cards serve as an avenue for additional narrative and typically appear as the reverse side of another scenario card. When you are instructed to resolve a story card, simply read its story text and resolve its game text, if any."
-  },
-  {
-    "id": "Supplies",
-    "title": "Supplies",
-    "cycle": ["tfa"],
-    "text": "At certain points throughout *The Forgotten Age* campaign, investigators are given the opportunity to choose supplies to bring on their expeditions into the wilds. These supplies are recorded in the Campaign Log, under each investigator's \"Supplies\" section.\nSupplies are purchased with supply points, which are granted to investigators whenever they are given the opportunity to purchase supplies. Leftover supply points are not recorded, and are lost.\nAn investigator's supplies will determine the possible options available during gameplay and throughout the story of this campaign. <b>Each supply has no effect on its own.</b> Some card effects, story options, and resolutions may change or become available depending on the supplies carried by the investigator(s)."
-  },
-  {
-    "id": "Surge",
-    "title": "Surge",
-    "text": "Surge is a keyword ability.\nAfter drawing and resolving an encounter with the surge keyword, an investigator must draw another card from the encounter deck.\n- If a card with the surge keyword is drawn during setup, the surge keyword does resolve."
-  },
-  {
-    "id": "Swarming X",
-    "cycle": ["tde"],
-    "title": "Swarming X",
-    "text": "An enemy with the swarming X keyword is actually a pack of enemies operating in unison. After you put any enemy with the swarming X keyword into play, place the top X cards of your deck facedown underneath the enemy as swarm cards, without looking at them. The enemy they are underneath is called the \"host enemy.\" Some scenario card effects may also instruct a player to add swarm cards to an enemy. This is done using the same process.\n- If it is ever unclear which investigator should add swarm cards, the lead investigator does so.\n- Each swarm card underneath the host enemy acts as a separate instance of that enemy for most purposes. Each swarm card has the same values and text as its host card. <i>(For example, if an investigator is engaged with a host enemy with 2 swarm cards underneath it, that investigator is engaged with 3 enemies in total.)</i>\n- Each swarm card attacks separately when enemies attack during the enemy phase. Once the host enemy and all of its swarm cards have attacked during this step, exhaust all of them.\n- Each swarm card can be attacked or dealt damage separately, but the host enemy cannot be defeated while it still has swarm cards underneath it. When a swarm card is defeated, any excess damage may be dealt to another swarm card underneath the same host enemy or to the host enemy itself. <i>(For example, Tony Morgan uses a .41 Derringer to attack a Stealthy Zoog with 2 swarm cards. The attack deals 2 damage. The first point of damage defeats 1 of the 2 swarm cards, so the excess point of damage may be dealt to another swarm card, defeating it as well.)</i>\n- Anytime a swarm card leaves play, place it on the bottom of its owner's deck. If you are unsure of the owner of the swarm card, you may look at it to determine its owner.\n- The host enemy and all of its swarm cards move, engage, and exhaust as a single entity. <i>(For example, if a host enemy or any of its swarm cards are evaded, all of them exhaust and become disengaged.)</i>"
-  },
-  {
-    "id": "Taking_Damage_Horror",
-    "title": "Taking Damage/Horror",
-    "text": "\"Take X damage\" is shorthand for \"deal X damage to your investigator.\" \"Take X horror\" is shorthand for \"deal X horror to your investigator.\"\nSee \"[Dealing Damage/Horror](#Dealing_Damage_Horror)\"."
-  },
-  {
-    "id": "Target",
-    "title": "Target",
-    "text": "The term \"choose\" indicates that one or more targets must be chosen in order for an ability to resolve. The player resolving the ability must choose a game element (usually a card) that meets the targeting requirements of the ability.\n- If an ability requires the choosing of a target, and there is no valid target (or not enough valid targets), the ability cannot be initiated.\n- If multiple targets are required to be chosen by the same player, they are chosen simultaneously.\n- An effect that can choose \"any number\" of targets does not successfully resolve (and cannot change the game state) if zero of those targets are chosen.\n- A card is not an eligible target for an ability if the resolution of that ability's effect could not change the target's state. *(For example, an exhausted enemy could not be chosen as the target of an effect that reads, \"choose and exhaust an enemy.\")*"
-  },
-  {
-    "id": "Tarot Slot",
-    "title": "Tarot Slot",
-    "text": "Tarot slots are a new type of asset slot introduced in this expansion. The following symbol indicates that an asset fills a tarot slot:\nAs with other slots, tarot slots limit the number of asset cards of that slot type an investigator is permitted to have in play simultaneously.\n<b>By default, an investigator has only one tarot slot available.</b>\nAll other rules governing slots apply to tarot slots, as usual."
-  },
-  {
-    "id": "Then",
-    "title": "Then",
-    "text": "If the effect of an ability includes the word \"then,\" the text preceding the word \"then\" must be successfully resolved in full before the remainder of the effect described after the word \"then\" can be resolved.\n- If the pre-then aspect of an effect does successfully resolve in full, the post-then aspect of the effect must also resolve.\n- The post-then aspect of an effect has timing priority over all other indirect consequences of the resolution of the pre-then aspect. <i>(For example, if an effect reads: \"Draw an encounter card. Then, take 1 horror,\" and a player controls an ability that reads \"After you draw an encounter card,\" the post-then \"take 1 horror\" aspect occurs before the \"After you draw an encounter card\" ability may initiate.)</i>\n- If the pre-then aspect of an effect does not successfully resolve in full, the post-then aspect does not resolve."
-  },
-  {
-    "id": "Threat_Area",
-    "title": "Bedrohungszone",
-    "text": "Die Bedrohungszone eines Ermittlers ist die Spielzone, in die Begegnungskarten platziert werden, mit denen der Ermittler aktuell in einen Kampf verwickelt ist und/oder die Auswirkungen auf diesen Ermittler haben. \n- Die Karten in der Bedrohungszone eines Ermittlers befinden sich am selben Ort wie der Ermittler."
-  },
-  {
-    "id": "Tokens",
-    "title": "Tokens, Running out of",
-    "text": "There is no limit to the number of tokens (of any type) which can be in the game area at a given time. If players run out of the provided tokens, other tokens, counters, or coins may be used to track the current game state."
-  },
-  {
-    "id": "Traits",
-    "title": "Traits",
-    "text": "Most cards have one or more traits listed at the top of the text box and printed in bold italics.\n- Traits have no inherent effect on the game. Instead, some card abilities reference cards that possess specific traits."
-  },
-  {
-    "id": "Trauma_Placeholder",
-    "title": "Trauma",
-    "text": "See \"[Campaign Play](#Trauma)\"."
-  },
-  {
-    "id": "Treachery_Cards",
-    "title": "Treachery Cards",
-    "text": "Treachery cards represent curses, afflictions, madnesses, obstacles, disasters, or other unexpected occurrences an investigator may encounter throughout the course of a scenario.\nWhen a treachery card is drawn by an investigator, that investigator must resolve its effects. Then, place the card in its discard pile unless otherwise instructed by the ability.\nSee \"[1.4 Each investigator draws 1 encounter card](#Mythos_Phase)\"."
-  },
-  {
-    "id": "Triggered_Abilities",
-    "title": "Triggered Abilities",
-    "text": "A triggered ability is an ability that is optionally triggered by a player. A triggered ability can be identified by one of the following icons.\n- The [action] icon indicates an action-costed triggered ability.\n- The [free] icon indicates a free triggered ability that does not cost an action and may be used during any player window.\n- The [reaction] indicates a reaction triggered ability that does not cost an action and may be used any time its triggering condition is met.\nSee also: \"[Ability](#Abilities_Triggered_Abilities)\", \"[Appendix I: Initiation Sequence](#Appendix_I_Initiation_Sequence)\".\"\nAn investigator is permitted to use triggered abilities ([free], [reaction], and [action] abilities) from the following sources:\n- A card in play and under his or her control. This includes his or her investigator card.\n- A scenario card that is in play and at the same location as the investigator. This includes the location itself, encounter cards placed at that location, and all encounter cards in the threat area of any investigator at that location.\n- The current act or current agenda card.\n- Any card that explicitly allows the investigator to activate its ability."
-  },
-  {
-    "id": "Triggering_Condition",
-    "title": "Triggering Condition",
-    "text": "A triggering condition indicates the timing point at which an ability may be triggered. Most triggering conditions use the word \"when\" or \"after\" to establish their relation to the specified timing point.\n- Each eligible ability that triggers in reference to a specified timing point may be used once each time that timing point occurs.\n- If multiple instances of the same ability are eligible to initiate, each instance may be used once.\nSee also: \"[Ability](#Ability)\", \"[After](#After)\", \"[When](#When)\"."
-  },
-  {
-    "id": "Unique",
-    "title": "Einzigartig (✷)",
-    "text": "Eine Karte mit dem ✷-Symbol vor dem Kartennamen ist eine einzigartige Karte. Es kann nicht mehr als 1 Instanz jeder einzigartigen Karte gleichzeitig im Spiel geben. Hierbei gilt der Name der Karte. \n- Ein Spieler kann eine einzigartige Karte nicht ins Spiel bringen, falls bereits eine Kopie dieser Karte (nach Name) im Spiel ist. \n- Falls eine einzigartige Begegnungskarte ins Spiel kommen würde, die den gleichen Namen wie eine einzigartige Spielerkarte hat, wird die Spielerkarte abgelegt und die Begegnungskarte gleichzeitig ins Spiel gebracht."
-  },
-  {
-    "id": "Upkeep_Phase_Placeholdler",
-    "title": "Upkeep Phase",
-    "text": "See \"[IV. Upkeep phase](#Upkeep_Phase)\"."
-  },
-  {
-    "id": "Uses",
-    "title": "Uses (X \"type\")",
-    "text": "Uses is a keyword ability.\nWhen a card bearing this keyword enters play, place a number of resource tokens equal to the value (X), from the token pool, on the card. The word following the value establishes and identifies the type of uses this card bears. The resource tokens placed on the card are considered uses of the established type, and are not considered resource tokens.\n- Each card bearing this keyword also has an ability which references the type of use established by the keyword as a part of its cost. When such an ability spends a use, a token of that type must be removed from the card bearing the ability.\n- Other cards may reference and interact with uses of a specified type, usually by adding uses of that type to a card, or using uses of that type for other purposes.\n- A card cannot bear uses of a type other than that established by its own \"Uses (X type)\" keyword. <i>(For example, a card with \"Uses (4 ammo)\" cannot gain charges.)</i>\n- Some cards with this keyword bear text that causes the card to be discarded if it has no uses remaining. If the card contains no such text, it remains in play even if out of uses."
-  },
-  {
-    "id": "Vengeance_X",
-    "title": "Vengeance X",
-    "cycle": ["tfa"],
-    "text": "Some encounter cards are worth vengeance points. The text <b>Vengeance X</b> indicates that a card is worth X vengeance points.\nLike <b>Victory X</b>, when an encounter card with <b>Vengeance X</b> is overcome by the investigators, it is stored in the victory display until the end of the scenario. However, unlike victory points, vengeance represents the awareness and animosity of the Father of Serpents, and it is generally a good idea to avoid accruing vengeance points whenever possible.\nVengeance points in the victory display have no impact upon the game unless specifically referenced by another encounter card.\n- As an enemy with <b>Vengeance X</b> is defeated, place the card in the victory display instead of in the discard pile.\n- At the end of a scenario, take each location with <b>Vengeance X</b> that is in play, revealed, and has no clues on it, and place it in the victory display.\n- As a treachery card with **Vengeance X** completes its resolution, place it in the victory display instead of in the discard pile.\n- Cards worth vengeance points are not also worth victory points unless the card has both <b>Victory X</b> and <b>Vengeance X</b>."
-  },
-  {
-    "id": "Victory_Display_Victory_Points",
-    "title": "Victory Display, Victory Points",
-    "text": "Some encounter cards are worth victory points. The text **Victory X** indicates that a card is worth X victory points.\nAn encounter card worth victory points that is overcome by the investigators is stored in the victory display until the end of the scenario. The victory display is an out-of-play game area shared by all players. Upon completion of the scenario, the cards in the victory display provide experience, which can be used to upgrade an investigator's deck (see \"[Campaign Play](#Campaign_Play)\").\n- As a victory point enemy is defeated, place the card in the victory display instead of in the discard pile.\n- At the end of a scenario, place each victory point location that is in play, revealed, and with no clues on it in the victory display.\n- As a victory point treachery card completes its resolution, place it in the victory display instead of in the discard pile."
-  },
-  {
-    "id": "Weakness",
-    "title": "Schwäche",
-    "text": "Schwäche ist eine Kartenunterart. Diese Karten stehen für die Charakterschwächen, Flüche, Wahnsinn, Verletzungen, Verpflichtungen, Gegner oder Storyelemente, die Teil der Hintergrundgeschichte eines Ermittlers sind oder im Verlauf einer Kampagne erworben werden. Schwächekarten werden unterschiedlich abgehandelt, abhängig von ihrem Kartentyp. \n- Sobald ein Ermittler eine Schwäche zieht, die eine Begegnungskarte ist (<i>zum Beispiel eine Gegner- oder Verratsschwäche</i>), handelt er diese Karte ab, als ob sie gerade vom Begegnungsdeck gezogen worden wäre. \n- Sobald ein Ermittler eine Schwäche zieht, die eine Spielerkarte ist (<i>zum Beispiel eine Vorteils-, Ereignis- oder Fertigkeitsschwäche</i>), handelt er sämtliche Enthüllungseffekte auf der Karte ab und fügt sie der Hand des Ermittlers hinzu. Die Karte darf dann wie jede andere Spielerkarte ihrer Art verwendet werden. \n- Falls eine Schwächekarte anders als durch das Ziehen einer Karte auf die Hand des Ermittlers kommt, muss der Ermittler die Karte abhandeln (einschließlich aller Enthüllungsfähigkeiten), als ob er sie gerade gezogen hätte. \n- Der Träger einer Schwäche ist der Ermittler, der das Spiel mit dieser Schwäche in seinem Deck oder seiner Spielzone begonnen hat. \n- Falls eine Schwäche einem Spielerdeck oder einer Hand während des Durchspielens eines Szenarios hinzugefügt wird, bleibt sie für den Rest der Kampagne Teil des Decks dieses Ermittlers (außer wenn sie durch eine Kartenfähigkeit oder eine Szenarioauflösung aus der Kampagne entfernt wird). \n- Ein Spieler kann sich nicht dafür entscheiden, eine Schwächekarte von seiner Hand abzulegen, falls eine Karte nicht ausdrücklich etwas anderes besagt. \n- Schwächen, die Begegnungskarten sind, werden wie andere Begegnungskarten nicht von einem Spieler kontrolliert. Schwächen, die Spielerkarten sind, werden von ihrem Träger kontrolliert. \n- Einige Karten- und Spieltexte beziehen sich auf „Grundschwächen“. Eine Grundschwäche kann man an dem Begriff „Grundschwäche“ und dem unten abgebildeten Symbol erkennen."
-  },
-  {
-    "id": "When",
-    "title": "Sobald",
-    "text": "Das Wort „sobald“ bezieht sich auf den Moment direkt nachdem die angegebene Timing-Vorgabe oder Auslösebedingung initiiert worden ist, aber bevor die Auswirkungen auf den Spielstatus abgehandelt werden. Die Abhandlung einer „sobald“-Fähigkeit unterbricht die Abhandlung ihrer Timing-Vorgabe oder Auslösebedingung. <i>(Beispiel: Eine Fähigkeit, die besagt „Sobald du eine Gegnerkarte ziehst“, wird sofort initiiert, nachdem man die Gegnerkarte gezogen hat, aber bevor ihre Enthüllungsfähigkeit, ihr Erscheinen u. s. w. abgehandelt werden).</i>\nSiehe auch: \"[Fähigkeit](#Ability)\", \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
-  },
-  {
-    "id": "Wild_Skill_Icons",
-    "title": "Wild Skill Icons",
-    "text": "A Wild ([wild]) skill icon on a player card may be used to match any other skill icon for the purposes of both card abilities and counting how many matching icons are committed to a skill test. When using Wild icons for the purpose of resolving a card ability, a player must state which icon the Wild is matching at the time the card is used.\nWild icons committed to a skill test are considered \"matching\" icons for the purposes of card abilities."
-  }
-  ,
-  {
-    "id": "Winning_and_Losing",
-    "title": "Winning and Losing",
-    "text": "Each scenario has a number of different possible endings.\nThe act deck represents the progress of the investigators through a scenario. Some instructions in the act deck (as well as on other encounter cardtypes) contain resolution points, in the format of: \"**(→R#)**.\" The players' primary objective is to advance through the act deck until a (hopefully favorable) resolution point is reached. Should the act deck invoke a resolution, the players have completed the scenario (they may even have \"won!\"). Instructions for resolving the designated resolution are found in the \"do not read until end of game\" section of the campaign manual.\nThe agenda deck represents the objectives and progress of the malicious forces pitted against the investigators in the scenario. Some instructions in the agenda deck (as well as on other encounter cardtypes) also contain resolution points, in the format of: \"<b>(→R#)</b>.\" Should the agenda deck invoke a (usually darker) resolution, the players have lost the scenario. Instructions for resolving the designated resolution are found in the \"do not read until end of game\" section of the campaign guide.\nShould the scenario end with no resolution being reached *(for example, if all investigators have been eliminated or have resigned)*, instructions for resolving the scenario can be found in the \"do not read until end of game\" section of the campaign guide.\n- If playing in a campaign, players will proceed to the next scenario in the campaign regardless of the outcome of the scenario. Even if players \"lose\" a scenario, they still continue their campaign (although with some negative consequences from their failure).\n- When playing a standalone scenario, players either win or lose the scenario. They win if they complete a resolution on an act card. Any other resolution is considered a loss (see \"[Standalone Mode](#Standalone_Mode)\").\nSee \"[Act Deck and Agenda Deck](#Act_Deck_and_Agenda_Deck)\"."
-  }
-  ,
-  {
-    "id": "The_letter_X",
-    "title": "The letter \"X\"",
-    "text": "The value of the letter X is defined by a card ability or a granted player choice. If X is not defined, its value is equal to 0.\n- For costs involving the letter X, the value of X is defined by card ability or player choice, after which the amount paid may be modified by effects without altering the value of X."
-  }
-  ,
-  {
-    "id": "You_Your",
-    "title": "You/Your",
-    "text": "The following guidelines are used to interpret which investigator is referenced by the words \"you\" and \"your.\"\n- A <b>Revelation</b> ability that references \"you/your\" refers to the investigator who drew the card and is resolving the ability.\n- When resolving a triggered ability ([fast], [reaction], or [action] ability), \"you/your\" refers to the investigator triggering the ability.\n- If an ability contains a clause identifying whom it is targeting, \"you/your\" in that ability refers to those investigators. <i>For example, Stubborn Detective reads: \"While Stubborn Detective is at your location…\" This clause identifies \"you\" as any investigator at his location. Young Deep One reads: \"After Young Deep One engages you…\" This clause identifies \"you\" as any investigator who engages Young Deep One.</i>\n- Any other instance of \"you/your\" that does not fall into the above categories refers to the investigator who controls the card, the investigator who has the card in his/her threat area, or who is currently interacting with the card.\nA card may have multiple different abilities in which \"you/your\" may be interpreted differently. “You/your” may refer to a different investigator in each of these abilities.\n<i>For example: Dreams of R’lyeh reads:</i>\n<i>\"<b>Revelation</b> - Put Dreams of R’lyeh into play in your threat area.\nYou get –1 [willpower] and –1 sanity.\n[action]: Test [willpower] (3). If you succeed, Discard Dreams of R’lyeh.\"</i>\nThese three abilities reference \"you/your\" in different ways. For the <b>Revelation</b> ability, \"your\" refers to the investigator who drew Dreams of R’lyeh and is resolving its <b>Revelation</b>. For its constant ability, \"you\" refers to the investigator who has Dreams of R’lyeh in his or her threat area. For its [action] ability, \"you\" refers to the investigator who is performing the [action] ability."
-  },
-  {
-    "id": "Appendix_I_Initiation_Sequence",
-    "title": "Appendix I: Initiation Sequence",
-    "text": "When a player wishes to initiate a triggered ability or play a card, that player first declares his or her intent. There are two preliminary confirmations that must be made before the process of initiating an ability or playing a card may begin. These are:\n- Check play restrictions: determine if the card can be played, or if the ability can be initiated, at this time. (This includes verifying that the resolution of the effect has the potential to change the game state.) If the play restrictions are not met, abort this process.\n- Determine the cost (or costs, if multiple costs are required) to play the card or initiate the ability. If it is established that the cost (taking modifiers into account) can be paid, proceed with the remaining steps of this sequence.\nOnce each of the above confirmations has been made, follow these steps, in order:\n1. Apply any modifiers to the cost(s).\n2. Pay the cost(s). If this step is reached and the cost(s) cannot be paid, abort this process without paying any costs.\n- Upon completion of this step, attacks of opportunity, if applicable, resolve.\n3. The card commences being played, or the effects of the ability attempt to initiate.\n4. The effects of the ability (if not canceled in step 3) complete their initiation, and resolve. The card is regarded as played (and placed in play, or in its owner's discard pile if it's an event), and the ability is considered resolved simultaneously with the completion of this step.\n- If the ability being initiated is on an in-play card, the sequence does not stop from completing if that card leaves play during the sequence."
-  },
-  {
-    "id": "Appendix_II_Timing_and_Gameplay",
-    "title": "Appendix II: Timing and Gameplay",
-    "text": "The \"[Phase Sequence timing chart](#Phase_Sequence_Timing)\" depicts the phases and steps of a game round. Each time an investigator makes a skill test, use the skill test timing detailed in the \"[Skill Test timing chart](#Skill_Test_Timing).\"\nNumbered items presented in the grey boxes are known as framework events. Framework events are mandatory occurrences dictated by the structure of the game.\nThe red boxes are player windows. Players may use [free] triggered abilities in these windows.\nThe specific details for each of these steps are explained starting.",
-    "rules": [
-      {
-        "id": "Phase_Sequence_Timing",
-        "title": "Phase Sequence timing chart",
-        "table": [
-          { "row": [{ "text": "I. Mythos phase (skip during first round of game)" }] },
-          { "row": [{ "color": "green", "text": "1.1 Round begins. Mythos phase begins." }] },
-          { "row": [{ "color": "green", "text": "1.2 Place 1 doom on the current agenda." }] },
-          { "row": [{ "color": "green", "text": "1.3 Check doom threshold." }] },
-          { "row": [{ "color": "green", "text": "1.4 Each investigator draws 1 encounter card." }] },
-          { "row": [{ "color": "red", "text": "[free] PLAYER WINDOW" }] },
-          { "row": [{ "color": "green", "text": "1.5 Mythos phase ends." }] },
-          { "row": [{ "color": "grey", "text": "Proceed to Investigation Phase." }] },
-          { "row": [] },
-          { "row": [{ "text": "II. Investigation phase" }] },
-          { "row": [{ "color": "green", "text": "2.1 Investigation phase begins." }] },
-          { "row": [{ "color": "red", "text": "[free] PLAYER WINDOW" }] },
-          { "row": [{ "color": "green", "text": "2.2 Next investigator's turn begins." }] },
-          { "row": [{ "color": "red", "text": "[free] PLAYER WINDOW" }] },
-          { "row": [{ "color": "green", "text": "2.2.1 Active investigator may take an action, if able. If an action was taken, return to previous player window. If no action was taken, proceed to 2.2.2." }] },
-          { "row": [{ "color": "green", "text": "2.2.2 Investigator's turn ends. If an investigator has not yet taken a turn this phase, return to 2.2. If each investigator has taken a turn this phase, proceed to 2.3." }] },
-          { "row": [{ "color": "green", "text": "2.3 Investigation phase ends." }] },
-          { "row": [{ "color": "grey", "text": "Proceed to Enemy Phase." }] },
-          { "row": [] },
-          { "row": [{ "text": "III. Enemy phase" }] },
-          { "row": [{ "color": "green", "text": "3.1 Enemy phase begins." }] },
-          { "row": [{ "color": "green", "text": "3.2 Hunter enemies move." }] },
-          { "row": [{ "color": "red", "text": "[free] PLAYER WINDOW" }] },
-          { "row": [{ "color": "green", "text": "3.3 Next investigator resolves engaged enemy attacks. If an investigator has not yet resolved enemy attacks this phase, return to previous player window. After final investigator resolves engaged enemy attacks, proceed to next player window." }] },
-          { "row": [{ "color": "red", "text": "[free] PLAYER WINDOW" }] },
-          { "row": [{ "color": "green", "text": "3.4 Enemy phase ends." }] },
-          { "row": [{ "color": "grey", "text": "Proceed to Upkeep Phase." }] },
-          { "row": [] },
-          { "row": [{ "text": "IV. Upkeep phase" }] },
-          { "row": [{ "color": "green", "text": "4.1 Upkeep phase begins." }] },
-          { "row": [{ "color": "red", "text": "[free] PLAYER WINDOW" }] },
-          { "row": [{ "color": "green", "text": "4.2 Reset actions." }] },
-          { "row": [{ "color": "green", "text": "4.3 Ready each exhausted card." }] },
-          { "row": [{ "color": "green", "text": "4.4 Each investigator draws 1 card and gains 1 resource." }] },
-          { "row": [{ "color": "green", "text": "4.5 Each investigator checks hand size." }] },
-          { "row": [{ "color": "green", "text": "4.6 Upkeep phase ends. Round ends." }] },
-          { "row": [{ "color": "grey", "text": "Proceed to Mythos Phase of next game round." }] }
-        ]
-      },
-      {
-        "id": "Framework_Event_Details",
-        "title": "Framework Event Details",
-        "text": "This section provides a detailed explanation of how to handle each framework event step presented on the game's flow chart, in the order that the framework events occur throughout the round.",
-        "rules": [
-          {
-            "id": "Mythos_Phase",
-            "title": "I. Mythos Phase",
-            "text": "<b>During the first round of the game, skip the mythos phase.</b>\n\n<b>1.1 Mythos phase begins.</b>\nThis step formalizes the beginning of the mythos phase. As this is the first framework event of the round, it also formalizes the beginning of a new game round.\nThe beginning of a phase is an important game milestone that may be referenced in card text, either as a point at which an ability may or must resolve, or as a point at which a delayed effect resolves or a lasting effect expires.\n\n<b>1.2 Place 1 doom on the current agenda.</b>\nTake 1 doom from the token pool, and place it on the current agenda card.\n\n<b>1.3 Check doom threshold.</b>\nCompare the total number of doom in play (on the current agenda and on each other card in play) with the doom threshold of the current agenda. If the value of doom in play equals or exceeds the doom threshold of the current agenda, the agenda deck advances.\nWhen the agenda deck advances, remove all doom from play, returning them to the token pool. Turn the current agenda over, read the story text, and follow any advancement instructions. Unless otherwise directed by the advancement instructions, the front side of the next sequential agenda card becomes the new current agenda, and the advancing agenda is simultaneously removed from the game.\n<i>Note: Unless a card otherwise specifies that it can advance the agenda, this is the only time at which the agenda can advance.</i>\n\n<b>1.4 Each investigator draws 1 encounter card.</b>\nIn player order, each investigator draws the top card of the encounter deck, resolves any revelation abilities on the card, and follows the instructions below based on the card's type.\nEach time an investigator draws an encounter card, perform the following steps, in order:\n1. Draw the card from the encounter deck.\n2. Check for the peril keyword on the drawn card. (If the card has the peril keyword, the investigator who drew the card cannot confer with the other players. Those other players cannot play cards, trigger abilities, or commit cards to that investigator's skill test(s) while the peril encounter is resolving.)\n3. Resolve the revelation ability on the drawn card.\n4. If the card is an <b>enemy</b>, spawn it following any spawn instruction the card bears. (A spawn instruction is any text bearing a \"spawn\" precursor.) If the encountered enemy has no spawn instruction, the enemy spawns engaged with the investigator encountering the card and is placed in that investigator's threat area.\nIf the card is a <b>treachery</b>, place the card in the encounter discard pile unless otherwise instructed by the ability.\n5. If the drawn card has the surge keyword, the investigator must draw another card. Restart this process at step 1.\n\n<b>1.5 Mythos phase ends.</b>\nThis step formalizes the end of the mythos phase.\nThe end of a phase is an important game milestone that may be referenced in card text, either as a point at which an ability may or must resolve, or as a point at which a delayed effect resolves or a lasting effect expires."
-          },
-          {
-            "id": "Investigation_Phase",
-            "title": "Investigation phase",
-            "text": "<b>2.1 Investigation phase begins.</b>\nThis step formalizes the beginning of the investigation phase.\n\n<b>2.2 Next investigator's turn begins.</b>\nThe investigators may take their turns in any order. The investigators choose among themselves who (among the investigators) will take this turn, and making this choice begins that investigator's turn. The investigator taking his or her turn is known as the \"active investigator.\"\nOnce an investigator begins a turn, that investigator must complete the turn before another investigator may take his or her turn. Each investigator takes one turn each round.\n\n<b>2.2.1 Investigator takes an action, if able.</b>\nDuring his or her turn, an investigator is permitted to take three actions. An action can be used to do one of the following:\n- <b>Investigate</b> your location.\n- <b>Move</b> to a connecting location.\n- <b>Draw</b> (draw 1 card).\n- <b>Resource</b> (gain 1 resource).\n- <b>Play</b> an asset or event card from your hand.\n- <b>Activate</b> an [action]-costed ability on an in-play card you control, an in-play encounter card at your location, a card in your threat area, the current act card, or the current agenda card.\n- <b>Fight</b> an enemy at your location.\n- <b>Engage</b> an enemy at your location.\n- Attempt to <b>evade</b> an enemy engaged with you.\nThe three actions an investigator performs during his or her turn may be any of the above, in any order, and may even be the same action three times in a row.\n<b>Important:</b> When an investigator is engaged with one or more enemies and takes an action other than to <b>fight</b>, to <b>evade</b>, or to activate a <b>parley</b> or <b>resign</b> ability, each of those enemies makes an attack of opportunity against the investigator, in the order of the investigator's choosing.\nAfter an investigator takes an action, return to the previous player window. An investigator may end his or her turn early if there are no other actions he or she wishes to perform. If the investigator does not or cannot take an action, proceed to 2.2.2.\n\n<b>2.2.2 Investigator's turn ends.</b>\nFlip the active investigator's mini card to its colorless side to show that the investigator's turn has ended. If there is an investigator who has not yet taken a turn this round, return to 2.2. If each investigator has taken a turn this round, proceed to 2.3.\n\n<b>2.3 Investigation phase ends.</b>\nThis step formalizes the end of the investigation phase."
-          },
-          {
-            "id": "Enemy_Phase",
-            "title": "III. Enemy phase",
-            "text": "<b>3.1 Enemy phase begins.</b>\nThis step formalizes the beginning of the enemy phase.\n\n<b>3.2 Hunter enemies move.</b>\nResolve the hunter keyword for each ready, unengaged enemy that has the hunter keyword (see \"[Hunter](#Hunter)\").\n\n<b>3.3 Next investigator resolves engaged enemy attacks.</b>\nResolve engaged enemy attacks in player order, with each player resolving all of his or her engaged enemies before advancing to the next player.\nEach ready, engaged enemy makes an attack against the investigator to which it is engaged. When an enemy attacks, deal its attack (both its damage and its horror, simultaneously) to the engaged investigator. Upon completion of dealing the attack (and all abilities triggered by the attack), exhaust the enemy. If an investigator is engaged with multiple enemies, resolve their attacks in the order of the attacked investigator's choosing.\nAfter an investigator has resolved the attacks of the enemies he or she is engaged with, return to the previous player window. After the final investigator resolves enemy attacks, proceed to the next player window.\n\n<b>3.4 Enemy phase ends.</b>\nThis step formalizes the end of the enemy phase."
-          },
-          {
-            "id": "Upkeep_Phase",
-            "title": "IV. Upkeep phase",
-            "text": "<b>4.1 Upkeep phase begins.</b>\nThis step formalizes the beginning of the upkeep phase.\n\n<b>4.2 Reset actions.</b>\nFlip each investigator's mini card back to its colored side. This indicates that the investigator's actions have been reset for his or her next turn.\n\n<b>4.3 Ready exhausted cards.</b>\nSimultaneously ready each exhausted card.\n\n<b>4.4 Each investigator draws 1 card and gains 1 resource.</b>\nIn player order, each investigator draws 1 card. Once those cards have been drawn, each investigator gains 1 resource.\n\n<b>4.5 Each investigator checks hand size.</b>\nIn player order, each investigator with more than 8 cards in hand chooses and discards cards from his or her hand until he or she has 8 cards remaining in hand.\n\n<b>4.6 Upkeep phase ends.</b>\nThis step formalizes the end of the upkeep phase.\nAs the upkeep phase is the final phase in the round, this step also formalizes the end of the round. Any active \"until the end of the round\" lasting effects expire at this time.\nAfter this step is complete, play proceeds to the beginning of the mythos phase of the next game round."
-          }
-        ]
-      },
-      {
-        "id": "Skill_Test_Timing",
-        "title": "Timing für Fertigkeitsproben",
-        "table": [
-          { "row": [{ "text": "Timing für Fertigkeitsproben"}] },
-          { "row": [{ "color": "green", "text": "FP.1 Fertigkeit für die Probe bestimmen. Die Probe auf diese Fertigkeit beginnt jetzt."}] },
-          { "row": [{ "color": "red", "text": "[free] SPIELERFENSTER"}] },
-          { "row": [{ "color": "green", "text": "FP.2 Karten von der Hand zu dieser Fertigkeitsprobe beitragen."}] },
-          { "row": [{ "color": "red", "text": "[free] SPIELERFENSTER"}] },
-          { "row": [{ "color": "green", "text": "FP.3 Chaosmarker enthüllen."}] },
-          { "row": [{ "color": "green", "text": "FP.4 Chaossymbol-Effekte abhandeln."}] },
-          { "row": [{ "color": "green", "text": "FP.5 Modifizierten Fertigkeitswert des Ermittlers bestimmen."}] },
-          { "row": [{ "color": "green", "text": "FP.6 Bestimmen, ob die Fertigkeitsprobe gelingt/misslingt."}] },
-          { "row": [{ "color": "green", "text": "FP.7 Ergebnis der Fertigkeitsprobe anwenden."}] },
-          { "row": [{ "color": "green", "text": "FP.8 Die Fertigkeitsprobe endet."}] }
-        ],
-        "rules": [
-          {
-            "id": "Skill_Test_1",
-            "title": "FP.1 Fertigkeit für die Probe bestimmen. Die Probe auf diese Fertigkeit beginnt jetzt.",
-            "text": "Dieser Schritt stellt den formalen Beginn der Fertigkeitsprobe dar. Es gibt vier Arten von Fertigkeitsproben: Willenskraftproben, Intellektproben, Kampfproben und Beweglichkeitsproben. Die Kartenfähigkeit oder die Spielregel bestimmt, welche Probe nötig ist und damit beginnt eine Probe dieser Art."
-          },
-          {
-            "id": "Skill_Test_2",
-            "title": "FP.2 Karten von der Hand zur Fertigkeitsprobe beitragen.",
-            "text": "Der Ermittler, der die Fertigkeitsprobe durchführt, darf eine beliebige Anzahl Karten von seiner Hand mit dem entsprechenden Fertigkeitssymbol zur Probe beitragen. \nJeder andere Ermittler am selben Ort wie der Ermittler, der die Probe ablegt, darf eine Karte von seiner Hand mit dem entsprechenden Fertigkeitssymbol zur Probe beitragen. \nEin entsprechendes Fertigkeitssymbol ist entweder eins, das der Probe entspricht, oder ein Jokersymbol. Der Ermittler, der die Probe durchführt, bekommt +1 auf seinen Fertigkeitswert für diese Probe pro entsprechendem Fertigkeitssymbol, das zu dieser Probe beigetragen wird. \nKarten, denen das entsprechende Fertigkeitssymbol fehlt, dürfen nicht zur Probe beigetragen werden. Wird eine Karte zu einer Fertigkeitsprobe beigetragen, werden keine Ressourcenkosten für die Karte gezahlt."
-          },
-          {
-            "id": "Skill_Test_3",
-            "title": "FP.3 Chaosmarker enthüllen.",
-            "text": "Der Ermittler, der die Probe durchführt, enthüllt einen zufälligen Chaosmarker aus dem Chaosbeutel.\nSiehe auch \"[Abhandlung mehrerer enthüllter Chaosmarker](#Resolving_Multiple_Revealed_Chaos_Tokens)\"."
-          },
-          {
-            "id": "Skilll_Test_4",
-            "title": "FP.4 Chaossymbol-Effekte abhandeln..",
-            "text": "Die Effekte, die durch das Symbol auf dem enthüllten Chaosmarker initiiert werden, werden angewendet. Jedes der folgenden Symbole zeigt an, dass eine Fähigkeit auf der Szenarioübersichtskarte initiiert werden muss: [skull], [cultist], [tablet], oder [elder_thing].\nDas [elder_sign]-Symbol zeigt an, dass die [elder_sign]-Fähigkeit auf der Ermittlerkarte des Spielers, der diese Probe durchführt, initiiert werden muss.\nFalls keines der oben angegebenen Symbole enthüllt worden ist oder falls das Symbol keine entsprechende Fähigkeit hat, wird dieser Schritt ohne Effekt abgeschlossen."
-          },
-          {
-            "id": "Skill_Test_5",
-            "title": "FP.5 Modifizierten Fertigkeitswert des Ermittlers bestimmen.",
-            "text": "Man beginnt mit dem Grundwert der Fertigkeit (der abzulegenden Probe) des Ermittlers, der die Probe durchführt, und wendet alle aktiven Modifikatoren an, einschließlich der entsprechenden Symbole, die zur Probe beigetragen wurden, der Effekte von enthüllten Chaosmarkern und allen aktiven Kartenfähigkeiten, die den Fertigkeitswert des Ermittlers modifizieren."
-          },
-          {
-            "id": "Skill_Test_6",
-            "title": "FP.6 Bestimmen, ob die Fertigkeitsprobe gelingt/misslingt.",
-            "text": "Der modifizierte Fertigkeitswert wird mit der Schwierigkeit der Fertigkeitsprobe verglichen. \nFalls der modifizierte Fertigkeitswert der Schwierigkeit der Probe entspricht oder höher ist (angegeben auf der Karte oder durch den Spielmechanismus, der diese Probe hervorgerufen hat), gelingt dem Ermittler die Probe. \n- Falls einem Ermittler eine Probe durch eine Kartenfähigkeit automatisch gelingt, gilt die Gesamtschwierigkeit der Probe als 0.\nFalls der Fertigkeitswert des Ermittlers niedriger ist als die Schwierigkeit dieser Probe, misslingt dem Ermittler die Probe. \n- Falls einem Ermittler eine Fertigkeitsprobe durch eine Kartenfähigkeit oder das Enthüllen des [auto_fail]-Symbols automatisch misslingt, ist der Gesamt-Fertigkeitswert des Ermittlers für diese Probe 0.\nSiehe auch \"[Automatischer Erfolg/Misserfolg](#Automatic_Failure_Success)\"."
-          },
-          {
-            "id": "Skill_Test_7",
-            "title": "FP.7 Ergebnis der Fertigkeitsprobe anwenden.",
-            "text": "Die Kartenfähigkeit oder Spielregel, die eine Fertigkeitsprobe initiiert hat, gibt normalerweise die Konsequenz eines Erfolges und/oder eines Misserfolges dieser Probe an. (Außerdem können zu diesem Zeitpunkt einige andere Karten zusätzliche Konsequenzen beitragen oder bestehende Konsequenzen verändern.) Die entsprechenden Konsequenzen (des in FP.6 bestimmten Erfolges oder Misserfolges) werden zu diesem Zeitpunkt abgehandelt. \nFalls mehrere Ergebnisse in diesem Schritt angewendet werden müssen, wählt der Ermittler, der die Probe durchführt, in welcher Reihenfolge die Ergebnisse angewendet werden."
-          },
-          {
-            "id": "Skill_Test_8",
-            "title": "FP.8 Die Fertigkeitsprobe endet.",
-            "text": "Dieser Schritt stellt das formale Ende der Fertigkeitsprobe dar. Alle Karten, die zur Probe beigetragen worden sind, werden abgelegt und alle enthüllten Chaosmarker werden zurück in den Chaosbeutel gelegt."
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "Appendix_III_Setting_Up_The_Game",
-    "title": "Anhang III: Spielvorbereitung",
-    "text": "Um ein Spiel vorzubereiten, werden folgende Schritte in angegebener Reihenfolge durchgeführt:\n1. <b>Ermittler wählen.</b> Jeder Spieler wählt einen anderen Ermittler und platziert die entsprechende Ermittlerkarte in seine Spielzone.\n2. <b>Schaden/-Horror durch Traumata nehmen.</b> Im Kampagnenspiel platziert jeder Spieler Schaden in Höhe seines körperlichen Traumas und Horror in Höhe seines seelischen Traumas auf seiner Ermittlerkarte.\n3. <b>Einen der Ermittler als Ermittlungsleiter für dieses Spiel wählen.</b>\n4. <b>Ermittlerdecks erstellen und mischen.</b>\n5. <b>Markervorrat erstellen.</b> Die Schadens-, Horror-, Hinweis-/Verderbens- und Ressourcenmarker werden für jeden Spieler leicht erreichbar bereitlegt.\n6. <b>Chaosbeutel erstellen.</b> Die in der Kampagnenvorbereitung angegebenen Chaosmarker werden in den Chaosbeutel gelegt. Die übrigen Chaosmarker kommen zurück in die Spielschachtel. \n- Im Kampagnenmodus wird der Chaosbeutel so verwendet, wie er am Ende des vorherigen Szenarios war.\n7. <b>Startressourcen nehmen.</b> Jeder Ermittler erhält 5 Ressourcen aus dem Markervorrat.\n8. <b>Starthand ziehen.</b> Jeder Spieler zieht 5 Karten. Jeder Spieler darf in Spielerreihenfolge einen Mulligan nehmen. \n- Jede Schwächekarte, die in diesem Schritt gezogen wird, wird ignoriert, beiseitegelegt (ohne sie abzuhandeln) und durch eine neu gezogene Karte vom Deck ersetzt. Nach Abschluss dieses Schrittes wird jede gezogene Schwächekarte zurück in das Deck ihres Besitzers gemischt.\n9. <b>Szenarioeinführung im Kampagnenhandbuch lesen.</b>\n10. <b>Die im Kampagnenhandbuch angegebenen Schritte zur Szenariovorbereitung durchführen.</b> Dazu gehört das Heraussuchen der in den Vorbereitungsanweisungen angegebenen Begegnungssets, die Platzierung der Orte, die Platzierung der kleinen Ermittlerkarten an den Orten, an denen jeder Ermittler das Spiel beginnt, das Beiseitelegen von dafür angegebenen Karten und das Mischen der übrigen Begegnungskarten, um das Begegnungsdeck zu erstellen.\n11. <b>Agendadeck vorbereiten.</b> Das Agendadeck wird in der angegebenen Reihenfolge zusammengestellt, jeweils mit der Seite nach oben, die das Kartenbild zeigt. Agenda 1a ist nun die oberste Karte des Decks. Ein Spieler liest den Storytext auf Agenda 1a vor.\n12. <b>Szenendeck vorbereiten.</b> Das Szenendeck wird in der angegebenen Reihenfolge zusammengestellt, jeweils mit der Seite nach oben, die das Kartenbild zeigt. Szene 1a ist nun die oberste Karte des Decks. Ein Spieler liest den Storytext auf Szene 1a vor.\n13. <b>Szenarioübersichtskarte neben das Agendadeck platzieren.</b>\nWährend der Vorbereitung gibt es kein Spielerfenster. Die Spieler dürfen während der Vorbereitung nur Spielerkartenfähigkeiten auslösen oder Karten von der Hand spielen, falls die spezielle Auslösebedingung der Karte oder der Fähigkeit erfüllt ist."
-  },
-  {
-    "id": "Appendix_IV_Card_Anatomy",
-    "title": "Anhang IV: Aufbau der Karten",
-    "text": "In diesem Abschnitt findet ihr detaillierte Angaben zum Aufbau jedes Kartentyps. Auf den Seiten 28–29 werden Szenariokarten erläutert, auf den Seiten 30–31 Ermittler-/Spielerkarten. \nSzenenkarten, Agendakarten, Ortskarten, Verratskarten, Gegnerkarten und die Szenarioübersichtskarte sind Szenariokarten. \nErmittlerkarten, kleine Ermittlerkarten, Vorteilskarten, Ereigniskarten und Fertigkeitskarten sind Spielerkarten."
-  }
+   {
+      "id":"Golden_Rule",
+      "title":"Die Goldenen Regeln",
+      "text":"Falls der Text des Referenzhandbuches im direkten Widerspruch zum Text der Spielregel steht, hat der Text des Referenzhandbuches Vorrang. \n\nFalls der Text einer Karte im direkten Widerspruch zum Text des Referenzhandbuches oder der Spielregel steht, gilt der Text der Karte."
+   },
+   {
+      "id":"Grim_Rule",
+      "title":"Die Galgenregel",
+      "text":"Falls die Spieler nicht in der Lage sind, mithilfe des Referenzhandbuches eine Regel zu finden oder einen Timing-Konflikt zu lösen, wird der Konflikt auf die für das Gewinnen des Szenarios ungünstigste Alternative aufgelöst. Dann geht das Spiel weiter.\n\nSobald die Ermittler gezwungen werden, eine Wahl zu treffen, für die es mehrere gültige Optionen gibt, entscheidet sich der Ermittlungsleiter für eine der Optionen. Die Galgenregel spielt bei einer Wahl der Optionen keine Rolle.\n\n<i>Beispiel: [Die Verschlossene Tür](/card/01174) hat den Text: \"Hänge diese Karte an den Ort mit den meisten Hinweisen an, der noch keine Verschlossene Tür angehängt hat.\" Falls es 3 Orte gibt, die alle gleich viele Hinweise haben und keine davon schon eine Verschlossene Tür angehängt hat, entscheidet sich der Ermittlungsleiter für einen der 3 Orte. Die Spieler müssen sich bei der Wahl der 3 Optionen nicht für die ungünstigste Alternative entscheiden.</i>\n\nDie Galgenregel tritt nur in Kraft, falls die Spieler nicht in der Lage sind, eine Antwort auf eine Regelfrage oder einen Timing-Konflikt zu finden, und deshalb nicht in der Lage wären, das Spiel fortzuführen. Die Regel ist dafür entwickelt worden, weiterspielen zu können, ohne zeitintensive Recherchen betreiben zu müssen. Die Galgenregel soll keine erschöpfende Antwort für Regelfragen und Timing-Konflikte sein."
+   },
+   {
+      "id":"The_Silver_Rule",
+      "title":"Die Silberne Regel",
+      "text":"Falls der Text einer Karte im direkten Widerspruch zum Text einer anderen Karte steht und sich keine Lösung finden lässt, hat der Text auf einer Begegnungskarte Vorrang vor dem Text einer Spielerkarte. Falls es sich bei beiden Karten um Begegnungskarten bzw. Spielerkarten handelt, darf der Ermittlungsleiter entscheiden, welche der beiden Karten Vorrang hat."
+   },
+   {
+      "id":"Discard_Piles",
+      "title":"Ablagestapel",
+      "text":"Immer wenn eine Karte abgelegt wird, wird sie offen auf den Ablagestapel ihres Besitzers gelegt. Begegnungskarten sind im Besitz des Begegnungsdecks.\n\n\n- Jeder Ablagestapel ist eine Zone, die nicht im Spiel ist.\n\n\n- Jeder Ermittler hat seinen eigenen Ablagestapel und das Begegnungsdeck hat ebenfalls einen eigenen Ablagestapel.\n\n\n- Jeder Ablagestapel ist eine offene Information und darf zu jedem Zeitpunkt von jedem Spieler angesehen werden.\n\n\n- Die Reihenfolge der Karten in einem Ablagestapel darf nicht verändert werden, es sei denn, ein Spieler wird durch eine Kartenfähigkeit angewiesen, dies zu tun.\n\n\n- Falls mehrere Karten gleichzeitig abgelegt werden, darf der Besitzer dieser Karten sie eine nach der anderen in beliebiger Reihenfolge oben auf seinen Ablagestapel legen. Falls mehrere Begegnungskarten gleichzeitig abgelegt werden, werden sie in beliebiger Reihenfolge (festgelegt durch den Ermittlungsleiter) oben auf den Begegnungs-Ablagestapel gelegt.\n\n\n- Eine Fähigkeit, die einen Ablagestapel, der keine Karten enthält, in ein Deck mischen würde, mischt das Deck nicht.\n\n\n- Eine einzelne Karte kann durch einen Karteneffekt nicht in ein leeres Spieler- oder Begegnungsdeck gemischt werden. Falls ein solches Mischen während des Spielens oder der Enthüllung einer Karte passieren würde, die üblicherweise nach ihrer Abhandlung abgelegt werden würde (wie z. B. eine Ereignis- oder Verratskarte), dann wird sie abgelegt. Ansonsten bleibt die Karte in der aktuellen Spielzone."
+   },
+   {
+      "id":"Qualifiers",
+      "title":"Adjektive",
+      "text":"Falls ein Kartentext ein Adjektiv enthält, dem mehrere Begriffe folgen, gilt das Adjektiv für jeden Begriff in der Liste.\n\n<i>Beispiel: Im Satz \"jeder einzigartige Verbündete und Gegenstand\" ist \"einzigartig\" ein Adjektiv, das sich auf \"Verbündeter\" und auf \"Gegenstand\" bezieht.</i>"
+   },
+   {
+      "id":"Agenda_Deck",
+      "title":"Agendadeck",
+      "text":"Siehe \"[Szenendeck und Agendadeck](#Act_Deck_and_Agenda_Deck)\"."
+   },
+   {
+      "id":"Action",
+      "title":"Aktion",
+      "text":"Während seines Zuges darf ein Ermittler bis zu <b>drei</b> Aktionen nehmen. Sobald eine Aktion durchgeführt wird, werden zunächst sämtliche Kosten der Aktion gezahlt. Dann werden die Konsequenzen der Aktion abgehandelt.\n\n\n- Falls ein Ermittler die Anweisung erhält, dass er 1 oder mehr Aktionen verliert, hat er in dieser Runde entsprechend weniger Aktionen zur Verfügung.\n\nManche Kartenfähigkeiten gewähren Ermittlern \"zusätzliche Aktionen\". Falls ein Ermittler während seines Zuges eine oder mehrere zusätzliche Aktionen hat, verbraucht die erste Aktion, die er nimmt die sich als zusätzliche Aktion qualifiziert, jene zusätzliche Aktion. \n\n<i>Beispiel: [Daisy Walker](/card/01502) hat den Text: \"Du darfst in deinem Zug eine zusätzliche Aktion nehmen, die nur für Buch-[action]-Fähigkeiten verwendet werden kann.\" Wenn Daisy das erste Mal eine Buch-[action]-Fähigkeit in jedem Zug durchführt, wird automatisch diese zusätzliche Aktion verwendet und nicht eine von Daisys 3 Standardaktionen. </i>\n\n\n- Falls sich eine Aktion als eine von mehreren zusätzlichen Aktionen eines Ermittlers qualifiziert, darf dieser wählen, welche zusätzliche Aktion verwendet wird. \n\n\n- Falls ein Effekt bewirkt, dass ein Ermittler eine oder mehrere Aktionen verliert, hat der Ermittler entsprechend viele Standardaktionen weniger in jenem Zug, die er nehmen kann (die 3 Standardaktionen sind die, welche als Erste \"verloren\" gehen). Falls dem Ermittler nur noch zusätzliche Aktionen verbleiben, gehen diese nun in einer vom Ermittler gewählten Reihenfolge verloren. \n\n<i>Beispiel: Ein Effekt bewirkt, dass Daisy 2 Aktionen verliert. Sie hat dadurch 2 Standardaktionen weniger die sie in ihrem Zug nehmen kann. Sie kann nicht wählen ihre zusätzliche Aktion zu verlieren, es sei denn, es wäre ihre einzige verbleibende Aktion. </i>\n\nEine vollständige Liste der zur Verfügung stehenden Aktionen befindet sich unter Punkt \"[2.2.1 Der Ermittler nimmt eine Aktion, falls möglich.](#Investigation_Phase)\".",
+      "rules":[
+         {
+            "id":"Only_As_Your_First_Action",
+            "title":"\"…nur als deine erste Aktion\"",
+            "text":"Falls eine Karte \"nur als deine erste Aktion\" gespielt oder eine Kartenfähigkeit \"nur als deine erste Aktion\" ausgelöst werden kann, musst du eine deiner Aktionen verwenden und diese Aktion muss die erste in deinem Zug sein. Falls es eine Fähigkeit mit dem Schlüsselwort Schnell oder eine freie ausgelöste Fähigkeit ist, die Fähigkeit ihre Aktionskosten ignoriert oder sie außerhalb deines Zuges stattfindet, kann diese Aktion <b>nicht</b> genommen werden."
+         },
+         {
+            "id":"Take_An_Action_Vs_Perform_An_Action",
+            "title":"\"Nimm eine Aktion\" vs \"Führe eine Aktion durch / Handle eine Aktion ab\"",
+            "text":"Manche Effekte erlauben es einem Ermittler eine Aktion zu \"nehmen\", normalerweise gefolgt von einer bestimmten Aktionsart (wie z. B. die Fähigkeit von [Ursula Downs](/card/04002) oder [Eile](/card/06239)). Falls ein Effekt einem Ermittler erlaubt eine Aktion zu nehmen, erhält er effektiv 1 Aktion, um sie sofort auszugeben und die entsprechende Aktion zu nehmen. Dies folgt den normalen Regeln für das Nehmen einer Aktion: Die Aktion kann Gelegenheitsangriffe provozieren, sie zählt in Bezug auf Kartenfähigkeiten, die zählen, wie viele Aktionen du genommen hast, usw.\n\nManche Effekte (wie z. B. auf [Schnellzug-Holster](/card/08089)) erlauben einem Ermittler, \"eine Aktion durchzuführen bzw. abzuhandeln\". Bei solchen Effekten ist normalerweise angegeben, dass sie die [action]-Kosten der Aktion ignorieren. In diesem Fall hat der Ermittler effektiv keine Aktion erhalten oder ausgegeben und die Aktion wird wie angegeben abgehandelt."
+         },
+         {
+            "id":"Basic_Action",
+            "title":"Basisaktionen",
+            "text":"Siehe \"[Basisaktion](#Basic_Action_types)\"."
+         }
+      ]
+   },
+   {
+      "id":"Active_Player",
+      "title":"Aktiver Spieler",
+      "text":"Der aktive Spieler ist der Spieler, der gerade während der Ermittlungsphase seinen Zug nimmt."
+   },
+   {
+      "id":"Activate_Action",
+      "title":"Aktivieren (Aktion)",
+      "text":"\"Aktivieren\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. \n\nSobald diese Aktion genommen wird, initiiert der Ermittler eine Fähigkeit, die eine oder mehrere [action]-Symbole als Teil der Kosten der Fähigkeit enthält. Die Anzahl der [action]-Symbole in den Kosten der Fähigkeit legt fest, wie viele Aktionen der Ermittler für diese Aktivieren-Aktion ausgeben muss. Sobald eine Aktivieren-Aktion durchgeführt wird, werden zunächst sämtliche Kosten der Aktion gleichzeitig bezahlt. Dann werden die Konsequenzen der Aktion abgehandelt.\n\nEin Ermittler darf Aktionen von folgenden Quellen aktivieren:\n\n\n- Eine Karte, die sich im Spiel und unter seiner Kontrolle befindet. Dies umfasst auch seine Ermittlerkarte.\n\n\n- Eine Szenariokarte, die sich im Spiel und am selben Ort wie der Ermittler befindet. Darunter fällt auch der Ort selbst, Begegnungskarten, die an diesen Ort platziert worden sind, und alle Begegnungskarten in der Bedrohungszone jedes Ermittlers, der sich an diesem Ort befindet.\n\n\n- Die aktuelle Szenen- oder Agendakarte."
+   },
+   {
+      "id":"Alert",
+      "cycle":[
+         "tfa",
+         "rttfa",
+         "tcu",
+         "rttcu",
+         "tde",
+         "tdea",
+         "tdeb",
+         "eoe",
+         "tskc",
+         "fof",
+         "zdm",
+         "zcf"
+      ],
+      "scenarios":[
+         "fortune_and_folly_part_1",
+         "fortune_and_folly_part_2"
+      ],
+      "title":"Alarmiert",
+      "text":"Immer wenn einem Ermittler eine Fertigkeitsprobe misslingt, während er versucht, einem Gegner mit dem Schlüsselwort Alarmiert zu entkommen, führt jener Gegner nach der Anwendung aller Ergebnisse jener Fertigkeitsprobe einen Angriff gegen den entkommenden Ermittler durch. Ein Gegner wird nicht erschöpft, nachdem er einen Alarmiert- Angriff durchgeführt hat. Dieser Angriff wird durchgeführt, egal ob der Gegner mit dem entkommenden Ermittler in einen Kampf verwickelt ist oder nicht."
+   },
+   {
+      "id":"As_if",
+      "title":"Als ob…",
+      "text":"Manche Karteneffekte erlauben es einem Ermittler, eine Fähigkeit abzuhandeln oder eine Aktion durchzuführen, als ob ein bestimmter Aspekt des Spiels verändert wäre. Um diesen Unterschied anzuzeigen, wird dies mit der Phrase \"als ob …\" eingeleitet. Die so angezeigte Fähigkeit oder Aktion wird abgehandelt, als wäre das Spiel in einem anderen Zustand, ohne den Zustand des Spiels aber zu ändern.\n\n\n- Der Spielzustand gilt für die Dauer der so angezeigten Fähigkeit oder Aktion als verändert; beginnend mit der Initiierung (darunter fällt das Bezahlen der Kosten, Gelegenheitsangriffe usw.) über das Abhandeln jedes Aspekts des Effekts bis hin zu seiner Beendigung.\n\n\n- Andere Kartenfähigkeiten oder Spieleffekte werden für die Dauer der Fähigkeit ebenfalls so abgehandelt, als wäre das Spiel in einem veränderten Zustand.\n\n\n- Der Spielzustand ist aber auf keine eigentliche Weise verändert. Wenn ein Ermittler z. B. behandelt wird, als ob er an einem Ort wäre, wird seine kleine Ermittlerkarte nicht an jenen Ort bewegt und mögliche Gegner an jenem Ort werden nicht automatisch in die Bedrohungszone des Ermittlers bewegt usw.\n\n<i>Beispiel: [Luke Robinson](/card/06004) will an einem Ort ohne Hinweise [Absonderliche Zeichen](/card/02186) spielen. Ein verbundener Ort hat 1 Hinweis auf sich. Also verwendet er seine Fähigkeit \"1 Ereignis in jedem Zug zu spielen, als ob er sich an einem verbundenen Ort befände und dort mit jedem Gegner in einen Kampf verwickelt wäre\". Der Spielzustand gilt für die Dauer des Spielens von Absonderliche Zeichen vom Initiieren bis zum Abhandeln der Karte als verändert. Unter anderem könnte das Folgendes bedeuten: (a) Falls sich ein Gegner an jenem Ort befände, würde das Spielen von Absonderliche Zeichen einen Gelegenheitsangriff provozieren, (b) falls jener Ort eine Fähigkeit hätte, welche die Kosten einer zu spielenden Karte ändern würde, würde dies in diesem Fall auch geschehen, und (c) falls Luke durch das Ziehen von 1 oder mehr Karten eine andere Kartenfähigkeit auslösen würde, würde sie so abgehandelt, als befände er sich an dem verbundenen Ort und wäre mit jenem Gegner in einen Kampf verwickelt usw. Nachdem Absonderliche Zeichen abgehandelt und auf den Ablagestapel gelegt worden ist, gilt Luke nicht länger, als ob er sich an jenem Ort befände oder mit jenem Gegner an jenem Ort in einen Kampf verwickelt wäre.</i>"
+   },
+   {
+      "id":"At",
+      "title":"\"Am ...\"- und \"Falls ...\"-Fähigkeiten",
+      "text":"Manche Fähigkeiten haben Auslösebedingungen, welche die Wörter \"am\" oder \"falls\" verwenden, anstatt \"sobald\" oder \"nachdem\".\n\n<i>Beispiel: \"am Ende der Runde\" oder \"falls der [Ghulpriester](/card/01116) besiegt worden ist\"</i>.\n\nDiese Effekte lösen zwischen den \"Sobald ...\"- und den \"Nachdem ...\"-Fähigkeiten mit derselben Auslösebedingung aus."
+   },
+   {
+      "id":"Farthest_From_All_Investigators",
+      "title":"\"Am weitesten von allen Ermittlern entfernt\"",
+      "text":"Manche Karteneffekte weisen die Ermittler dazu an, eine Karte an dem Ort ins Spiel zu bringen, der \"am weitesten von allen Ermittlern entfernt\" ist. Es ist der Ort am weitesten entfernt, der von allen Ermittlern zusammengezählt die meisten Verbindungen entfernt ist (ohne Ermittler an diesem Ort). Bei Gleichstand entscheidet wie immer der Ermittlungsleiter.\n\n<i>Beispiel: Ort A ist 5 Verbindungen von Ermittler A entfernt und 1 Verbindung von Ermittler B. Ort B ist dagegen 3 Verbindungen von Ermittler A entfernt und 4 Verbindungen von Ermittler B. Ort A ist somit insgesamt 6 Verbindungen von allen Ermittlern entfernt und Ort B ist insgesamt 9 Verbindungen entfernt. Deshalb ist Ort B der am weitesten von allen Ermittlern entfernte Ort, auch wenn Ort A zu Ermittler A mit 5 Verbindungen die am weitesten entfernte Einzelverbindung aufweist.</i>"
+   },
+   {
+      "id":"Lasting_Effects",
+      "title":"Andauernde Effekte",
+      "text":"Einige Karten erzeugen Zustände, die den Spielstatus für einen bestimmten Zeitraum beeinflussen (<i>Beispiel: \"bis zum Ende der Phase\" oder \"für diese Fertigkeitsprobe\"</i>). Solche Effekte nennt man andauernde Effekte.\n\n\n- Ein andauernder Effekt besteht über die Abhandlung der Fähigkeit, die ihn erschaffen hat, hinaus. Er wirkt für die Dauer, die durch den Effekt angegeben ist. Der Effekt beeinf lusst den Spielstatus für die angegebene Dauer unabhängig davon, ob die Karte, die den andauernden Effekt erschaffen hat, im Spiel ist oder bleibt.\n\n\n- Falls ein andauernder Effekt Karten beeinf lusst, die sich im Spiel (oder in einer bestimmten Zone) befinden, wird er nur auf Karten angewendet, die sich zu dem Zeitpunkt im Spiel (oder in der bestimmten Zone befinden), sobald der andauernde Effekt in Erscheinung tritt. Karten, die ins Spiel (oder in die angegebene Zone) kommen, nachdem der Effekt in Erscheinung getreten ist, sind von dem andauernden Effekt nicht betroffen.\n\n\n- Ein andauernder Effekt hört auf zu wirken, sobald die Timing-Vorgabe erreicht ist, die durch seine Dauer angegeben wurde. Dies bedeutet, dass ein andauernder Effekt, der \"bis zum Ende der Phase\" wirkt, auf hört zu wirken, ehe eine Fähigkeit oder ein aufgeschobener Effekt \"am Ende der Phase\" initiiert werden kann.\n\n\n- Ein andauernder Effekt, der am Ende eines bestimmten Zeitraums auf hört zu wirken, kann nur während dieses Zeitraums initiiert werden."
+   },
+   {
+      "id":"Attacker_Attacked",
+      "title":"Angreifer, angegriffen",
+      "text":"Ein \"Angreifer\" ist eine Entität (normalerweise ein Gegner oder Ermittler), die ihren Angriff gegen eine andere Entität ausführt. Die angegriffene Entität nennt man den \"angegriffenen Gegner\" oder \"angegriffenen Ermittler\".\""
+   },
+   {
+      "id":"Constant_Abilities",
+      "title":"Anhaltende Fähigkeiten",
+      "text":"Siehe \"[Anhaltende Fähigkeiten](#Abilities_Constant_Abilities)\" im Bereich \"[Fähigkeiten](#Ability)\"."
+   },
+   {
+      "id":"Attach_To",
+      "title":"Anhängen an",
+      "text":"Falls eine Karte den Begriff \"hänge diese Karte … an\" verwendet, muss sie an das angegebene Spielelement angehängt werden, sobald sie ins Spiel kommt (sie wird teilweise überlappend darunter platziert). Sobald eine Karte angehängt ist, wird sie als Verstärkung bezeichnet.\n\n\n- Der Begriff \"anhängen an\" wird immer auf Zulässigkeit des Ziels überprüft, sobald eine Karte an ein Spielelement angehängt wird, aber nach dem Anhängen wird diese nicht erneut überprüft. Falls die ursprüngliche Überprüfung beim Anhängen ungültig ist, ist die Karte nicht in der Lage, angehängt zu werden, und bleibt in ihrem vorherigen Status oder ihrer vorherigen Spielzone. Falls eine solche Karte nicht in ihrem vorherigen Spielstatus oder ihrer vorherigen Spielzone bleiben kann, wird sie abgelegt.\n\n\n- Ist eine Verstärkung einmal im Spiel, bleibt sie angehängt, bis entweder die Verstärkung oder das Spielelement, an das sie angehängt ist, das Spiel verlässt (die Verstärkung wird in diesem Fall abgelegt), oder bis eine Kartenfähigkeit die Karte ausdrücklich löst.\n\n\n- Eine Verstärkung wird unabhängig von dem Spielelement, an das sie angehängt ist, erschöpft oder spielbereit gemacht.",
+      "rules":[
+         {
+            "id":"Control_of_Attachments",
+            "title":"Kontrolle über Verstärkungen",
+            "text":"Die Kontrolle über eine Verstärkung kann abhängig von der Karte, an die sie angehängt ist, wechseln.\n\n\n- Falls ein Ermittler eine Spielerkarte an eine Spielerkarte anhängt, die er kontrolliert, behält er die Kontrolle über die Verstärkung.\n\n\n- Falls ein Ermittler eine Spielerkarte an eine Spielerkarte anhängt, die ein anderer Spieler kontrolliert, übernimmt jener andere Spieler die Kontrolle über die Verstärkung.\n\n\n- Falls die Kontrolle über eine Spielerkarte mit 1 oder mehr Spielerverstärkungen wechselt, übernimmt der Spieler, der die Kontrolle über jene Karte übernommen hat, auch die Kontrolle über jene Spielerverstärkungen.\n\n\n- Falls ein Spieler eine Spielerkarte an eine Begegnungskarte anhängt, behält er die Kontrolle über die Verstärkung (er erhält aber nicht die Kontrolle über die Begegnungskarte, an die jene Karte angehängt worden ist).\n\n\n- Eine Karte mit dem Schlüsselwort Dauerhaft kann nicht gewählt werden, um an eine Karte eines anderen Spielers angehängt zu werden, außer es wird ausdrücklich erlaubt. \n\n<i>Beispiel: [Sündenfresser](/card/09094) kann nicht an [Elle Rubash](/card/09092) angehängt werden.</i>"
+         },
+         {
+            "id":"Moving_Attachments",
+            "title":"Verstärkungen bewegen",
+            "text":"Falls eine Verstärkung von einem Spielelement zu einem anderen \"bewegt\" wird, oder eine Verstärkung an ein Spielelement angehängt wird, während es bereits an einem Spielelement angehängt ist, wird die Verstärkung vom alten Spielelement abgehängt und an das neue angehängt."
+         },
+         {
+            "id":"Attaching_Permanent_Cards",
+            "title":"Anhängen von Dauerhaft-Karten",
+            "text":"Siehe \"[Kontrolle und Anhängen von Dauerhaft-Karten](#Controlling_and_Attaching_Permanent_Cards)\"."
+         }
+      ]
+   },
+   {
+      "id":"Uses",
+      "title":"Anwendungen (X \"Art\")",
+      "text":"Anwendungen ist eine Schlüsselwortfähigkeit.\n\nSobald eine Karte mit diesem Schlüsselwort ins Spiel kommt, werden Ressourcenmarker in Höhe des X-Wertes aus dem Markervorrat auf diese Karte platziert. Das Wort nach dem Wert legt die Art der Anwendungen dieser Karte fest. Die Ressourcenmarker auf der Karte gelten als Anwendungen dieser festgelegten Art und nicht als Ressourcenmarker.\n\n\n- Jede Karte mit diesem Schlüsselwort hat außerdem eine Fähigkeit, die sich als Teil ihrer Kosten auf die Anwendungs-Art bezieht, die durch das Schlüsselwort festgelegt worden ist. Sobald eine solche Fähigkeit eine Anwendung ausgibt, muss ein Marker dieser Art von der Karte entfernt werden, welche die Fähigkeit hat.\n\n\n- Andere Karten können sich auf Anwendungen einer bestimmten Art beziehen oder mit ihnen interagieren, normalerweise dadurch, dass sie Anwendungen dieser Art zu einer Karte hinzufügen oder die Anwendungen für andere Zwecke verwenden.\n\n\n- Eine Karte kann keine Anwendungen einer anderen Art haben als die, die durch ihr eigenes \"Anwendungen (X Art)\"-Schlüsselwort festgelegt worden sind.\n\n<i>Beispiel: Eine Karte mit \"Anwendungen (4 Munition)\" kann keine Ladungen erhalten.</i>\n\n\n- Einige Karten mit diesem Schlüsselwort enthalten Text, der bewirkt, dass die Karte abgelegt wird, falls sie keine Anwendungen mehr übrig hat. Falls die Karte keinen solchen Text enthält, bleibt sie auch im Spiel, falls sie keine Anwendungen mehr hat."
+   },
+   {
+      "id":"Resign",
+      "title":"Aufgeben",
+      "text":"Einige Fähigkeiten haben das Aktionskennzeichen <b>Aufgeben</b>. Solche Fähigkeiten können durch die Aktivieren-Aktion initiiert werden (siehe \"[Aktivieren (Aktion)](#Activate_Action)\").\n\n\n- Sobald ein Ermittler aufgibt, scheidet dieser Ermittler dadurch aus dem Spiel aus (siehe \"[Ausscheiden](#Elimination)\"). Ein Ermittler, der aufgibt, gilt nicht als besiegt."
+   },
+   {
+      "id":"Printed",
+      "title":"Aufgedruckt",
+      "text":"Das Wort \"aufgedruckt\" bezieht sich auf Texte, Eigenschaften, Symbole oder Werte, die auf der Karte aufgedruckt sind."
+   },
+   {
+      "id":"Delayed_Effects",
+      "title":"Aufgeschobene Effekte",
+      "text":"Einige Fähigkeiten erzeugen aufgeschobene Effekte. Solche Fähigkeiten geben einen zukünftigen Zeitpunkt oder eine Bedingung an, die in der Zukunft auftreten kann, und bestimmen einen Effekt, der dann eintritt.\n\n\n- Jeder aufgeschobene Effekt wird automatisch und sofort initiiert (wie eine erzwungene Fähigkeit), falls seine zukünftige Timing-Vorgabe oder die zukünftige Bedingung eintritt.\n\n\n- Ein aufgeschobener Effekt wirkt sich auf alle angegebenen Elemente aus, die sich in der angegebenen Spielzone befinden und zum Zeitpunkt, an dem der aufgeschobene Effekt abgehandelt wird, gültig sind."
+   },
+   {
+      "id":"Cancel",
+      "title":"Aufheben",
+      "text":"Einige Kartenfähigkeiten können andere Karteneffekte oder Spieleffekte \"aufheben\". Aufheben-Fähigkeiten unterbrechen die Initiierung eines Effektes und verhindern, dass der Effekt initiiert wird.\n\n\n- Jedes Mal wenn man die Effekte einer Fähigkeit aufhebt, gilt diese Fähigkeit immer noch als initiiert (mit Ausnahme ihrer Effekte) und ihre Kosten sind immer noch bezahlt. Das Initiieren der Effekte der Fähigkeit wird allerdings verhindert und man handelt die Effekte nicht ab.\n\n\n- Falls die Effekte einer Ereigniskarte aufgehoben werden, gilt die Karte immer noch als gespielt und die Karte wird weiterhin auf den Ablagestapel ihres Besitzers gelegt.\n\n\n- Falls die Effekte einer Verratskarte aufgehoben werden, gilt die Karte immer noch als gezogen und die Karte wird weiterhin auf den Begegnungs-Ablagestapel gelegt."
+   },
+   {
+      "id":"Removed_from_Game",
+      "title":"Aus dem Spiel entfernt",
+      "text":"Eine Karte, die aus dem Spiel entfernt worden ist, wird weggelegt und interagiert nicht mehr mit dem Spiel, solange sie aus dem Spiel entfernt ist.\n\nFalls keine Dauer angegeben ist, gilt eine aus dem Spiel entfernte Karte bis zum Ende des Spiels als aus dem Spiel entfernt."
+   },
+   {
+      "id":"Health_and_Damage",
+      "title":"Ausdauer und Schaden",
+      "text":"Ausdauer steht für die körperliche Widerstandskraft einer Karte. Schaden zeigt die körperlichen Verletzungen an, die einer Karte in einem Szenario zugefügt worden sind.\n\n\n- Immer wenn eine Karte Schaden nimmt, platziert man Schadensmarker in Höhe der gerade genommenen Schadensmenge auf die Karte (siehe \"[Schaden/Horror zufügen](#Dealing_Damage_Horror)\").\n\n\n- Falls ein Ermittler Schaden in Höhe seiner Ausdauer (oder höher) hat, ist dieser Ermittler besiegt. Sobald ein Ermittler besiegt ist, scheidet er aus dem Szenario aus (siehe \"[Ausscheiden](#Elimination)\").\n\n\n- Im Kampagnenspiel erleidet ein Ermittler, der dadurch besiegt wurde, dass er Schaden in Höhe seiner Ausdauer genommen hat, 1 körperliches Trauma. Körperliche Traumata zu nehmen kann einen Ermittler töten (siehe \"[Kampagnenspiel](#Campaign_Play)\").\n\n\n- Falls ein Gegner Schaden in Höhe seiner Ausdauer (oder höher) hat, ist dieser Gegner besiegt und wird auf den Begegnungs-Ablagestapel gelegt.\n\n\n- Falls eine Vorteilskarte Schaden in Höhe ihrer Ausdauer (oder höher) hat, ist sie besiegt und wird auf den Ablagestapel ihres Besitzers gelegt.\n\n\n- Eine Vorteilskarte ohne Ausdauer gilt nicht als eine Karte mit einer Ausdauer von 0, kann keine Ausdauer erhalten und ihr kann kein Schaden zugewiesen werden.\n\n\n- Die \"verbliebene Ausdauer\" einer Karte ist ihre Grund-Ausdauer abzüglich der Menge Schaden darauf, plus oder minus aktiver Ausdauermodifikatoren.\n\nSiehe auch \"[Direkter Schaden, Direkter Horror](#Direct_Damage_Direct_Horror)\"."
+   },
+   {
+      "id":"Triggered_Abilities",
+      "title":"Ausgelöste Fähigkeiten",
+      "text":"Eine ausgelöste Fähigkeit ist eine Fähigkeit, die optional von einem Spieler ausgelöst wird. Eine ausgelöste Fähigkeit erkennt man an einem der folgenden Symbole:\n\n\n- Das [action]-Symbol zeigt eine aktionsausgelöste Fähigkeit an, die eine Aktion kostet.\n\n\n- Das [free]-Symbol zeigt eine freie ausgelöste Fähigkeit an, die keine Aktion zum Auslösen kostet und in jedem Spielerfenster verwendet werden kann.\n\n\n- Das [reaction]-Symbol zeigt eine reaktionsausgelöste Fähigkeit an, die keine Aktion zum Auslösen kostet und jederzeit verwendet werden kann, wenn ihre Auslösebedingung erfüllt ist. Siehe auch \"[Fähigkeiten](#Abilities_Triggered_Abilities)\", \"[Anhang I: Abfolge einer Initiierung](#Appendix_I_Initiation_Sequence)\".\n\nEinem Ermittler ist es erlaubt, ausgelöste Fähigkeiten ([free]-, [reaction]- und [action]-Fähigkeiten) von folgenden Quellen zu verwenden:\n\n\n- Von einer Karte im Spiel, die er kontrolliert. Das beinhaltet seine Ermittlerkarte.\n\n\n- Von einer Szenariokarte, die im Spiel und am selben Ort wie der Ermittler ist. Das beinhaltet den Ort selbst, Begegnungskarten, die an den Ort angelegt sind, und alle Begegnungskarten in der Bedrohungszone jedes Ermittlers, der sich an diesem Ort befindet.\n\n\n- Von der aktuellen Szenen- oder Agendakarte.\n\n\n- Von jeder Karte, die dem Ermittler ausdrücklich erlaubt, ihre Fähigkeit zu aktivieren."
+   },
+   {
+      "id":"Triggering_Condition",
+      "title":"Auslösebedingung",
+      "text":"Eine Auslösebedingung gibt den Zeitpunkt an, an dem eine Fähigkeit ausgelöst werden darf. Die meisten Auslösebedingungen verwenden die Worte \"sobald\" oder \"nachdem\", um ihre Beziehung zum speziellen Zeitpunkt zu beschreiben.\n\n\n- Jede gültige Fähigkeit, die in Verbindung mit einem bestimmten Zeitpunkt ausgelöst wird, darf ein Mal ausgelöst werden, wenn der Zeitpunkt eintritt.\n\n\n- Falls mehrere Instanzen derselben Fähigkeit gültig initiiert werden können, darf jede Instanz ein Mal verwendet werden.\n\nSiehe auch \"[Fähigkeiten](#Ability)\", \"[Nachdem](#After)\", \"[Sobald](#When)\"."
+   },
+   {
+      "id":"Supplies",
+      "title":"Ausrüstung",
+      "cycle":[
+         "tfa",
+         "rttfa"
+      ],
+      "text":"Im Verlauf der Kampagne <i>Das vergessene Zeitalter</i> erhalten die Ermittler die Gelegenheit, Ausrüstung zu wählen, die sie auf ihre Expedition in die Wildnis mitnehmen können. Diese Ausrüstung wird im Kampagnenlogbuch im Abschnitt \"Ausrüstung\" jedes Ermittlers notiert.\n\nDie Ausrüstung wird mit Ausrüstungspunkten gekauft, die ein Ermittler erhält, wenn er die Gelegenheit dazu hat, Ausrüstung zu erwerben. Nicht ausgegebene Ausrüstungspunkte werden nicht notiert und gehen verloren.\n\nDie Ausrüstung eines Ermittlers entscheidet über seine Möglichkeiten während des Spiels und der Geschichte der Kampagne <i>Das vergessene Zeitalter</i>. <b>Ausrüstung selbst hat keinen Spieleffekt.</b> Einige Karteneffekte, Storymöglichkeiten und Auflösungen können sich verändern oder überhaupt erst zur Verfügung stehen, abhängig davon, welche Ausrüstung die Ermittler mit sich führen."
+   },
+   {
+      "id":"Elimination",
+      "title":"Ausscheiden",
+      "text":"Ein Spieler scheidet aus einem Szenario aus, sobald sein Ermittler besiegt worden ist oder er aufgibt. Ausgeschiedene Ermittler interagieren nicht mehr mit dem Spiel, außer wenn Werte \"pro Ermittler\" berechnet werden (siehe \"[Pro Ermittler](#Per_Investigator)\"). Immer wenn ein Spieler aus dem Spiel ausscheidet, geschieht Folgendes:\n\n0. In Bezug auf Schwächekarten ist das Spiel für den ausgeschiedenen Ermittler beendet. Alle\"Sobald das Spiel endet\"-Fähigkeiten auf jeder Schwäche, die der ausgeschiedene Ermittler besitzt und die im Spiel ist, werden ausgelöst. Dann werden jene Schwächen aus dem Spiel entfernt.\n\n1. Karten im Spiel, die der Spieler kontrolliert, und alle Karten in seinen Zonen außerhalb des Spiels (wie zum Beispiel Handkarten, Deck, Ablagestapel) werden aus dem Spiel entfernt.\n\n\n-- Karten im Spiel, die diesem Spieler gehören, die er aber nicht kontrolliert, bleiben im Spiel, aber sobald diese Karten das Spiel verlassen, werden sie aus dem Spiel entfernt.\n\n2. Alle Hinweismarker, die dieser Spieler besitzt, werden auf den Ort platziert, an dem sich der Ermittler befunden hat, als er ausgeschieden ist, und alle Ressourcenmarker dieses Spielers werden zurück in den Markervorrat gelegt.\n\n3. Alle Gegner, die mit diesem Spieler in einen Kampf verwickelt sind, werden an den Ort platziert, an dem der Ermittler war, als er aus dem Spiel ausgeschieden ist. Sie sind in keinen Kampf verwickelt, behalten aber ansonsten ihren aktuellen Spielstatus.\n\n4. Alle anderen Karten in der Bedrohungszone des ausgeschiedenen Ermittlers werden auf den entsprechenden Ablagestapel gelegt.\n\n5. Falls der Ermittlungsleiter das Spiel verlässt, wählen die verbliebenen Spieler (falls vorhanden) einen neuen Ermittlungsleiter.\n\n6. Falls es keine verbliebenen Spieler mehr gibt, endet das Szenario. Im Kampagnenleitfaden wird im Eintrag \"Falls keine Auf lösung erreicht wurde\" für das Szenario nachgelesen, was weiter geschieht."
+   },
+   {
+      "id":"Swarming X",
+      "cycle":[
+         "tde",
+         "tdea",
+         "tdeb",
+         "zdm"
+      ],
+      "scenarios":[
+         "war_of_the_outer_gods"
+      ],
+      "title":"Ausschwärmen X",
+      "text":"Ein Gegner mit dem Schlüsselwort Ausschwärmen X ist Teil einer größeren Gruppe von Gegnern, die gemeinsam vorgehen. Nachdem ein Spieler einen Gegner mit dem Schlüsselwort Ausschwärmen X ins Spiel gebracht hat, werden die obersten X Karten des Spielerdecks als sogenannte Schwarmkarten verdeckt unter dem Gegner platziert, ohne sie sich anzusehen. Der Gegner, unter dem die Schwarmkarten liegen, wird \"Wirtsgegner\" genannt. Manche Szenariokarteneffekte können einen Spieler dazu anweisen, einem Gegner Schwarmkarten hinzuzufügen. Dies geschieht nach demselben Verfahren.\n\n\n= Falls unklar ist, welcher Ermittler Schwarmkarten hinzufügen soll, macht dies der Ermittlungsleiter.\n\n\n= Jede Schwarmkarte unter dem Wirtsgegner agiert für die meisten Zwecke als eigenständige Instanz jenes Gegners. Jede Schwarmkarte hat die gleichen Werte und den gleichen Text wie die Wirtskarte.\n\n<i>Beispiel: Ist ein Ermittler mit einem Wirtsgegner in einen Kampf verwickelt, der 2 Schwarmkarten unter sich liegen hat, ist der Ermittler mit insgesamt 3 Gegnern in einen Kampf verwickelt.</i>\n\n\n= Jede Schwarmkarte greift einzeln an, sobald Gegner während der Gegnerphase angreifen. Haben der Wirtsgegner und alle seine Schwarmkarten in diesem Schritt angegriffen, werden sie alle erschöpft.\n\n\n= Jede Schwarmkarte kann unabhängig voneinander angegriffen werden und man kann jeder Schwarmkarte unabhängig voneinander Schaden zufügen, aber der Wirtsgegner kann nicht besiegt werden, solange er noch Schwarmkarten unter sich liegen hat. Sobald eine Schwarmkarte besiegt wird, darf überschüssiger Schaden einer anderen Schwarmkarte unter demselben Wirtsgegner oder dem Wirtsgegner selbst zugefügt werden.\n\n<i>Beispiel: [Tony Morgan](/card/06003) verwendet eine [41er Derringer](/card/01047), um einen [heimlichen Zoog](/card/06107) mit 2 Schwarmkarten anzugreifen. Der Angriff fügt 2 Schaden zu. Der erste Schadenspunkt besiegt 1 der 2 Schwarmkarten. Überschüssiger Schaden darf der anderen Schwarmkarte zugefügt werden, was ausreicht, um auch sie zu besiegen.</i>\n\n\n= Jedes Mal wenn eine Schwarmkarte das Spiel verlässt, wird sie unter das Deck ihres Besitzers platziert. Falls unklar ist, wer der Besitzer einer Schwarmkarte ist, darf man sie sich ansehen, um ihren Besitzer zu bestimmen.\n\n\n= Der Wirtsgegner und alle seine Schwarmkarten werden als Einheit bewegt, in Kämpfe verwickelt und erschöpft.\n\n<i>Beispiel: Gelingt es einem Ermittler, einem Wirtsgegner oder einer seiner Schwarmkarten zu entkommen, werden alle Karten dieser Einheit erschöpft und von dem Ermittler gelöst.</i>\n\n<b>FAQ:</b>\n\n\n- <i>F: Was passiert, wenn ein Gegner mit dem Schlüsselwort Ausschwärmen X sein Schlüsselwort verliert oder sein Textfeld so behandelt wird, als ob es leer wäre (wie z. B. durch [Geistesschlag](/card/01068))?</i>\n\nA: Das Schlüsselwort Ausschwärmen X wird nur abgehandelt, sobald der Gegner mit einem solchen Schlüsselwort ins Spiel kommt. Wenn dieser Gegner später sein Schlüsselwort verliert oder sein Textfeld als leer betrachtet wird, bleiben die Schwarmkarten weiterhin im Spiel und er gilt auch weiterhin als Wirtsgegner.\n\n\n- <i>F: Kann ich einen Karteneffekt verwenden, der einen Wirtsgegner ablegt, ohne ihn zu besiegen (wie z. B. durch [Das war knapp](/card/01083))?</i>\n\nA: Ein Wirtsgegner kann nicht besiegt werden, solange er noch Schwarmkarten unter sich liegen hat. Er kann jedoch abgelegt oder auf andere Weise entfernt werden. In einem solchen Fall verlassen seine Schwarmkarten ebenfalls das Spiel."
+   },
+   {
+      "id":"Automatic_Failure_Success",
+      "title":"Automatischer Erfolg/Misserfolg",
+      "text":"Einige Karten- und Markerfähigkeiten können dafür sorgen, dass eine Fertigkeitsprobe automatisch gelingt oder misslingt. Falls eine Fertigkeitsprobe automatisch gelingt oder misslingt, geschieht dies in Schritt \"FP. 6\" des \"[Timings von Fertigkeitsproben](#Skill_Test_Timing)\".\n\n\n- Falls eine Fertigkeitsprobe automatisch misslingt, wird der Gesamt-Fertigkeitswert des Ermittlers für diese Probe als 0 behandelt.\n\n\n- Falls eine Fertigkeitsprobe automatisch gelingt, wird die Gesamtschwierigkeit dieser Probe als 0 behandelt. Einige Karteneffekte führen dazu, dass einem Ermittler eine Fertigkeitsprobe automatisch gelingt oder misslingt. Falls dies geschieht, können abhängig vom Timing des Effekts manche Schritte der Fertigkeitsprobe komplett übersprungen werden.\n\n\n- Falls noch vor Schritt 3 (Chaosmarker enthüllen) klar ist, dass einem Ermittler die Fertigkeitsprobe automatisch gelingt oder misslingt, wird jener Schritt zusammen mit Schritt 4 übersprungen. Aus dem Chaosbeutel werden keine Chaosmarker enthüllt. Der Ermittler macht sofort mit Schritt 5 weiter. Alle anderen Schritte der Fertigkeitsprobe werden wie üblich abgehandelt.\n\n\n- Falls der Effekt eines Chaosmarkers dazu führt, dass einem Ermittler eine Fertigkeitsprobe automatisch gelingt oder misslingt, wird mit Schritt 3 und Schritt 4 wie üblich weitergemacht.\n\n\n- Falls eine Fähigkeit dazu führt, dass einem oder mehreren Gegnern \"automatisch entkommen wird\", ist dies nicht dasselbe wie ein automatischer Erfolg bei einem Entkommen-Versuch. Wie im Eintrag unter \"[Entkommen, Entkommen (Aktion)](#Evade)\" beschrieben, wird überhaupt keine Fertigkeitsprobe für einen Entkommen-Versuch abgelegt, wenn eine Fähigkeit automatisch 1 oder mehreren Gegnern entkommt. Weil keine Fertigkeitsprobe abgelegt wird, kann die Probe auch nicht als \"erfolgreiche\" Probe angesehen werden. Der Ermittler führt nur die Schritte durch, die abgehandelt werden, sobald er einem Gegner entkommt: Er erschöpft den Gegner und löst sich von ihm.\n\n<i>Beispiel: Patrice verwendet die Fähigkeit auf [Hope](/card/06031) mit dem Text: \"[action] Falls Hope spielbereit ist, erschöpfe ihn oder lege ihn ab: <b>Entkommen.</b> Versuche mit einem Grund-[agility]-Fertigkeitswert von 5 zu entkommen. (Falls du Hope abgelegt hast, gelingt diese Probe automatisch.)\" Wenn sich Patrice entscheidet, Hope abzulegen, gelingt die Fertigkeitsprobe automatisch, bevor Chaosmarker enthüllt werden. Deshalb werden Schritt 3 und Schritt 4 dieser Fertigkeitsprobe übersprungen. Die Fertigkeitsprobe findet aber statt. Karten dürfen noch immer zu der Probe beigetragen werden und der modifizierte Fertigkeitswert des Ermittlers wird immer noch bestimmt, da dies wichtig für andere Kartenfähigkeiten sein kann. Wenn Patrice stattdessen die Fähigkeit auf [Streunende Katze](/card/01076) verwenden würde, würde gar keine Fertigkeitsprobe abgelegt, da ihr Text lautet: \"[fast] Lege Streunende Katze ab: Du entkommst automatisch einem Nicht-Elite-Gegner an deinem Ort.\"</i>"
+   },
+   {
+      "id":"Exceptional",
+      "title":"Außergewöhnlich",
+      "text":"Außergewöhnlich ist eine Schlüsselwortfähigkeit für den Deckbau.\n\n\n- Um eine Karte mit dem Schlüsselwort Außergewöhnlich zu kaufen, muss man das Doppelte ihrer aufgedruckten Erfahrungspunkte bezahlen.\n\nEin Ermittlerdeck eines Spielers kann nicht mehr als 1 Kopie (nach Name) einer Karte mit Außergewöhnlich enthalten."
+   },
+   {
+      "id":"Basic_Action_types",
+      "title":"Basisaktion",
+      "text":"Eine Basisaktion ist eine Aktion, die ein Spieler vollständig ohne zusätzliche Modifikatoren oder Fähigkeiten ausführen kann, einschließlich fettgedruckter Aktionskennzeichen. Die folgenden Aktionen sind Basisaktionen: <b>Ziehen</b>, <b>Ressourcen</b>, <b>Bewegen</b>, <b>Ermitteln</b>, <b>Kampf</b>, <b>In einen Kampf verwickeln</b> und <b>Entkommen</b>.\n\n<b>Aktivieren</b>, <b>Spielen</b>, <b>Aufgeben</b> und <b>Verhandlung</b> sind keine Basisaktionen.\n\n<i>Beispiel: Ein Ermittler kann die Fähigkeit von [Den Kreis schließen](/card/08062) nutzen, um die Basisaktion <b>Kampf</b> auszuführen, aber er kann damit kein Ereignis mit einem <b>Kampf</b>-Aktionskennzeichen spielen, da das Spielen eines Ereignisses nicht als Basisaktion gilt.</i>"
+   },
+   {
+      "id":"Threat_Area",
+      "title":"Bedrohungszone",
+      "text":"Die Bedrohungszone eines Ermittlers ist die Spielzone, in die Begegnungskarten platziert werden, mit denen der Ermittler aktuell in einen Kampf verwickelt ist und/oder die Auswirkungen auf diesen Ermittler haben.\n\n\n- Die Karten in der Bedrohungszone eines Ermittlers befinden sich am selben Ort wie der Ermittler."
+   },
+   {
+      "id":"Encounter_Deck",
+      "title":"Begegnungsdeck",
+      "text":"Das Begegnungsdeck enthält die Begegnungskarten (Gegner-, Verratsund Storyvorteilskarten), auf welche die Ermittler in einem Szenario treffen können.\n\n\n- Falls das Begegnungsdeck leer ist, wird der Begegnungs-Ablagestapel zurück in das Begegnungsdeck gemischt."
+   },
+   {
+      "id":"Encounter_Cards_Vs_Scenario_Cards",
+      "title":"\"Begegnungskarten\" gegen \"Szenariokarten\"",
+      "text":"Diese zwei Begriffe sind austauschbar und beschreiben Nicht-Spielerkarten, die in einem Szenario verwendet werden. Dazu zählen die Karten des Begegnungsdecks, Orte, Agenden, Szenarien, die Szenarioübersichtskarte usw."
+   },
+   {
+      "id":"Encounter_Set",
+      "title":"Begegnungsset",
+      "text":"Ein Begegnungsset ist eine Gruppe von Begegnungskarten, erkennbar an dem gemeinsamen Begegungssetsymbol neben dem Kartentyp."
+   },
+   {
+      "id":"Set_Aside",
+      "title":"Beiseitelegen",
+      "text":"Einige Szenarien weisen die Spieler an bestimmte Karten beiseitezulegen. Beiseitegelegte Karten interagieren nicht mit dem Spiel, bis sich Anweisungen des Szenarios oder einer Kartenfähigkeit auf sie beziehen.\n\nFalls ein Effekt einen Ermittler dazu anweist, die Kontrolle über eine derzeit beiseitegelegte Karte zu übernehmen, bringt der Effekt jene Karte in der Spielzone jenes Ermittlers ins Spiel."
+   },
+   {
+      "id":"Limits_and_Maximums",
+      "title":"Beschränkung und Maximum",
+      "text":"<b>\"Nur X pro [Zeitraum]\"</b> ist eine Beschränkung, die auf Karten zu finden ist, die nach der Abhandlung eines Fähigkeit-Effektes im Spiel bleiben. Jede Instanz einer Fähigkeit mit einer solchen Beschränkung darf während des angegebenen Zeitraums X Mal initiiert werden. Falls eine Karte das Spiel verlässt und während desselben Zeitraums erneut ins Spiel kommt, wird die Karte behandelt, als würde sie eine neue Instanz der Fähigkeit ins Spiel bringen.\n\n<b>\"Nur X pro \"[Karte/Spielelement]\"</b> ist eine Beschränkung auf Verstärkungskarten und beschränkt die Anzahl der Kopien dieser Karte (nach Name), die an jede festgelegte Karte oder jedes festgelegte Spielelement angehängt werden können.\n\n\n-- Falls nicht anders angegeben, gelten diese Beschränkungen für jeden Spieler individuell.\n\n\n-- Eine \"Gruppenbeschränkung\" dagegen wird auf die gesamte Ermittler-Gruppe angewendet. (<i>Beispiel: Falls ein Ermittler eine Fähigkeit auslöst, die die Beschränkung \"Gruppenlimit nur ein Mal pro Spiel\" hat, darf kein weiterer Ermittler während des Spiels diese Fähigkeit auslösen.</i>)\n\n<b>\"Max. X pro [Dauer]\"</b> legt eine Maximalzahl für alle Kopien einer Karte (nach Namen) für alle Spieler fest. Normalerweise gibt dieser Begriff an, wie oft im angegebenen Zeitraum eine Kopie dieser Karte maximal gespielt werden darf. Falls ein Maximum das Wort \"beitragen\" enthält (<i>Beispiel: \"Max. 1 pro Fertigkeitsprobe beitragen\"</i>), legt es fest, wie viele Kopien dieser Karte im angegebenen Zeitraum zu Fertigkeitsproben beigetragen werden dürfen. Falls ein Maximum als Teil einer Fähigkeit angegeben ist, gibt es an, wie oft die Fähigkeit von allen Kopien der Karte (nach Name), die diese Fähigkeit haben (einschließlich der Karte selbst), im angegebenen Zeitraum maximal initiiert werden kann.\n\nFalls der Effekt einer Karte oder Fähigkeit mit einer Beschränkung oder einem Maximum aufgehoben wird, zählt er im Hinblick auf die Beschränkung/das Maximum immer noch mit, da die Fähigkeit initiiert wurde.",
+      "rules":[
+         {
+            "id":"Limits_Pertaining_to_Play_Areas",
+            "title":"Beschränkungen im Bezug auf Spielzonen",
+            "text":"Manche Beschränkungen beziehen sich auf bestimmte Spielzonen, wie z. B. \"Nur 1 pro Deck\", \"Nur 1 im Siegpunktestapel \" oder \"Nur 1 im Spiel\". Diese Beschränkung bezieht sich auf die Anzahl Kopien jener Karte (nach Name), die in einer bestimmten Spielzone existieren dürfen. Eine weitere Kopie jener Karte kann nicht in die bestimmte Spielzone kommen, falls die angegebene Beschränkung bereits erreicht ist. Beschränkungen gelten für jeden Spieler individuell, falls nichts anderes angegeben ist.\n\n<i>Beispiel: Eine Karte mit \"Nur 1 pro Deck\" kann in den Decks zweier verschiedener Ermittler existieren)</i>.\n\n<i>Anmerkung: \"Nur X pro Ermittler\" ist eine Beschränkung, die sich auf die Spielzone eines Ermittlers bezieht.</i>"
+         }
+      ]
+   },
+   {
+      "id":"Defeat",
+      "title":"Besiegt",
+      "text":"Ein Ermittler, Gegner oder eine Vorteilskarte kann durch das Nehmen von Schaden/Horror besiegt werden.\n\n\n- Falls ein Ermittler Schaden in Höhe seiner Ausdauer (oder höher) hat, ist dieser Ermittler besiegt (dasselbe gilt für Horror in Höhe seiner geistigen Gesundheit). Ein Ermittler kann auch durch eine Kartenfähigkeit besiegt werden. Sobald ein Ermittler besiegt ist, scheidet er aus dem Szenario aus (siehe \"[Ausscheiden](#Elimination)\").\n\n\n- Im Kampagnenspiel erleidet ein Ermittler, der durch Schaden in Höhe seiner Ausdauer besiegt worden ist, 1 körperliches Trauma. Ein Ermittler, der durch Horror in Höhe seiner geistigen Gesundheit besiegt worden ist, erleidet 1 seelisches Trauma. Durch das Erleiden eines Traumas kann ein Ermittler getötet oder wahnsinnig werden (siehe \"[Kampagnenspiel](#Campaign_Play)\").\n\n\n- Falls ein Gegner Schaden in Höhe seiner Ausdauer (oder höher) hat, ist dieser Gegner besiegt und wird auf den Begegnungs-Ablagestapel gelegt (oder auf den Ablagestapel ihres Besitzers, falls es eine Schwäche ist).\n\n\n- Falls eine Vorteilskarte mit einem Ausdauerwert Schaden in Höhe ihrer Ausdauer (oder höher) hat, ist sie besiegt. Falls eine Vorteilskarte mit einem Wert für geistige Gesundheit Horror in Höhe ihrer geistigen Gesundheit (oder höher) hat, ist sie besiegt. Eine besiegte Vorteilskarte wird auf den Ablagestapel ihres Besitzers gelegt."
+   },
+   {
+      "id":"Ownership_and_Control",
+      "title":"Besitz und Kontrolle",
+      "text":"Der Besitzer einer Karte ist der Spieler, in dessen Deck (oder Spielzone) sich die Karte zu Beginn des Spiels befunden hat.\n\nEin Spieler kontrolliert Karten, die sich in seinen Zonen außerhalb des Spiels befinden (wie Handkarten, Deck, Ablagestapel).\n\nDas Szenario kontrolliert die Karten in den Zonen außerhalb des Spiels (wie Begegnungs-, Szenen- und Agendadeck und den Begegnungs-Ablagestapel).\n\n\n- Normalerweise kommen Karten unter der Kontrolle ihres Besitzers ins Spiel. Einige Fähigkeiten können dafür sorgen, dass die Kontrolle über eine Karte im Verlauf des Spiels wechselt.\n\n\n- Falls eine Karte in eine Zone außerhalb des Spiels kommen würde, die nicht dem Besitzer der Karte gehört, wird die Karte stattdessen in die entsprechende Nicht-Im-Spiel-Zone ihres Besitzers platziert. Die Karte wird behandelt, als hätte sie die Nicht-Im-Spiel-Zone des Spielers, der sie kontrolliert, betreten, und nur die Stelle, an welche die Karte tatsächlich platziert wird, wird angepasst."
+   },
+   {
+      "id":"Prey",
+      "title":"Beute",
+      "text":"Wenn sie die Möglichkeit haben, verfolgen einige Gegner einen bestimmten Ermittler. Diese Gegner kann man an dem fettgedruckten Wort \"<b>Beute</b>\" in ihrem Textfeld erkennen, gefolgt von Anweisungen, welchen Ermittler sie in einen Kampf verwickeln sollen.\n\n\n- Falls ein Gegner, der einen Ermittler an seinem Ort automatisch in einen Kampf verwickeln soll, mehrere Möglichkeiten hat, verwickelt der Gegner den Ermittler in einen Kampf, der seine Beute-Anweisung am besten erfüllt (falls es einen Gleichstand bei der Erfüllung dieser Anweisung gibt, darf der Ermittlungsleiter zwischen den Ermittlern wählen, siehe \"[Gegner in einen Kampf verwickeln](#Enemy_Engagement)\").\n\n\n- Falls ein Gegner, der sich auf den nächstgelegenen Ermittler zubewegt, die Wahl zwischen zwei gleich weit entfernten Ermittlern hat, muss sich dieser Gegner zwischen ihnen für den Ermittler entscheiden, der seine \"Beute\"-Anweisung am besten erfüllt. (Falls mehrere Ermittler die Beutekriterien erfüllen, entscheidet der Ermittlungsleiter zwischen diesen Ermittlern, siehe \"[Jäger](#Hunter)\").\n\n\n- Falls die Beuteanweisung eines Gegners das Wort \"nur\" enthält, bewegt sich dieser Gegner nur auf diesen Ermittler zu und verwickelt auch nur ihn in einen Kampf (als ob er der einzige Ermittler im Spiel wäre), und ignoriert alle anderen Ermittler bei der Bewegung und dem Verwickeln in einen Kampf. Andere Ermittler dürfen die Aktion \"In einen Kampf verwickeln\" oder eine Kartenfähigkeit verwenden, um diesen Gegner in einen Kampf zu verwickeln.\n\n\n- Beute hat keinen unmittelbaren Effekt darauf, wo ein Gegner erscheinen wird (siehe \"[Erscheinen](#Spawn)\")."
+   },
+   {
+      "id":"Move",
+      "title":"Bewegen",
+      "text":"Immer wenn sich eine Entität (ein Ermittler oder Gegner) bewegt, wird die Gegnerkarte oder die kleine Ermittlerkarte vom aktuellen Ort auf einen anderen Ort verschoben.\n\n\n- Falls durch den Bewegungseffekt oder die Fähigkeit nicht anders angegeben, muss die sich bewegende Einheit auf einen verbundenen Ort bewegt werden. Welche Orte verbunden sind, kann man auf der aktuellen Ortskarte der Entität erkennen (siehe unten).\n\n\n- Immer wenn sich eine Entität bewegt, wird sie behandelt, als würde sie den aktuellen Ort verlassen und gleichzeitig den neuen Ort betreten.\n\n\n- Falls eine Entität zu einem angegebenen Ort \"bewegt wird\", wird diese Entität direkt auf diesen Ort bewegt und bewegt sich nicht auf dem Weg dorthin durch andere Orte.\n\n\n- Falls sich ein Ermittler an einen verhüllten Ort bewegt, wird dieser Ort enthüllt, indem er auf die andere Seite gedreht wird, und es werden Hinweise entsprechend des Hinweiswertes des Ortes auf ihn platziert. Die meisten Hinweiswerte sind Werte \"pro Ermittler\" ([per_investigator]).\n\n\n- Falls sich ein Gegner auf einen verhüllten Ort bewegt, bleibt dieser Ort verhüllt.\n\n\n- Spielelemente (Marker oder Karten) können ebenfalls durch Kartenfähigkeiten von einer Karte auf eine andere Karte oder von einer Spielzone in eine andere Spielzone bewegt werden.\n\n\n- Sobald sich eine Entität oder ein Spielelement bewegt, kann es sich nicht zu seinem gleichen (d.h. seinem aktuellen) Standort bewegen. Falls es kein legales Ziel für eine Bewegung gibt, kann die Bewegung nicht versucht werden."
+   },
+   {
+      "id":"Move_Action",
+      "title":"Bewegen (Aktion)",
+      "text":"\"Bewegen\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. Sobald ein Ermittler diese Aktion nimmt, wird dieser Ermittler (die kleine Ermittlerkarte) auf einen anderen Ort bewegt. Der neue Ort muss mit einer Markierung versehen sein, die anzeigt, dass der neue Ort mit dem aktuellen Ort des Ermittlers verbunden ist (siehe \"[Bewegen](#Move)\")."
+   },
+   {
+      "id":"unless_all_clues_have_been_discovered",
+      "title":"\"… bis alle Hinweise (auf dem Ort) entdeckt worden sind.\"",
+      "text":"Manche Orte haben Fähigkeiten, die verhindern, dass eine Ort betreten werden kann oder ein bestimmter Gegner verwendet werden kann, bis alle an einem bestimmten Ort entdeckt worden sind, (<i>z. B. [Lokomotive](/card/51028)</i>). Bei der Interpretation einer solchen Fähigkeit sind verhüllte Orte (die von sich aus keine Hinweise auf sich liegen haben können) nicht ausreichend für die Fähigkeit. Es muss sich um Orte handeln, die zu einem bestimmten Zeitpunkt im Spiel enthüllt worden sind."
+   },
+   {
+      "id":"Chaos_Tokens",
+      "title":"Chaosmarker",
+      "text":"Aus dem Chaosbeutel werden während Fertigkeitsproben Chaosmarker enthüllt, um die Ergebnisse der Fertigkeitsproben zu modifizieren oder zu beeinflussen.\n\n[skull] [cultist] [elder_thing] [tablet] – Falls einer dieser Marker für eine Fertigkeitsprobe enthüllt wird, handelt man den Effekt des entsprechenden Symbols auf der Szenarioübersichtskarte des aktuellen Szenarios ab.\n\n[auto_fail] – Dieser Marker bedeutet, dass die Probe automatisch misslingt. Falls dieser Marker in einer Fertigkeitsprobe enthüllt wird, bedeutet dies, dass dem Ermittler die Probe automatisch misslingt (siehe \"[Automatischer Erfolg/Misserfolg](#Automatic_Failure_Success)\").\n\n[elder_sign] – Dies ist der Ältere-Zeichen-Marker. Falls dieser Marker bei einer Fertigkeitsprobe enthüllt wird, wird der [elder_sign]-Effekt auf der Ermittlerkarte des Spielers abgehandelt, der die Fertigkeitsprobe durchführt.\n\nFalls der enthüllte Chaosmarker (oder der Effekt, auf den sich dieser Chaosmarker bezieht) einen numerischen Modifikator hat, wird dieser Modifikator auf den Fertigkeitswert des Ermittlers für diese Probe angewendet.\n\nSiehe \"[FP.3 Chaosmarker enthüllen](#Skill_Test_Timing)\".",
+      "rules":[
+         {
+            "id":"Bless_and_Curse_Tokens",
+            "cycle":[
+               "tic"
+            ],
+            "title":"Segensmarker und Fluchmarker",
+            "text":"In der Erweiterung <i>Die-Innsmouth-Verschwörung</i> werden 2 neue Chaosmarker eingeführt: Segensmarker ([bless]) und Fluchmarker ([curse]). Normalerweise enthält der Chaosbeutel keine [bless]- oder [curse]-Marker. Durch bestimmte Karteneffekte können diese Marker dem Chaosbeutel hinzugefügt werden.\n\n\n= Während einer Fertigkeitsprobe enthüllte [bless]-Marker haben folgende Effekte: \"+2. Enthülle einen weiteren Marker. Lege diesen Marker in den Markervorrat zurück, anstatt ihn in den Chaosbeutel zurückzuschicken.\" Insgesamt können sich nicht mehr als 10 [bless]-Marker gleichzeitig im Chaosbeutel und/oder versiegelt auf Karten im Spiel befinden.\n\n\n= Während einer Fertigkeitsprobe enthüllte [curse]-Marker haben folgende Effekte: \"–2. Enthülle einen weiteren Marker. Lege diesen Marker in den Markervorrat zurück, anstatt ihn in den Chaosbeutel zurückzuschicken.\" Insgesamt können sich nicht mehr als 10 [curse]-Marker gleichzeitig im Chaosbeutel und/oder versiegelt auf Karten im Spiel befinden.\n\n\n= [bless]- oder [curse]-Marker, die außerhalb einer Fertigkeitsprobe enthüllt werden, haben keinen eigenständigen Effekt, es sei denn, ein Karteneffekt besagt etwas anderes.\n\n<b>FAQ:</b>\n\n\n- <i>F: Haben [bless]- und [curse]-Marker Modifikatoren oder Werte, falls sie außerhalb einer Fertigkeitsprobe enthüllt werden?</i>\n\nA: Nein. Außerhalb einer Fertigkeitsprobe enthüllte [bless]- und [curse]-Marker haben keine Modifikatoren und keine Werte.\n\n\n- <i>Was passiert, wenn du durch einen Teil eines Fähigkeitseffekts dem Chaosbeutel eine bestimmte Anzahl an [bless]- oder [curse]-Markern hinzufügen musst, aber nicht mehr genug [bless]- oder [curse]-Marker übrig sind, um den Effekt zu erfüllen?</i>\n\nA: Du führst so viel von der Fähigkeit durch, wie du kannst. In dem Fall fügst du dem Chaosbeutel so viel [bless]- und [curse]-Marker hinzu, bis keine mehr da sind.\n\n\n- <i>F: Was passiert, wenn du als Teil der Kosten eines Fähigkeits- oder Karteneffekts dem Chaosbeutel eine bestimmten Anzahl an [bless]- oder [curse]-Markern hinzufügen musst, aber nicht mehr genug [bless]- oder [curse]-Marker übrig sind, um die Kosten zu bezahlen?</i>\n\nA: Wenn die Kosten nicht bezahlt werden können, kann die Karte/Fähigkeit nicht gespielt/ausgelöst werden.\n\n\n- <i>F: Verbleiben [bless]- und [curse]-Marker im Verlauf einer Kampagne von Szenario zu Szenario im Chaosbeutel?</i>\n\nA: Nein. [bless]- und [curse]-Marker verbleiben im Verlauf der Kampagne von Szenario zu Szenario nicht im Chaosbeutel.\n\n\n- <i>F: Wann genau werden [bless]- und [curse]-Marker aus dem Chaosbeutel entfernt? Sind sie bei der Auflösung eines Szenarios noch Teil des Chaosbeutels?</i>\n\nA: Ja. [bless]- und [curse]-Marker werden erst nach der Auflösung eines Szenarios aus dem Chaosbeutel entfernt, wenn das Spiel aufgeräumt wird. Das passiert, bevor mit anschließenden Zwischenspielen weitergemacht wird, außer es ist etwas anderes angegeben."
+         },
+         {
+            "id":"Frost_Tokens",
+            "cycle":[
+               "eoe"
+            ],
+            "title":"Frost Tokens",
+            "text":"In der Erweiterung <i>Am Rande der Welt</i> wird ein neuer Chaosmarker eingeführt: Der Frostmarker ([frost]). Zu Beginn der Kampagne Am Rande der Welt enthält der Chaosbeutel (wenn überhaupt) nur sehr wenige [frost]-Marker, was für die Ermittler noch recht harmlos ist. Im weiteren Verlauf der Expedition, abhängig von den Entscheidungen der Ermittler und den eingetretenen Ereignissen, können mehr [frost]-Marker dem Chaosbeutel hinzugefügt (oder aus ihm entfernt) werden, wodurch sich die Schwierigkeit von Proben für die Ermittler verändert. Je mehr Frostmarker sich im Chaosbeutel befinden, umso verhängnisvoller werden ihre Effekte.\n\n\n= Der erste während einer Fertigkeitsprobe enthüllte [frost]-Marker hat folgenden Effekt: \"–1. Enthülle einen weiteren [frost]-Marker.\" Falls ein weiterer [frost]-Marker während der gleichen Probe enthüllt wird, endet der Schritt \"Chaosmarker enthüllen\" der Fertigkeitsprobe sofort und die Probe gilt automatisch als misslungen. <i>(Am Ende der Probe werden alle enthüllten [frost]-Marker in den Chaosbeutel zurückgeschickt.)</i>\n\n<i>Beispiel: Bob ermittelt an einem Ort und es befinden sich 2 [frost]-Marker im Chaosbeutel. Während Bobs erstem Ermittlungsversuch enthüllt er einen [frost]-Marker. Dieser verringert seinen Fertigkeitswert um 1 und zwingt ihn, einen weiteren Marker zu enthüllen. Der nächste enthüllte Marker ist eine \"+1\", was zur Folge hat, dass beide Marker zusammen den Fertigkeitswert um 0 modifizieren. Bobs Probe gelingt! Davon ermutigt, versucht Bob ein zweites Mal zu ermitteln. Dieses Mal enthüllt er einen [frost]-Marker, gefolgt von einem zweiten [frost]-Marker. Bob darf keine weiteren Marker mehr enthüllen und muss die Ermittlung automatisch als misslungen abhandeln.</i>\n\n\n= Insgesamt können sich nicht mehr als 8 [frost]-Marker im Chaosbeutel und/oder versiegelt auf Karten im Spiel befinden.\n\n\n= Ein [frost]-Marker, der außerhalb einer Fertigkeitsprobe enthüllt wird, hat keinen eigenständigen Effekt, es sei denn, ein Karteneffekt besagt etwas anderes.\n\n\n= Ein [frost]-Marker, der dem Chaosbeutel hinzugefügt wird, bleibt von Szenario zu Szenario im Chaosbeutel, es sei denn, er wird durch einen Karten- oder Spieleffekt entfernt. Die App merkt sich den Zustand des Chaosbeutel beim Hinzufügen/Entfernen automatisch."
+         },
+         {
+            "id":"Resolving_Multiple_Revealed_Chaos_Tokens",
+            "title":"Abhandlung mehrerer enthüllter Chaosmarker",
+            "text":"Falls ein Ermittler dazu angewiesen wird, mehrere enthüllte Chaosmarker \"abzuhandeln\" , wird jeder Spiel- und Karteneffekt, der sich im Singular auf \"den enthüllten Chaosmarker\" bezieht, auf alle enthüllten Chaosmarker angewendet. Sobald z. B. die Effekte des Chaosmarker in Schritt 4 einer Fertigkeitsprobe oder die Modifikatoren für den Fertigkeitswert in Schritt 5 einer Fertigkeitsprobe angewendet werden, sollten die Effekte und Modifikatoren aller abgehandelten Chaosmarker angewendet werden, auch wenn in den Regeln von \"dem enthüllten Chaosmarker\" die Rede ist. Gleiches gilt für Karteneffekte, die sich auf \"den enthüllten Chaosmarker\" beziehen. Auch hier wird Bezug auf alle abgehandelten Chaosmarker genommen.\n\n<i>Beispiel: Ein Ermittler spielt [Vorahnung](/card/04199) mit dem Text: \"Bringe Vorahnung ins Spiel, enthülle einen zufälligen Chaosmarker aus dem Chaosbeutel und versiegle ihn auf Vorahnung.\" Dann verwendet dieser Ermittler [Olive McBride](/card/04197), \"um 3 Chaosmarker statt 1 zu enthüllen, 2 jener Marker zu wählen und abzuhandeln und die anderen zu ignorieren\" . In diesem Fall würden beide der abgehandelten Chaosmarker auf Vorahnung versiegelt werden, auch wenn sich Vorahnung nur auf einen aufgedeckten Chaosmarker im Singular bezieht. Gleiches gilt auch für die Erzwungen-Fähigkeit auf Vorahnung: \"Handle stattdessen den hier versiegelten Marker ab, als ob er gerade aus dem Chaosbeutel enthüllt worden wäre.\" In diesem Fall würden beide versiegelten Marker abgehandelt werden.</i>\n\nZusätzlich gilt, dass bei der Abhandlung von mehreren Chaosmarkern jeder Spiel-oder Karteneffekt, der bei einem bestimmten enthüllten Chaosmarker ausgelöst werden würde, – wie z. B. die Fähigkeit auf [Erinnerungen an die Zukunft](/card/04158): \"Falls der benannte Chaosmarker während dieser Fertigkeitsprobe enthüllt wird …\" ) – ausgelöst wird, falls einer der abgehandelten Chaosmarker die entsprechende Bedingung erfüllt.\n\nZu beachten ist, dass dieser Eintrag nur bei mehreren Chaosmarkern angewendet wird, die auch \"abgehandelt\" werden. Falls mehrere Chaosmarker enthüllt werden und alle bis auf 1 aufgehoben oder ignoriert werden, findet dieser Eintrag keine Anwendung."
+         }
+      ]
+   },
+   {
+      "id":"Checkpoints",
+      "cycle":[
+         "eoe"
+      ],
+      "title":"Checkpoints",
+      "text":"Einige der Szenarien in der Kampagne <i>Am Rande der Welt</i> sind in mehrere Teile aufgeteilt. Spieler können jeden Teil einzeln (mit Unterbrechung) oder mehrere Teile nacheinander als Teil einer längeren Sitzung spielen. Jeder Teil gilt als eigenständiges Spiel mit eigener Szenariovorbereitung und Auf lösung.\n\nNachdem ein Teil eines Szenarios abgeschlossen wurde, führt der Kampagnenleitfaden die Ermittler zu einem Checkpoint, der sie anweist, wie weiter fortzufahren ist. Falls die Ermittler direkt mit dem nächsten Teil des Szenarios fortfahren möchten, weist der Checkpoint sie an, wie das Spiel aufgeräumt und für den nächsten Teil des Szenarios vorbereitet wird. Falls die Ermittler pausieren und das Spiel zu einem späteren Zeitpunkt fortführen möchten, weist der Checkpoint sie an, bestimmte Informationen im Kampagnenlogbuch zu notieren, um die Vorbereitung für die nächste Spielsitzung zu vereinfachen."
+   },
+   {
+      "id":"Then",
+      "title":"Dann",
+      "text":"Falls der Effekt einer Fähigkeit das Wort \"dann\" enthält, muss der Text vor dem Wort \"dann\" erfolgreich und vollständig abgehandelt werden, bevor der Rest des Effektes nach dem Wort \"dann\" abgehandelt werden kann.\n\n\n- Falls der Teil eines Effektes vor dem \"dann\" erfolgreich und vollständig abgehandelt wird, muss der Teil des Effektes nach dem \"dann\" ebenfalls abgehandelt werden.\n\n\n- Der Teil des Effektes nach dem \"dann\" hat Timing-Vorrang vor allen anderen indirekten Konsequenzen der Abhandlung des Teils vor dem \"dann\".\n\n<i>Beispiel: Falls ein Effekt lautet: \"Ziehe eine Begegnungskarte. Dann nimmst du 1 Horror\" und ein Spieler eine Fähigkeit mit dem Text \"Nachdem du eine Begegnungskarte gezogen hast\" kontrolliert, tritt der Teil \"Dann nimmst du 1 Horror\" ein, bevor die \"Nachdem du eine Begegnungskarte gezogen hast\" -Fähigkeit initiiert werden kann.</i>\n\n\n- Falls der Teil eines Effektes vor dem \"dann\" nicht erfolgreich und vollständig abgehandelt wird, wird der Teil des Effektes nach dem \"dann\" nicht abgehandelt."
+   },
+   {
+      "id":"Leaves_Play",
+      "title":"Das Spiel verlassen",
+      "text":"Der Begriff \"das Spiel verlassen\" bezieht sich auf jeden Zeitpunkt, an dem eine Karte vom \"im Spiel\"-Status in den \"nicht im Spiel\"-Status übergeht (siehe \"[Im Spiel/Nicht im Spiel](#In_Play_and_Out_of_Play)\")\"). Falls eine Karte das Spiel verlässt, treten folgende Konsequenzen gleichzeitig in dem Moment ein, in dem die Karte das Spiel verlässt.\n\n\n- Alle Marker auf der Karte werden zurück in den Markervorrat gelegt.\n\n\n- Alle Verstärkungen an der Karte werden abgelegt.\n\n\n- Andauernde und/oder aufgeschobene Effekte, die diese Karte betroffen haben, solange sie im Spiel war, hören für diese Karte auf zu wirken."
+   },
+   {
+      "id":"Permanent",
+      "title":"Dauerhaft",
+      "text":"Dauerhaft ist eine Schlüsselwortfähigkeit für den Deckbau.\n\n\n- Eine Karte mit dem Schlüsselwort Dauerhaft zählt nicht gegen die Deckgröße.\n\n\n- Eine Karte mit dem Schlüsselwort Dauerhaft zählt aber weiterhin als Teil des Decks und muss deswegen alle anderen Einschränkungen beim Deckbau beachten.\n\n\n- Eine Karte mit dem Schlüsselwort Dauerhaft ist zu Beginn jedes Spiels im Spiel und wird während der Vorbereitung nicht in das Ermittlerdeck gemischt.\n\n\n- Eine Karte mit dem Schlüsselwort Dauerhaft kann durch nichts das Spiel verlassen (außer durch Ausscheiden).\n\n\n- Einmal zu deinem Deck hinzugefügt, können permanente Karten nicht mehr aus deinem Deck entfernt oder ausgetauscht werden, es sei denn, es ist ausdrücklich anders angegeben.\n\nSiehe \"[Kontrolle und Anhängen von Dauerhaft-Karten](#Controlling_and_Attaching_Permanent_Cards)\"."
+   },
+   {
+      "id":"Deckbuilding",
+      "title":"Deckbau",
+      "text":"Beim Bau eines eigenen Decks müssen folgende Richtlinien beachtet werden:\n\n\n- Der Spieler muss genau 1 Ermittlerkarte wählen.\n\n\n- Das Ermittlerdeck eines Spielers muss exakt so viele Spielerkarten enthalten, wie auf der Rückseite der Ermittlerkarte als \"Deckgröße\" angegeben ist. Schwächen, ermittlerspezifische Karten und Szenariokarten, die einem Spielerdeck hinzugefügt werden, zählen dabei nicht mit.\n\n\n- Ein Ermittlerdeck eines Spielers darf nicht mehr als 2 Kopien (nach Name) einer Spielerkarte enthalten.\n\n\n- Jede normale Spielerkarte im Deck eines Spielers muss unter Beachtung der \"Deckbauoptionen\" auf der Rückseite seiner Ermittlerkarte ausgesucht werden.\n\n\n- Die meisten Ermittler haben zu Beginn einer Kampagne 0 Erfahrungspunkte, die sie ausgeben können, was bedeutet, dass ihre Decks nur Karten der Stufe 0 enthalten dürfen. Einige Ermittler und/oder einige Kampagnen können einem Spieler zu Beginn der Kampagne zusätzliche Erfahrungspunkte gewähren, die sofort zum Kauf höherstufiger Karten verwendet werden können (siehe \"[Kampagnenspiel](#Campaign_Play)\").\n\n\n- Alle anderen \"Deckbau-Voraussetzungen\" auf der Rückseite der Ermittlerkarte eines Spielers müssen ebenfalls eingehalten werden.\n\n\n- Jede geforderte zufällige Grundschwäche wird dem Deck am Ende des Deckbaus hinzugefügt.\n\n\n- Storyvorteile dürfen nicht zu Spielerdecks hinzugefügt werden, es sei denn, die Vorbereitung oder die Auf lösung eines Szenarios erlaubt dies dem Spieler. Diese Vorteilskarten sind daran zu erkennen, dass sie keine Kartenstufe und kein Begegnungssetsymbol haben (siehe \"[Vorteilskarten](#Asset_Cards)\").\n\n\n- Während einer Kampagne bauen die Spieler ihre Decks, bevor sie das erste Szenario spielen. Zwischen den Szenarien können die Spieler neue Karten erwerben oder Karten in ihren Decks verbessern, indem sie die Regeln unter \"[Kampagnenspiel](#Campaign_Play)\" befolgen.\n\n\n- Falls 1 oder mehr Karten zwangsweise aus dem Deck eines Ermittlers entfernt und in die Sammlung zurückgelegt werden (z. B. sobald eine Karte ins Exil geschickt wird oder sobald ein Kampagneneffekt einen Ermittler dazu zwingt, Karten aus seinem Deck zu entfernen), muss der Ermittler Karten erwerben, sodass seine legale Deckgröße aufrechterhalten werden kann. Wenn er auf diese Weise Karten erwirbt, darf der Ermittler Karten der Stufe 0 für die Kosten von 0 Erfahrungspunkten erwerben, bis sein Deck wieder die legale Deckgröße erreicht hat.\n\n\n- Diese Regel findet auch dann Anwendung, falls ein Effekt die Deckgröße, die Deckbau-Einschränkungen oder die Deckbau-Optionen eines Ermittlers verändert, sodass als Ergebnis 1 oder mehr Karten aus dem Deck entfernt oder dem Deck hinzugefügt werden müssen.",
+      "rules":[
+         {
+            "id":"Classes",
+            "title":"Klassen",
+            "text":"Die meisten Spielerkarten, einschließlich der Ermittler, gehören zu einer der 5 Klassen. Jede Klasse hat wie unten beschrieben ihre eigene Hintergrundgeschichte und ihre eigene Identität.\n\n<b>Wächter</b> ([guardian]) fühlen den Drang, die Menschheit zu beschützen und scheuen deshalb keine Mühen bei der Bekämpfung der Mächte des Mythos. Durch ihr ausgeprägtes Pflichtbewusstsein und ihre Selbstlosigkeit werden sie dazu getrieben, andere zu beschützen und Monster zur Strecke zu bringen.\n\n<b>Mystiker</b> ([mystic]) werden von den arkanen Kräften des Mythos angezogen und von ihnen beeinf lusst. Viele von ihnen haben Spruchfähigkeiten und sind in der Lage, die Kräfte des Universums durch ihr magisches Talent zu beeinflussen.\n\n<b>Schurken</b> ([rogue]) sind selbstsüchtig und ichbezogen. Sie sind listig und opportunistisch, immer auf der Suche nach einer Möglichkeit, Vorteile aus der aktuellen Situation zu schlagen.\n\n<b>Sucher</b> ([seeker]) wollen in erster Linie mehr über die Welt und den Mythos lernen. Ihr Wunsch ist es, vergessenes Wissen zu erforschen, unkartierte Bereiche zu kartieren und fremdartige Kreaturen zu erforschen.\n\n<b>Überlebende</b> ([survivor]) sind normale Menschen, die sich zur falschen Zeit am falschen Ort befinden und einfach versuchen zu überleben. Da sie schlecht vorbereitet und ausgerüstet sind, stellen sie Außenseiter dar, die jede sich bietende Gelegenheit zum Überleben ergreifen, wenn ihr Leben in Gefahr ist.\n\nEinige Karten gehören zu keiner Klasse; diese Karten sind neutral. Normalerweise haben Ermittler nur Zugriff auf Karten ihrer Klasse.\n\nEinige Ermittler haben Zugriff auf Karten anderer Klassen. Auf welche Karten ein Ermittler Zugriff hat, kann unter dem Absatz \"Deckbau-Optionen\" auf der Rückseite der Ermittlerkarte nachgelesen werden."
+         },
+         {
+            "id":"Deckbuilding_Options",
+            "title":"Deckbau-Optionen",
+            "text":"Der folgende Abschnitt stellt klar, wie bestimmte Deckbau-Optionen funktionieren.\n\n\n- Falls eine der Kategorien der Deckbau-Optionen eines Ermittlers das Wort \"andere(r)\" enthält, fallen Karten nur in diese Kategorie, falls sie in keine andere Kategorie fallen.\n\n<i>Beispiel: Falls unter den Deckbau-Optionen eines Ermittlers folgende Formulierung vorkommt: \"Wächterkarten Stufe 0–5, bis zu 10 andere <b>Waffe</b>-Karten”, dann verbraucht eine Wächter-Karte mit dem Merkmal <b>Waffe</b> nicht einen der 10 begrenzten Slots, weil sie zuerst in die unbegrenzte Wächter-Kategorie fällt.</i>\n\n\n- Falls eine der Kategorien der Deckbau-Optionen eines Ermittlers Kartentext aufzählt, fallen Karten nur in diese Kategorie, falls der aufgezählte Kartentext auf irgendeine Weise (wenn auch nur nebensächlich) auf der Karte auftaucht.\n\n<i>Beispiel: Falls unter den Deckbau-Optionen eines Ermittlers folgende Formulierung vorkommt: \"Karten, \"die Horror heilen\", Stufe 0–5\", dann fällt jede Karte mit der Fähigkeit eine beliebige Anzahl Horror zu heilen in diese Kategorie, auch wenn sie nur unter bestimmten Umständen Horror heilt.</i>"
+         }
+      ]
+   },
+   {
+      "id":"Deck",
+      "title":"Decks",
+      "text":"Es gibt in jedem Spiel 4 Hauptarten von Decks: Ermittlerdecks, das Begegnungsdeck, das Szenendeck und das Agendadeck.\n\n\n- Die Reihenfolge der Karten in einem Deck darf nicht verändert werden, es sei denn, ein Spieler wird durch eine Kartenfähigkeit angewiesen dies zu tun. Siehe auch \"[Ermittlerdeck](#Investigator_Deck)\", \"[Begegnungsdeck](#Encounter_Deck)\", \"[Szenendeck und Agendadeck](#Act_Deck_and_Agenda_Deck)\"."
+   },
+   {
+      "id":"Dilemmas_and_Revelation_Abilities",
+      "title":"Dilemmas und Enthüllungsfähigkeiten",
+      "text":"Einige der Spielerkarten in der Erweiterung <i>Die scharlachroten Schlüssel</i>(diejenigen mit dem Merkmal [[Dilemma]]) haben Enthüllungsfähigkeiten. Wie bei anderen Kartentypen auch werden diese Fähigkeiten abgehandelt, sobald die Karte gezogen wird oder auf andere Weise auf die Hand eines Spielers gelangt und nicht, sobald die Karte gespielt wird.\n\n\n= Diese Karten haben keine Kosten (\"–\") und können nicht gespielt werden. Ihre Effekte werden nur dann abgehandelt, sobald sie gezogen oder der Hand eines Spielers hinzugefügt werden.\n\n\n= Nach dem Abhandeln einer Enthüllungsfähigkeit auf einer Spielerkarte wird die Karte auf den Ablagestapel seines Besitzers gelegt.\n\n\n= Enthüllungsfähigkeiten werden nicht bei der Vorbereitung abgehandelt. Falls 1 oder mehr Spielerkarten mit Enthüllungsfähigkeiten bei der Vorbereitung gezogen werden, wird gewartet, bis das Spiel beginnt. Dann handelt jeder Spieler (in Spielerreihenfolge) alle seine Enthüllungsfähigkeiten in der Reihenfolge seiner Wahl ab.",
+      "rules":[
+         {
+            "id":"Revelation_Ability_Priority",
+            "title":"Priorität von Enthüllung-Fähigkeiten",
+            "text":"Falls ein Ermittler sowohl eine [[Dilemma]]-Karte als auch eine Schwächekarte und/oder Begegnungskarte auf der Hand hat, muss die Schwäche- und/ oder Begegnungskarte zuerst abgehandelt werden. Falls bei der Abhandlung einer Fertigkeitsprobe eine [[Dilemma]]-Karte gezogen wird, wird die Probe zuerst vollständig abgehandelt, bevor der <b>Enthüllung</b>-Effekt der [[Dilemma]]-Karte abgehandelt wird."
+         }
+      ]
+   },
+   {
+      "id":"Direct_Damage_Direct_Horror",
+      "title":"Direkter Schaden, Direkter Horror",
+      "text":"Falls eine Fähigkeit dazu führt, dass eine Karte direkten Schaden oder direkten Horror nimmt, muss dieser direkt der angegebenen Karte zugewiesen werden und kann nicht woanders hin umverteilt werden."
+   },
+   {
+      "id":"You_Your",
+      "title":"Du/dein",
+      "text":"Die folgenden Richtlinien werden verwendet, um herauszufinden, auf welchen Ermittler sich \"du\" oder \"dein\" bezieht.\n\n\n- Eine <b>Enthüllung</b>-Fähigkeit mit \"du/dein\" bezieht sich auf den Ermittler, der die Karte gezogen hat und die Fähigkeit abhandelt.\n\n\n- Sobald eine ausgelöste Fähigkeit ([fast]-, [reaction]- oder [action]-Fähigkeit) abgehandelt wird, bezieht sich \"du/dein\" auf den Ermittler, der die Fähigkeit auslöst.\n\n\n- Falls eine Fähigkeit einen Satz beinhaltet, der angibt, auf wen sich \"du/dein\" bezieht, dann bezieht sie sich auf genau jene Ermittler.\n\n<i>Beispiel: Der Text auf [Sturer Detective](/card/01103) beginnt mit: \"Solange Sturer Detective an deinem Ort ist ...\". \"Deinem\" bezieht sich auf alle Ermittler an seinem Ort. Der Text auf [Junges Tiefes Wesen](/card/01181) beginnt mit: \"Nachdem dich Junges Tiefes Wesen in einen Kampf verwickelt hat ...\". \"Dich\" bezieht sich auf jeden Ermittler, der mit dem Gegner in einen Kampf verwickelt ist.</i>\n\n\n- Jede andere Instanz von \"du/dein\", die nicht in die oben angegebenen Kategorien passen, bezieht sich auf den Ermittler, der die Karte kontrolliert, den Ermittler, der die Karte in seiner Bedrohungszone hat, oder den Ermittler, der gerade mit der Karte interagiert.\n\nEine Karte kann mehrere verschiedene Fähigkeiten haben, die \"du/dein\" unterschiedlich interpretieren. \"Du/dein\" kann sich bei jeder dieser Fähigkeiten auf verschiedene Ermittler beziehen.\n\n<i>Beispiel: Der Text auf [Träume von R’lyeh](/card/01182) lautet:</i>\n\n<i> \"<b>Enthüllung</b> – Bringe Träume von R’lyeh in deiner Bedrohungszone ins Spiel.</i>\n<i>Du bekommst –1 [willpower] und –1 geistige Gesundheit.</i>\n<i>[action]: Lege eine [willpower]-Probe (3) ab. Falls die Probe gelingt, lege Träume von R’lyeh ab.”</i>\n\n<i>Bei diesen drei Fähigkeiten bezieht sich \"du/dein\" auf verschiedene Ermittler. Bei der <b>Enthüllung</b>-Fähigkeit bezieht sich \"deiner\" auf den Ermittler, der Träume von R’lyeh gezogen hat und die <b>Enthüllung</b> abhandelt. Bei der anhaltenden Fähigkeit bezieht sich \"du\" auf den Ermittler, der Träume von R’lyeh in seiner Bedrohungszone hat. Die [action]-Fähigkeit bezieht sich auf den Ermittler, der die [action]-Fähigkeit durchführt.</i>",
+      "rules":[
+         {
+            "id":"Interpreting_You_When_Taking_or_Being_Dealt_Damage",
+            "title":"Interpretation von \"du/dir\" im Bezug auf Schaden nehmen",
+            "text":"Falls sich eine Fähigkeit auf \"du/dir\" bezieht, wenn du Schaden nimmst oder dir Schaden zugefügt wird, umfasst dies auch deine Vorteilskarten, die du kontrollierst.\n\n<i>Beispiel: Die [reaction]-Fähigkeit auf [Überlebensmesser](/card/04017) wird ausgelöst, \"nachdem dir ein Gegnerangriff während der Gegnerphase Schaden zugefügt hat\". Diese Fähigkeit wird auch dann ausgelöst, wenn der Schaden des Angriffs einer oder mehr Vorteilskarten statt der Ermittlerkarte zugewiesen wird. Wenn aber der gesamte Schaden des Angriffs anderen Ermittlern und/oder seinen Vorteilen zugewiesen wird (durch die Verwendung von Karteneffekten, die so etwas zulassen), dann wurde dir kein Schaden zugefügt.</i>"
+         }
+      ]
+   },
+   {
+      "id":"May",
+      "title":"Dürfen",
+      "text":"Eine Form des Wortes \"dürfen\" gibt an, dass der betreffende Spieler die Möglichkeit hat, das zu tun, was auf die Form von \"dürfen\" folgt. Falls kein Spieler angegeben ist, betrifft dies den Spieler, der die Karte kontrolliert, auf der sich die Fähigkeit befindet."
+   },
+   {
+      "id":"Effects",
+      "title":"Effekte",
+      "text":"Ein Karteneffekt ist ein Effekt, der durch die Abhandlung eines Fähigkeitstextes, der auf eine Karte aufgedruckt ist oder den man durch eine Karte erhalten hat, hervorgerufen wird. Ein Rahmeneffekt ist ein Effekt, der durch die Abhandlung eines Rahmenereignisses (siehe \"[Genaue Erläuterung der Rahmenereignisse](#Framework_Event_Details)\") hervorgerufen wird.\n\n\n- Karteneffekten können Kosten, Auslösebedingungen, Spieleinschränkungen und/oder Spielberechtigungen vorausgehen; Diese Elemente werden nicht als Effekte (siehe \"[Fähigkeiten](#Ability)\") behandelt.\n\n\n- Ist er einmal initiiert, müssen die Spieler jeden Teil des Effektes so gut sie können abhandeln, es sei denn der Effekt enthält das Wort \"darf \".\n\n\n- Sobald ein nicht gezielter Effekt versucht mit einer Anzahl von Spielelementen zu interagieren (Beispiel: \"Ziehe 3 Karten\" oder \"Durchsuche die obersten 5 Karten deines Decks\"), die größer ist als die Anzahl dieser Elemente, die sich derzeit in der angegebenen Spielzone befinden, interagiert der Effekt mit so vielen Elementen wie möglich.\n\n\n- Das Ende eines andauernden Effektes (oder das Beenden einer anhaltenden Fähigkeit) gilt nicht als Veränderung des Spielstatus durch einen Karteneffekt.\n\n\n- Alle Aspekte eines Effektes haben Timing-Priorität vor allen \"nachdem\"-Auslösebedingungen, die als Konsequenz des Effektes auftreten können.\n\n<i>Beispiel: Falls ein Effekt besagt \"Du erhältst 3 Ressourcen und ziehst 3 Karten\", werden beide Aspekte des Effektes (Erhalten von Ressourcen und Ziehen von Karten) abgehandelt, bevor man eine Fähigkeit initiiert, die den Text hat \"Nachdem du eine Karte gezogen hast ...\".</i>\n\nSiehe auch \"[Andauernde Effekte](#Lasting_Effects)\", \"[Aufgeschobene Effekte](#Delayed_Effects)\", \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
+   },
+   {
+      "id":"A_An",
+      "title":"Ein, eine",
+      "text":"Sobald eine Bedingung beschrieben wird, gilt diese im Hinblick auf die Worte \"ein\" oder \"eine\" als erfüllt, falls 1 oder mehr der Elemente, auf die sich die Bedingung bezieht, vorhanden sind.\n\n<i>Beispiel: Ein Ermittler mit 3 Ressourcen erfüllt die Bedingung \"Jeder Ermittler mit einer Ressource\".</i>"
+   },
+   {
+      "id":"Nested_Skill_Tests",
+      "title":"Eingebettete Fertigkeitsproben",
+      "text":"Eine Fertigkeitsprobe kann nicht während einer anderen Fertigkeitsprobe initiiert werden. Falls während der Abhandlung einer Fertigkeitsprobe eine andere Fertigkeitsprobe initiiert werden würde, wird die zweite Fertigkeitsprobe stattdessen erst dann initiiert, nachdem die Abhandlung der ersten Probe abgeschlossen ist. Falls die erste Fertigkeitsprobe Teil einer Aktion ist, wird die zweite Fertigkeitsprobe erst dann initiiert, nachdem die Abhandlung der Aktion abgeschlossen ist. \n\n<i>Beispiel: Ursula führt eine Ermitteln-Aktion durch. Als Teil dieser Ermitteln-Aktion muss sie eine [intellect]-Probe ablegen. Während der Abhandlung der Fertigkeitsprobe spielt sie die Karte [Schwäche aufzeigen](/card/02228), ein Ereignis mit dem Schlüsselwort Schnell, mit dem eine weitere [intellect]-Probe initiiert wird. Statt die zweite [intellect]-Probe während der ersten Probe abzuhandeln, wird die Initiierung der zweiten [intellect]-Probe aufgeschoben, bis die Abhandlung der ersten Fertigkeitsprobe (und damit die Ermitteln-Aktion) abgeschlossen ist.</i>"
+   },
+   {
+      "id":"Nested_Sequences",
+      "title":"Eingebettete Sequenzen",
+      "text":"Jedes Mal wenn eine Auslösebedingung eintritt, wird die folgende Sequenz angewandt: (1) \"Sobald ...\"- Effekte, die die Auslösebedingung unterbrechen, werden ausgeführt. (2) Die Auslösebedingung wird abgehandelt. (3) Dann werden die \"Nachdem ...\"-Effekte als Reaktion auf die Auslösebedingung ausgeführt.\n\nInnerhalb dieser Sequenz pausiert das Spiel und beginnt mit einer neuen Sequenz, falls die Verwendung einer [reaction]- oder <b>Erzwungen</b>-Fähigkeit zu einer neuen Auslösebedingung führt: (1) \"Sobald ...\"- Effekte, die die Auslösebedingung unterbrechen, werden ausgeführt. (2) Die Auslösebedingung wird abgehandelt. (3) Dann werden die \"Nachdem ...\"-Effekte als Reaktion auf die Auslösebedingung ausgeführt. Das nennt sich <b>eingebettete Sequenz</b>. Ist die eingebettete Sequenz abgeschlossen, geht das Spiel dort weiter, wo es unterbrochen worden ist; bei der ursprünglichen Auslösebedingung der Sequenz.\n\nEs ist möglich, dass eine eingebettete Sequenz weitere Auslösebedingungen erschafft (und somit mehr eingebettete Sequenzen). Es gibt keine Obergrenze für die Anzahl der eingebetteten Sequenzen, aber jede eingebettete Sequenz muss abgeschlossen sein, bevor zur Sequenz zurückgekehrt wird, die sie erschaffen hat. Im Endeffekt werden diese Sequenzen nach der LIFO-Methode abgehandelt (\"last in, first out\"; \"zuletzt herein, zuerst heraus\").\n\n<i>Beispiel: Roland und Agnes sind in ein erbittertes Gefecht mit mehreren Gegnern verwickelt. Roland hat einen [Wachhund](/card/01021) in seinem Spielbereich und ist mit einer [Ausgeburt der Ziege](/card/01180) mit 2 Schaden darauf in einen Kampf verwickelt, Agnes mit einem [Ghuldiener](/card/01160). Roland möchte eine [45er Automatik](/card/01016) spielen, was einen Gegenangriff der Ausgeburt der Ziege provoziert und Roland 1 Schaden zufügt. Roland weist den Schaden seinem Wachhund zu, der die [reaction]-Fähigkeit hat: \"Sobald ein Gegnerangriff Wachhund Schaden zufügt: Füge dem angreifenden Gegner 1 Schaden zu.\" Noch bevor das Spielen von Rolands 45er Automatik abgehandelt wird, wird die Fähigkeit des Wachhunds abgehandelt, die der Ausgeburt der Ziege 1 Schaden zufügt, was ausreichen würde, diesen Gegner zu besiegen. Die Ausgeburt der Ziege hat folgende <b>Erzwungen</b>-Fähigkeit: \"Sobald Ausgeburt der Ziege besiegt ist: Jeder Ermittler an diesem Ort nimmt 1 Horror.\" Noch bevor der Schaden, der dem Wachhund zugefügt wird, abgehandelt wird, wird jedem Ermittler an diesem Ort 1 Horror zugefügt, was Agnes mit einschließt, die wiederum folgende [reaction]-Fähigkeit hat: \"Nachdem 1 oder mehr Horror auf Agnes Baker platziert worden ist, füge einem Gegner an deinem Ort 1 Schaden zu.\" Noch bevor die Niederlage der Ausgeburt der Ziege abgehandelt wird, fügt Agnes dem Ghuldiener, der mit ihr in einen Kampf verwickelt ist, 1 Schaden zu. Da jetzt keine weiteren [reaction]- oder <b>Erzwungen</b>-Fähigkeiten mehr ausgelöst werden, kehren die Spieler zur ursprünglichen Auslösebedingung zurück und handeln die Niederlage der Ausgeburt der Ziege und alle \"Nachdem ...\"-Effekte ab, die eintreten könnten, sobald der Gegner besiegt worden ist. Dann handeln die Spieler den Schaden ab, der dem Wachhund zugefügt worden ist, und alle \"Nachdem ...\"-Effekte ab, die aufgrund des Schadens eintreten könnten. Zuletzt kehren die Spieler zur ursprünglichen Auslösebedingung zurück: Roland kann endlich seine 45er Automatik ins Spiel bringen.</i>"
+   },
+   {
+      "id":"Standalone_Mode",
+      "title":"Einzelspielszenario",
+      "text":"Sobald ein Einzelspielszenario gespielt wird (d. h. ein Szenario wird als eigenständiges Abenteuer gespielt, nicht als Teil seiner Kampagne), gelten folgende Regeln:\n\n\n- Sobald ein Deck für ein Einzelspielszenario gebaut wird, kann ein Ermittler höherstufige Karten in seinem Deck verwenden (solange sie den Einschränkungen beim Deckbau für diesen Ermittler entsprechen), indem er die Summe der Erfahrungspunkte aller höherstufigen Karten in diesem Deck zählt und zusätzlich zufällige Grundschwächen nach der folgenden Tabelle hinzufügt:\n\n| Erfahrungspunkte | Zufällige Grundschwächen |\n| --- | --- |\n| 0-9 | 0 zusätzliche |\n| 10-19 | 1 zusätzliche |\n| 20-29 | 2 zusätzliche |\n| 30-39 | 3 zusätzliche |\n| 40-49 | 4 zusätzliche |\n| > 50 | Nicht erlaubt |\n\n\n- Nachdem man ein Szenario ausgewählt hat, liest man im Kampagnenleitfaden des gewählten Szenarios nach, wie zunächst die Kampagne und dann das erste Szenario der Kampagne vorbereitet wird. Man liest die Einleitung des Szenarios und springt dann direkt zu seiner Auf lösung und wählt eine Auf lösung, die einem gefällt. Jede beliebige Auf lösung kann gewählt werden. (Wünscht man eine zusätzliche Herausforderung, wählt man eine für die Ermittler ungünstige Auf lösung.) Falls man sich nicht sicher ist, welche Auf lösung man wählen soll oder einfach unentschlossen ist, wählt man <b>Auflösung 1</b>. Die Ergebnisse der ausgewählten Auf lösung notiert man in einem Kampagnenlogbuch, als ob man das Szenario im Kampagnenmodus durchgespielt hätte, mit einer Ausnahme: <b>Die Erfahrungspunkte werden nicht gezählt</b>.\n\n\n- Diesen Ablauf wiederholt man für jedes Szenario bis zu dem Szenario, das man spielen will. Das gewählte Szenario wird dann normal vorbereitet und gespielt.\n\n\n- Falls eine Storyentscheidung während des Spiels getroffen werden muss, wählt man das Ergebnis und trägt es ins Kampagnenlogbuch ein.\n\n\n- Traumata für während des Spiels besiegte Ermittler werden nicht angewendet, aber falls in einer Szenarioauf lösung Traumata zugefügt werden, werden diese auch angewendet.\n\n\n- Falls man eine Szenarioschwäche oder -Vorteilskarte verdient hat, die sich in einer Erweiterung befindet, die man nicht besitzt, macht man einfach ohne die betreffende Karte weiter."
+   },
+   {
+      "id":"Unique",
+      "title":"Einzigartig (✷)",
+      "text":"Eine Karte mit dem ✷-Symbol vor dem Kartennamen ist eine einzigartige Karte. Es kann nicht mehr als 1 Instanz jeder einzigartigen Karte gleichzeitig im Spiel geben. Hierbei gilt der Name der Karte.\n\n\n- Ein Spieler kann eine einzigartige Karte nicht ins Spiel bringen, falls bereits eine Kopie dieser Karte (nach Name) im Spiel ist.\n\n\n- Falls eine einzigartige Begegnungskarte ins Spiel kommen würde, die den gleichen Namen wie eine einzigartige Spielerkarte hat, wird die Spielerkarte abgelegt und die Begegnungskarte gleichzeitig ins Spiel gebracht."
+   },
+   {
+      "id":"Revelation",
+      "title":"Enthüllung",
+      "text":"Eine Enthüllungsfähigkeit kann auf Begegnungs- oder Schwächekarten vorkommen.\n\n\n- Sobald ein Ermittler eine Begegnungskarte zieht, muss dieser Ermittler alle \"<b>Enthüllung</b> –\"-Fähigkeiten auf dieser Karte abhandeln. Dies passiert, bevor die Karte ins Spiel kommt, oder bei einer Verratskarte, bevor sie auf den Ablagestapel gelegt wird.\n\n\n- Sobald eine Schwächekarte auf die Hand eines Ermittlers gelangt, muss dieser Ermittler sofort alle Enthüllungsfähigkeiten auf dieser Karte abhandeln, als ob er sie gerade gezogen hätte.\n\nSiehe auch \"[Dilemmas und Enthüllungsfähigkeiten](#Dilemmas_and_Revelation_Abilities)\"."
+   },
+   {
+      "id":"Evade",
+      "title":"Entkommen, Entkommen (Aktion)",
+      "text":"\"Entkommen\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. \n\nUm einem Gegner zu entkommen, mit dem man in einen Kampf verwickelt ist, legt ein Ermittler eine Beweglichkeitsprobe gegen den Entkommenwert dieses Gegners ab (siehe \"[Fertigkeitsproben](#Skill_Tests)\").\n\nFalls die Probe gelingt, entkommt der Ermittler diesem Gegner (siehe unten). (Dies geschieht in Schritt 7 der Fertigkeitsprobe \"[FP.7 Ergebnis der Fertigkeitsprobe anwenden](#Skill_Test_Timing)\".)\n\nFalls die Probe misslingt, entkommt der Ermittler dem Gegner nicht und bleibt mit ihm in einen Kampf verwickelt.\n\n\n- Falls eine Fähigkeit \"automatisch\" 1 oder mehreren Gegnern entkommt, wird für diesen Entkommen-Versuch keine Fertigkeitsprobe abgelegt.\n\n\n- Immer wenn ein Ermittler einem Gegner entkommt (ob durch eine Entkommen-Aktion oder durch eine Kartenfähigkeit), wird der Gegner erschöpft (falls er vorher spielbereit war) und der Ermittler löst sich aus dem Kampf. Der Gegner wird aus der Bedrohungszone des Ermittlers an den derzeitigen Ort des Ermittlers verschoben, um anzuzeigen, dass er nicht länger mit dem Ermittler in einen Kampf verwickelt ist.\n\n\n- Anders als bei den Aktionen \"Kampf\" und \"in einen Kampf verwickeln\" kann ein Ermittler eine Entkommen-Aktion nur gegen einen mit ihm in einen Kampf verwickelten Gegner durchführen."
+   },
+   {
+      "id":"Event_Cards",
+      "title":"Ereigniskarten",
+      "text":"Ereigniskarten stehen für taktische Aktionen, Manöver, Zaubersprüche, Tricks und andere spontane Effekte, die einem Spieler zur Verfügung stehen.\n\n\n- Falls eine Ereigniskarte nicht das Schlüsselwort Schnell hat, darf sie nur durch eine Spielen-Aktion während des Zuges eines Spielers von dessen Hand durchgeführt werden. Sämtliche Berechtigungen und Einschränkungen für das Spielen der Karte müssen dabei beachtet werden.\n\n\n- Eine Ereigniskarte mit Schnell darf jederzeit nach den Anweisungen zum Spielen der Karte von der Hand eines Spielers gespielt werden (siehe \"[Schnell](#Fast)\").\n\n\n- Immer wenn ein Spieler eine Ereigniskarte spielt, werden ihre Kosten bezahlt, ihre Effekte abgehandelt (oder aufgehoben) und die Karte wird auf den Ablagestapel des Besitzers gelegt, nachdem diese Effekte abgehandelt (oder aufgehoben) worden sind.\n\n\n- Falls die Effekte einer Ereigniskarte aufgehoben werden, gilt die Karte immer noch als gespielt und ihre Kosten als bezahlt. Nur die Effekte werden aufgehoben.\n\n\n- Das Spielen (oder Nichtspielen) einer Ereigniskarte von der Hand ist für einen Spieler immer optional, falls das Ereignis in den Spielanweisungen nicht das Wort \"muss\" verwendet.\n\n\n- Eine Ereigniskarte kann nicht gespielt werden, falls ihre Abhandlung keine Möglichkeit hat, den Spielstatus zu verändern."
+   },
+   {
+      "id":"Experience_Placeholder",
+      "title":"Erfahrungspunkte",
+      "text":"Siehe \"[Erfahrung](#Experience)\"."
+   },
+   {
+      "id":"Researched",
+      "title":"Erforscht",
+      "cycle":[
+         "eoe"
+      ],
+      "text":"Erforscht ist eine neue Schlüsselwortfähigkeit, die auf manchen höherstufigen Karten (zumeist auf Sucherkarten) zu finden ist.\n\nBevor eine Karte mit dem Schlüsselwort Erforscht einem Ermittlerdeck hinzugefügt werden kann, muss sie zuerst \"identifiziert\" oder \"übersetzt\" werden. Dies geschieht, indem eine auf einer niederstufigen Version der Karte beschriebene Aufgabe durchgeführt wird und diese im Kampagnenlogbuch notiert wird.\n\n\n= Eine Karte mit dem Schlüsselwort Erforscht darf einem Deck nur hinzugefügt werden, indem eine niederstufige Version von ihr verbessert wird.\n\n\n= Eine Karte mit dem Schlüsselwort Erforscht darf einem Deck nur hinzugefügt werden, falls im Kampagnenlogbuch steht, dass die auf der niederstufigeren Version der Karte beschriebene Aufgabe erfüllt wurde.\n\n\n= Nachdem ein Ermittler eine dieser Aufgaben erfüllt hat und dies im Kampagnenlogbuch notiert hat, darf ein beliebiger Ermittler in der Kampagne die entsprechende Karte verbessern, bei dem die normalen Regeln zum Verbessern von Spielerkarten angewandt werden.\n\n<i>Beispiel: [Ley-Linien-Sammlung (Tor Nach Tindalos)](/card/08041) hat das Schlüsselwort Erforscht. Deshalb darf ein Ermittler diese Karte nicht direkt erwerben. Er muss stattdessen [Ley-Linien-Sammlung (Unidentifiziert)](/card/08033) verbessern. Dies kann er nur tun, falls zuvor \"das Tor identifiziert\" wurde.</i>"
+   },
+   {
+      "id":"Skill_Test_Results_and_Advanced_Timing",
+      "title":"Ergebnisse von Fertigkeitsproben und erweitertes Timing",
+      "text":"In Schritt 7 des Timings von Fertigkeitsproben (\"Ergebnis der Fertigkeitsprobe anwenden\") werden alle Effekte einer gelungenen Fertigkeitsprobe bestimmt und nacheinander abgehandelt. Das beinhaltet die Effekte der Fertigkeitsprobe selbst (wie z. B. das Entdecken eines Hinweises beim Ermitteln oder das Hinzufügen von Schaden während eines Angriffs) sowie alle \"Falls die Probe gelingt ...\"-Effekte durch Kartenfähigkeiten oder Fertigkeitskarten, die zu der Probe beigetragen haben. \n\n[reaction]- oder <b>Erzwungen</b>-Effekte mit einer Auslösebedingung, die abhängig vom Gelingen oder Misslingen einer Fertigkeitsprobe ist (wie z. B. \"Nachdem du erfolgreich ermittelt hast\" oder \"Nachdem dir eine Fertigkeitsprobe um 2 oder mehr misslungen ist\"), lösen zu diesem Zeitpunkt nicht aus. Diese Fähigkeiten werden in Schritt 6 (\"Bestimmen, ob die Fertigkeitsprobe gelingt/misslingt\") ausgelöst (siehe \"[Timing für Fertigkeitsproben (FP)](#Skill_Test_Timing)\")."
+   },
+   {
+      "id":"Gains",
+      "title":"Erhalten",
+      "text":"Das Wort \"erhalten\" kommt in verschiedenen Zusammenhängen vor.\n\n\n- Falls ein Spieler eine oder mehrere Ressourcen erhält, nimmt dieser Spieler die angegebene Anzahl Ressourcen aus dem Markervorrat und fügt sie seinem Ressourcenvorrat hinzu.\n\n\n- Falls ein Ermittler eine Aktion erhält, darf dieser Ermittler im angegebenen Zeitraum eine zusätzliche Aktion nehmen.\n\n\n- Falls eine Karte eine Eigenschaft erhält (wie ein Symbol, ein Merkmal, ein Schlüsselwort oder einen Fähigkeitstext), funktioniert die Karte, als ob sie die erhaltene Eigenschaft besitzen würde.\n\n\n- \"Erhaltene\" Eigenschaften gelten nicht als auf der Karte \"aufgedruckt\". Falls sich eine Fähigkeit auf die aufgedruckten Eigenschaften einer Karte bezieht, bezieht sie sich nicht auf erhaltene Eigenschaften"
+   },
+   {
+      "id":"Explore",
+      "cycle":[
+         "tfa",
+         "gob"
+      ],
+      "scenarios":[
+         "the_eternal_slumber",
+         "the_nights_usurper"
+      ],
+      "title":"Erkunden",
+      "text":"Einige Fähigkeiten in der Kampagne <i>Das vergessene Zeitalter</i> haben das Aktionskennzeichen \"Erkunden\". Diese Fähigkeiten werden generell verwendet, um neue Orte zu finden, die ins Spiel gebracht werden können, und sie werden mit ihrer \"Aktivieren\"-Aktion initiiert.\n\n\"Erkunden\"-Fähigkeiten weisen die Spieler an die oberste Karte des \"Erkundungsdecks\" zu ziehen. Dabei handelt es sich um ein separates Deck, das während der Vorbereitung zu einigen Szenarien erstellt wird. Dieses Deck besteht aus einigen einseitig bedruckten Orten und Verratskarten.\n\n\n= Jede \"Erkunden\"-Fähigkeit gibt einen speziellen Ortstyp an, der durch sie gezogen werden soll. <b>Falls ein Ort dieses Typs gezogen wird, wird er ins Spiel gebracht und der Ermittler, der ihn gezogen hat, bewegt sich auf diesen Ort.</b> Dies gilt als \"erfolgreiches\" Erkunden.\n\n\n= Falls ein anderer Ort gezogen wird, wird er neben das Erkundungsdeck gelegt und die nächste Karte des Erkundungsdecks wird gezogen. Dies wird wiederholt, bis ein Ort des angegebenen Typs oder eine Verratskarte gezogen wird. Nachdem diese Aktion abgeschlossen worden ist, wird jeder Ort neben dem Erkundungsdeck zurück in das Deck gemischt.\n\n\n= Falls eine Verratskarte gezogen wird, wird diese normal abgehandelt. Falls sie abgelegt wird, wird sie normal auf den Begegnungs-Ablagestapel gelegt. Es gibt keinen Ablagestapel für das Erkundungsdeck. Dies gilt als \"nicht erfolgreiches\" Erkunden.\n\n\n= Wenn ein einseitig bedruckter Ort vom Erkundungsdeck ins Spiel gebracht wird, gibt dessen Hinweiswert an, wie viele Hinweise zu diesem Zeitpunkt auf dem Ort platziert werden.\n\n<i>Beispiel: Agenda 1a – [Expedition in die Wildnis](/card/04044) hat folgende Fähigkeit: \"[action]: Erkunden. Ziehe die oberste Karte des Erkundungsdecks. Falls es ein verbundener Ort ist, bringe ihn ins Spiel und bewege dich dorthin.\" [Ursula Downs](/card/04002) ist im [Expeditionslager](/card/04050) und möchte einen neuen Ort finden, zu dem sie reisen kann. Sie gibt ihre erste Aktion aus, um zu erkunden. Sie zieht die oberste Karte des Erkundungsdecks. Die Karte, die sie zieht, ist [Weitläufiger Pfad](/card/04073). Weil Weitläufiger Pfad ein Ort ist, der nicht mit dem Expeditionslager verbunden ist, wird er neben dem Erkundungsdeck platziert und Ursula zieht die nächste Karte des Erkundungsdecks. Jetzt zieht sie die Verratskarte [Versorgungsengpass](/card/04082), die sie normal abhandelt und auf den Begegnungskarten-Ablagestapel legt. Ihr Erkunden ist nicht erfolgreich und sie muss die Karte Weitläufiger Pfad, die sie zuvor gezogen hat, zurück ins Erkundungsdeck mischen. Ursula entscheidet sich eine zweite Aktion auszugeben, um erneut zu erkunden. Jetzt zieht sie den [Dornenpfad](/card/04069), der mit dem Expeditionslager verbunden ist. Ihr Erkunden ist erfolgreich. Der Dornenpfad wird mit Hinweisen in Höhe seines Hinweiswertes ins Spiel gebracht und Ursula bewegt sich sofort vom Expeditionslager zum Dornenpfad.</i>"
+   },
+   {
+      "id":"Investigate_Action",
+      "title":"Ermitteln (Aktion)",
+      "text":"Ermitteln\" ist eine Aktion, die ein Ermittler während seines Zuges in der Ermittlungsphase nehmen darf.\n\nImmer wenn ein Ermittler diese Aktion nimmt, legt er eine Intellektprobe gegen den Schleierwert dieses Ortes ab (siehe \"[Fertigkeitsproben](#Skill_Tests)\").\n\nFalls diese Probe gelingt, hat der Ermittler erfolgreich an dem Ort ermittelt und er entdeckt dort einen Hinweis (dies passiert in Schritt 7 der Fertigkeitsprobe, siehe \"[FP.7 Ergebnis der Fertigkeitsprobe anwenden](#Skill_Test_Timing)\".\n\nImmer wenn ein Ermittler einen Hinweis entdeckt, nimmt er den Hinweis von dem Ort und platziert ihn auf seine Ermittlerkarte unter seiner Kontrolle.\n\nFalls die Probe misslingt, hat der Ermittler keinen Erfolg beim Ermitteln an dem Ort. Er entdeckt keine Hinweise in Schritt 7 der Fertigkeitsprobe."
+   },
+   {
+      "id":"Prologue_Investigators",
+      "title":"Ermittler für den Prolog",
+      "cycle":[
+         "tcu",
+         "rttcu"
+      ],
+      "text":"Die 4 Ermittler aus der Kampagnen-Erweiterung <i>Der gebrochene Kreis</i> [Gavriella Mizrah](/card/05046), [Jerome Davids](/card/05047), [Penny White](/card/05049) und [Valentino Rivas](/card/05048) haben das Begegnungssetsymbol für <i>Die Vermissten vom Anwesen der Dämmerung</i> und können nur für den Prolog von <i>Der gebrochene Kreis</i> verwendet werden. Sie können nicht in anderen Szenarien verwendet werden. Sie sollten mit den übrigen Szenariokarten für <i>Die Vermissten vom Anwesen der Dämmerung</i> auf bewahrt und nicht in die Sammlung der Spielerkarten einsortiert werden.\n\nDas Szenario <i>Die Vermissten vom Anwesen der Dämmerung</i> enthält zusätzlich noch 15 Spielerkarten aus der Ermittler-Erweiterung <i>Der gebrochene Kreis</i>, sodass ihr den Anweisungen bei der Vorbereitung auf den Rückseiten der 4 Ermittler für den Prolog folgen könnt und die Starthand für den jeweiligen Ermittler erstellen könnt, auch wenn ihr jene Ermittler-Erweiterung nicht zur Hand habt. Diese Karten gelten nicht als Teil des Begegnungsdecks und können der Sammlung eines Spielers hinzugefügt werden."
+   },
+   {
+      "id":"Investigator_Deck",
+      "title":"Ermittlerdeck",
+      "text":"Das \"Ermittlerdeck\" eines Spielers ist das Deck, das dessen Vorteils-, Ereignis-, Fertigkeits- und Schwächekarten enthält. Eine Anweisung, die sich auf \"dein Deck\" bezieht, bezieht sich auf das Ermittlerdeck unter der Kontrolle des betreffenden Spielers."
+   },
+   {
+      "id":"Lead_Investigator",
+      "title":"Ermittlungsleiter",
+      "text":"Der Ermittlungsleiter muss gelegentlich für das Szenario wichtige Entscheidungen treffen. Zu Beginn eines Szenarios wählen die Ermittler einen Ermittlungsleiter. Falls sie sich nicht einigen können, wird zufällig ein Ermittlungsleiter bestimmt.\n\n\n- Immer wenn es mehrere gültige Optionen für eine Wahl oder eine Entscheidung gibt (<i>Beispiel: ein Jäger-Gegner, der sich in zwei verschiedene Richtungen bewegen könnte</i>), hat der Ermittlungsleiter das letzte Wort bei der Wahl zwischen diesen Optionen.\n\n\n- Falls der Ermittlungsleiter ausscheidet, wählen die verbliebenen Spieler (falls vorhanden) einen neuen Ermittlungsleiter."
+   },
+   {
+      "id":"Investigation_Phase_Placeholder",
+      "title":"Ermittlungsphase",
+      "text":"Siehe \"[II. Ermittlungsphase](#Investigation_Phase)\"."
+   },
+   {
+      "id":"Spawn",
+      "title":"Erscheinen",
+      "text":"Einige Gegner erscheinen an einem speziellen Ort, sobald sie vom Begegnungsdeck gezogen werden. Dieser Ort wird durch eine fettgedruckte \"<b>Erscheinen</b>\"-Anweisung im Textfeld angegeben.\n\n\n- Die Erscheinen-Anweisung eines Gegners wird abgehandelt, sobald der Gegner ins Spiel kommt, unabhängig davon, auf welche Weise dies geschieht.\n\n\n- Falls ein Gegner keine Erscheinen-Anweisung hat, erscheint er mit dem Ermittler, der ihn gezogen hat, in einen Kampf verwickelt.\n\n\n- Falls es keinen legalen Ort gibt, an dem ein Gegner erscheinen kann (z. B. falls in seiner Erscheinen-Anweisung ein spezieller Ort angegeben ist, der aber nicht im Spiel ist, oder kein Ort im Spiel seine Erscheinen-Anweisung erfüllt), erscheint er nicht und wird stattdessen abgelegt.\n\n\n- Falls mehrere Orte die Erscheinen-Anweisung erfüllen, entscheidet sich der Ermittler, der den Gegner erscheinen lässt, zwischen diesen Orten.\n\n\n- Falls eine Kartenfähigkeit die Spieler anweist einen Gegner an einem bestimmten Ort erscheinen zu lassen (<i>Beispiel: \"Durchsuche das Begegnungsdeck nach einer Kopie von Akolyth und lasse sie in der Südstadt erscheinen\"</i>), behandelt man die Fähigkeit, welche die Karte ins Spiel bringt, als die Erscheinen-Anweisung dieses Gegners, die jede andere Erscheinen-Anweisungen überschreibt.",
+      "rules":[
+         {
+            "id":"Spawn_Enemy",
+            "title":"Das Erscheinen eines Gegners",
+            "text":"1. Falls ein Gegner erscheint, ohne dass ein Ermittler ihn zieht, gibt der Effekt, der den Gegner erscheinen lässt, gewöhnlich an, wo der Gegner erscheinen soll. Nach dem Erscheinen des Gegners an jenem Ort verwickelt er Ermittler an seinem Ort automatisch in einen Kampf. Dafür werden die Regeln für \"[Gegner in einen Kampf verwickeln](#Enemy_Engagement)\" verwendet (außer der Gegner hat das Schlüsselwort Zurückhaltend).\n\n2. Falls ein Ermittler einen Gegner zieht, wird überprüft, ob der Gegner eine \"Erscheinen\"-Anweisung hat.\n\n\n- Falls der Gegner eine \"Erscheinen\"-Anweisung hat, erscheint der Gegner an dem angegebenen Ort. Nach dem Erscheinen des Gegners an jenem Ort verwickelt er Ermittler an seinem Ort automatisch in einen Kampf. Dafür werden die Regeln für \"[Gegner in einen Kampf verwickeln](#Enemy_Engagement)\" verwendet (außer der Gegner hat das Schlüsselwort Zurückhaltend).\n\n\n- Falls der Gegner keine \"Erscheinen\"-Anweisung hat, erscheint er mit dem Ermittler, der ihn gezogen hat, in einen Kampf verwickelt (außer der Gegner hat das Schlüsselwort Zurückhaltend).\n\n<b>\"Beute\"-Anweisungen haben keinen direkten Einfluss auf den Ort, an dem der Gegner erscheinen wird.</b> \"Beute\"-Anweisungen haben nur dann Einfluss auf den Prozess, wenn ein Gegner (nicht in einen Kampf verwickelt) an einem Ort mit mehreren Ermittlern erscheint. Um zu bestimmen, welchen Ermittler er automatisch in einen Kampf verwickelt, werden die Regeln für \"[Gegner in einen Kampf verwickeln](#Enemy_Engagement)\" verwendet."
+         }
+      ]
+   },
+   {
+      "id":"Exhaust",
+      "title":"Erschöpfen, erschöpft",
+      "text":"Gelegentlich bewirkt eine Kartenfähigkeit oder ein Spielschritt, dass eine Karte erschöpft wird, um anzuzeigen, dass sie verwendet worden ist, um eine Funktion durchzuführen. Sobald eine Karte erschöpft wird, wird sie um 90° gedreht. Eine Karte in diesem Zustand nennt man erschöpft.\n\n\n- Eine erschöpfte Karte kann nicht erneut erschöpft werden, bis sie wieder spielbereit ist (normalerweise durch einen Spielschritt oder eine Kartenfähigkeit).."
+   },
+   {
+      "id":"Forced_Abilities",
+      "title":"Erzwungene Fähigkeiten",
+      "text":"Siehe \"[Erzwungene Fähigkeiten](#Abilities_Forced_Abilities)\" im Bereich \"[Fähigkeiten](#Ability)\"."
+   },
+   {
+      "id":"Exile",
+      "title":"Exil",
+      "text":"Einige der Spielerkarten in der Erweiterung <i>Das Vermächtnis von Dunwich</i> müssen ins Exil geschickt werden, sobald sie verwendet werden. Sobald eine Karte ins Exil geschickt wird, wird sie aus dem Spiel entfernt und zurück in die Sammlung gelegt. Während des Kampagnenspiels muss eine Karte, die ins Exil geschickt worden ist, (zwischen Szenarien) erneut mit Erfahrungspunkten erworben werden, falls man sie wieder in sein Deck aufnehmen will. Falls 1 oder mehrere Karten ins Exil geschickt werden und dadurch die Deckgröße unter die für den Ermittler vorgegebene Größe sinkt, müssen, sobald man zwischen Szenarien Karten erwirbt, so viele Karten erworben werden, dass die Deckgröße wieder den Regeln entspricht. (Sobald auf diese Weise Karten erworben werden, dürfen Karten der Stufe 0 für 0 Erfahrungspunkte erworben werden, bis die vorgegebene Deckgröße wieder erreicht ist.)"
+   },
+   {
+      "id":"Skill_Cards",
+      "title":"Fertigkeitskarten",
+      "text":"Fertigkeitskarten stehen für angeborene oder erlernte Attribute oder Charaktermerkmale, welche die Fertigkeitsproben eines Ermittlers verbessern.\n\nFertigkeitskarten werden nicht von der Hand eines Spielers gespielt. Um ihre Fähigkeiten abzuhandeln, müssen Fertigkeitskarten zu einer Fertigkeitsprobe beigetragen werden.\n\nFalls eine Fertigkeitskarte zu einer Fertigkeitsprobe beigetragen wird, darf ihre Fähigkeit während der Abhandlung dieser Fertigkeitsprobe wie auf der Karte angegeben angewendet werden.\n\nSiehe \"[Timing für Fertigkeitsproben (FP)](#Skill_Test_Timing)\"."
+   },
+   {
+      "id":"Skill_Tests",
+      "title":"Fertigkeitsproben",
+      "text":"Viele Situationen im Spiel erfordern, dass ein Ermittler eine Fertigkeitsprobe gegen eine seiner vier Fertigkeiten ablegt: Willenskraft ([willpower]), Intellekt ([intellect]), Kampf ([combat]) oder Beweglichkeit ([agility]). Bei Fertigkeitsproben wird mit dem Wert eines Ermittlers für eine bestimmte Fertigkeit gegen einen Schwierigkeitswert angetreten, der von der Fähigkeit oder dem Spielschritt bestimmt wird, der/die diese Probe initiiert hat. Der Ermittler versucht den Schwierigkeitswert zu erreichen oder zu übertreffen, um bei dieser Probe erfolgreich zu sein.\n\nEine Fertigkeitsprobe wird oft als Probe gegen diese Fertigkeit angegeben.\n\n<i>Beispiel: \"Beweglichkeitsprobe\", \"Kampfprobe\", \"Willenskraftprobe\" oder \"Intellektprobe\".</i>\n\nSiehe \"[Timing für Fertigkeitsproben (FP)](#Skill_Test_Timing)\"."
+   },
+   {
+      "id":"Flood_Tokens",
+      "cycle":[
+         "tic",
+         "zrttic"
+      ],
+      "title":"Flutmarker",
+      "text":"Im Laufe der Kampagne <i>Die Innsmouth-Verschwörung</i> kann es vorkommen, dass Orte durch Szenariokarteneffekte überflutet werden. Jeder Ort besitzt 1 von 3 verschiedenen Flutstufen: Ein Ort ist entweder nicht überflutet, teilweise überflutet oder völlig überflutet. Die Flutstufe eines Ortes kann durch doppelseitige in der Erweiterung <i>Die Innsmouth-Verschwörung</i> enthaltene Flutmarker angezeigt werden.<b>Die Flutstufe eines Ortes hat keinen eigenständigen Spieleffekt.</b>Manche Karteneffekte können sich aber ändern oder stärker werden, solange sich ein Ermittler an einem überfluteten Ort befindet, besonders wenn der Ort völlig überflutet ist.\n\n\n= Ein Ort ohne Flutmarker ist nicht überflutet.\n\n\n= Falls ein Ort teilweise überflutet wird, wird ein Flutmarker mit der \"Teilweise überflutet\"-Seite nach oben darauf platziert, um dies anzuzeigen.\n\n\n= Falls ein Ort völlig überflutet wird, wird ein Flutmarker mit der \"Völlig überflutet\"-Seite nach oben darauf platziert (oder der Flutmarker wird umgedreht, falls der Ort schon teilweise überflutet ist), um dies anzuzeigen.\n\n\n= Falls die Flutstufe eines Ortes \"erhöht\" wird, wechselt sie von \"nicht überflutet\" zu \"teilweise überflutet\" oder von \"teilweise überflutet\" zu \"völlig überflutet\". Bei einem völlig überfluteten Ort kann die Flutstufe nicht mehr erhöht werden.\n\n\n= Falls die Flutstufe eines Ortes \"gesenkt\" wird, wechselt sie von \"völlig überflutet\" zu \"teilweise überflutet\" oder von \"teilweise überflutet\" zu \"nicht überflutet\". Ist ein Ort nicht mehr überflutet, wird sein Flutmarker entfernt.\n\n\n= Sowohl teilweise überflutete Orte als auch völlig überflutete Orte gelten in Bezug auf Karteneffekte als \"überflutet\".\n\n<b>FAQ:</b>\n\n\n- <i>F: Ein Ermittler beginnt seinen Zug an einem völlig überfluteten Ort und betritt dann einen verhüllten Ort ohne Flutmarker. Der neue Ort wird überflutet, \"nachdem er enthüllt worden ist\". Muss der Ermittler auch dann \"versuchen, nach Luft zu schnappen\"? Oder zählt das so, als hätte er einen nicht überfluteten Ort betreten?</i>\n\nA: Im spieltechnischen Sinn hat der Ermittler einen nicht überfluteten Ort betreten, der erst kurze Zeit später überflutet wird, nachdem er enthüllt worden ist. Also muss er nicht versuchen, nach Luft zu schnappen."
+   },
+   {
+      "id":"Ability",
+      "title":"Fähigkeiten",
+      "text":"Eine Fähigkeit ist der spezielle Spieltext, der angibt, wie eine Karte das Spiel beeinflusst.\n\n\n- Kartenfähigkeiten interagieren nur mit dem Spiel, falls die Karte mit der Fähigkeit im Spiel ist, es sei denn, die Fähigkeit (oder die Regel für den entsprechenden Kartentyp) bezieht sich ausdrücklich auf die Verwendung aus einer Zone heraus, die sich nicht im Spiel befindet.\n\n\n- Kartenfähigkeiten interagieren nur mit anderen Karten, die im Spiel sind, es sei denn die Fähigkeit bezieht sich ausdrücklich auf eine Interaktion mit Karten in einer Zone außerhalb des Spiels.\n\n\n- Falls sich mehrere Instanzen derselben Fähigkeit im Spiel befinden, interagiert jede Instanz individuell mit dem Spielstatus (oder darf individuell mit ihm interagieren).\n\nFolgende Typen von Kartenfähigkeiten gibt es: anhaltende Fähigkeiten, erzwungene Fähigkeiten, Enthüllungsfähigkeiten, ausgelöste Fähigkeiten, Schlüsselwörter und Anweisungen für Gegner (Erscheinen und Beute). Jeder dieser Fähigkeitstypen wird im Folgenden detailliert beschrieben.\n\nSiehe auch \"[Adjektive](#Qualifiers)\", \"[Effekte](#Effects)\", \"[Kosten](#Costs)\",  \"[Selbstreferenzieller Text](#Self_Referential_Text)\".",
+      "rules":[
+         {
+            "id":"Abilities_Constant_Abilities",
+            "title":"Anhaltende Fähigkeiten",
+            "text":"Anhaltende Fähigkeiten sind ohne besondere Formatierung auf der Karte angegeben. Anhaltende Fähigkeiten interagieren immer mit dem Spielstatus, solange sich die Karte im Spiel befindet. (Einige anhaltende Fähigkeiten überprüfen dauerhaft eine bestimmte Bedingung; Dies ist an Wörtern wie \"während\" oder \"solange\" zu erkennen. Die Effekte einer solchen Fähigkeit sind zu jeder Zeit aktiv, wenn die angegebene Bedingung erfüllt ist.) Anhaltende Fähigkeiten haben keinen Initiierungszeitpunkt."
+         },
+         {
+            "id":"Abilities_Forced_Abilities",
+            "title":"Erzwungene Fähigkeiten",
+            "text":"Eine erzwungene Fähigkeit erkennt man an der fettgedruckten Anweisung \"<b>Erzwungen</b> –\". Erzwungene Fähigkeiten werden automatisch initiiert und interagieren automatisch zu einem festgelegten Zeitpunkt mit dem Spielstatus. Diesen Zeitpunkt kann man normalerweise an Wörtern wie \"sobald\", \"nachdem\", \"falls\" oder \"zu\" erkennen.\n\n\n- Falls eine erzwungene Fähigkeit nicht die Möglichkeit hat, den Spielstatus zu verändern, wird sie nicht initiiert.\n\n\n- Die Initiierung einer erzwungenen Fähigkeit, welche die Möglichkeit hat, den Spielstatus zu verändern, ist jedes Mal verpflichtend, wenn der vorgegebene Zeitpunkt erfüllt ist.\n\n\n- Eine erzwungene Fähigkeit mit einer Timing-Vorgabe, die mit dem Wort \"sobald …\" beginnt, wird automatisch initiiert, sobald die angegebene Timing-Vorgabe eintritt, aber noch bevor ihre Auswirkungen auf den Spielstatus abgehandelt werden.\n\n\n- Eine erzwungene Fähigkeit mit einer Timing-Vorgabe, die mit dem Wort \"nachdem …\" beginnt, wird automatisch initiiert, nachdem die Auswirkungen der Timing-Vorgabe auf den Spielstatus abgehandelt worden sind.\n\n\n- Zu jeder Timing-Vorgabe müssen alle erzwungenen Fähigkeiten, die sich auf diese Timing-Vorgabe beziehen, abgehandelt werden, bevor [reaction]-Fähigkeiten (siehe unten), die sich auf dieselbe Timing-Vorgabe beziehen, initiiert werden dürfen.\n\nSiehe auch \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
+         },
+         {
+            "id":"Abilities_Revelation_Abilities",
+            "title":"Enthüllungsfähigkeiten",
+            "text":"Eine Enthüllungsfähigkeit, zu erkennen an einem fettgedruckten \"<b>Enthüllung</b> – \" auf einer Begegnungskarte oder Schwäche, wird initiiert, wenn ein Ermittler diese Karte zieht (siehe \"[Enthüllung](#Revelation)\")."
+         },
+         {
+            "id":"Abilities_Triggered_Abilities",
+            "title":"Ausgelöste Fähigkeiten",
+            "text":"Vor einer ausgelösten Fähigkeit steht entweder ein [free]-Symbol, ein [reaction]-Symbol, oder ein [action]-Symbol. Falls die Fähigkeit eine oder mehrere Voraussetzungen hat (Kosten und/oder Bedingungen), werden diese im Text direkt hinter diesem Symbol angegeben. Spieler müssen diese Voraussetzungen für ausgelöste Fähigkeiten immer erfüllen, um diese Fähigkeit auslösen zu können. Es gibt drei Arten ausgelöster Fähigkeiten:\n\n<b>Freie ausgelöste Fähigkeiten ([free]):</b>\n\nEine freie ausgelöste Fähigkeit ([free]) darf in jedem Spielerfenster als Spielerfähigkeit ausgelöst werden. (Siehe \"[Anhang II: Timing und Spiel](#Appendix_II_Timing_and_Gameplay)\" für eine vollständige Liste der Spielerfenster.)\n\n<b>Reaktionsausgelöste Fähigkeiten ([reaction]):</b>\n\nEine reaktionsausgelöste Fähigkeit ([reaction]) mit einer festgelegten Auslösebedingung darf zu jedem Zeitpunkt ausgelöst werden, an dem die Auslösebedingung erfüllt ist.\n\n<i>Beispiel: \"[reaction] Nachdem du einen Gegner besiegt hast:\"</i>\n\n\n- Eine [reaction]-Fähigkeit mit einer Auslösebedingung, die mit dem Wort \"sobald …\" beginnt, darf verwendet werden, nachdem die angegebene Auslösebedingung initiiert worden ist, aber noch bevor ihre Auswirkungen auf den Spielstatus abgehandelt werden.\n\n\n- Eine [reaction]-Fähigkeit mit einer Auslösebedingung, die mit dem Wort \"nachdem …\" beginnt, darf verwendet werden, sofort nachdem die Auswirkungen ihrer Auslösebedingung auf den Spielstatus abgehandelt worden sind.\n\n\n- Jede [reaction]-Fähigkeit darf jedes Mal, wenn ihre angegebene Bedingung erfüllt ist, nur ein Mal ausgelöst werden.\n\n<i>Beispiel: Eine Fähigkeit die ausgelöst wird, \"nachdem X passiert ist\", darf jedes Mal, wenn X passiert ist, nur ein Mal ausgelöst werden.</i>\n\n<b>Aktionsausgelöste Fähigkeiten ([action]):</b>\n\nEine aktionsausgelöste Fähigkeit ([action]) darf nur während eines Spielerzuges in der Ermittlungsphase durch eine Aktivieren-Aktion ausgelöst werden, und nur wenn der Ermittler 1 Aktion für jedes in den Kosten der Fähigkeit angegebene [action]-Symbol verwendet.\n\nFür alle ausgelösten Fähigkeiten gelten folgende Regeln:\n\n\n- Ausgelöste Fähigkeiten auf einer Karte, die ein Spieler kontrolliert, werden von diesem Spieler entsprechend der Timing-Vorgabe, die in der Fähigkeit angegeben ist, freiwillig ausgelöst.\n\n\n- Eine ausgelöste Fähigkeit kann nur initiiert werden, falls ihr Effekt die Möglichkeit hat, den Spielstatus zu ändern, und ihre Kosten (falls vorhanden) vollständig gezahlt werden können, wobei aktive Modifikatoren für Kosten beachtet werden müssen. Ob diese Möglichkeit besteht, wird überprüft, ohne die Konsequenzen der Zahlung der Kosten oder die Interaktion mit anderen Fähigkeiten in Betracht zu ziehen.\n\n\n- Sobald eine Fähigkeit initiiert worden ist, müssen die Spieler ihre Effekte soweit möglich abhandeln, außer wenn der Effekt das Wort \"darf\" enthält (siehe \"[Dürfen](#May)\").\n\nEinem Ermittler ist es erlaubt, ausgelöste Fähigkeiten ([fast], [reaction], und [action]-Fähigkeiten) von folgenden Quellen zu verwenden:\n\n\n- Von einer Karte im Spiel, die er kontrolliert. Das beinhaltet seine Ermittlerkarte.\n\n\n- Von einer Szenariokarte, die im Spiel und am selben Ort wie der Ermittler ist. Das beinhaltet den Ort selbst, Begegnungskarten, die an den Ort angelegt sind, und alle Begegnungskarten in der Bedrohungszone jedes Ermittlers, der sich an diesem Ort befindet.\n\n\n- Von der aktuellen Szenen- oder Agendakarte.\n\n\n- Von jeder Karte, die dem Ermittler ausdrücklich erlaubt, ihre Fähigkeit zu aktivieren."
+         },
+         {
+            "id":"Abilities_Keywords",
+            "title":"Schlüsselwörter",
+            "text":"Ein Schlüsselwort ist eine Kartenfähigkeit, die eine Karte mit speziellen Regeln versieht (siehe \"[Schlüsselwörter](#Keywords)\")."
+         },
+         {
+            "id":"Spawn_Instructions_and_Prey_Instructions",
+            "title":"Erscheinen- und Beute-Anweisungen",
+            "text":"Erscheinen-Anweisungen enthalten Informationen darüber, wo ein Gegner erscheint, wenn er ins Spiel kommt (siehe \"[Erscheinen](#Spawn)\")\n\nBeute-Anweisungen enthalten Informationen darüber, welchen Ermittler ein Gegner verfolgt und/oder in einen Kampf verwickelt, falls er die Wahl hat (siehe \"[Beute](#Prey)\")."
+         },
+         {
+            "id":"Action_Designators",
+            "title":"Aktionskennzeichen",
+            "text":"Einige Fähigkeiten enthalten fett gedruckte Aktionskennzeichen (wie <b>Kampf</b>, <b>Entkommen</b>, <b>Ermitteln</b> oder <b>Bewegen</b>). Durch die Aktivierung einer solchen Fähigkeit wird die bezeichnete Aktion wie in den Regeln beschrieben durchgeführt, allerdings wird sie auf die in der Fähigkeit angegebene Weise modifiziert."
+         }
+      ]
+   },
+   {
+      "id":"For_Each_Or_For_Every",
+      "title":"\"Für jede(n)\" und \"Für je\"",
+      "text":"Manche Karteneffekte weisen einen Ermittler an, einen Effekt mehrmals durchzuführen – für jede Instanz einer bestimmten Bedingung (wie z. B. \"für jeden Horror auf dir\" oder \"für jede Karte auf deiner Hand\"). Falls ein solcher Effekt zusammengefasst werden kann, dann sollte die Anzahl ermittelt werden und der Effekt gleichzeitig abgehandelt werden (und kann zusammen aufgehoben, ignoriert oder verhindert werden). Falls dies nicht möglich ist (weil es z. B. mehrere Schritte, eine Auswahl oder andere Abhängigkeiten gibt), sollte jede Instanz als eigenständiger Effekt abgehandelt werden (und muss daher einzeln aufgehoben, ignoriert oder verhindert werden). \n\n<i>Beispiel: Eine Verratskarte weist dich an: \"Nimm für jeden Punkt, um den die Probe misslingt, 1 Horror.\" Da du auf einen Blick erkennen kannst, um wie viele Punkte die Probe misslungen ist, handle den zugefügten Horror gleichzeitig als 1 einzigen Effekt ab.</i>\n<i>Eine andere Verratskarte weist dich an: \"Für jeden Punkt, um den die Probe misslingt, musst du entweder 1 Aktion verlieren oder 1 Horror nehmen.\" Bei diese Verratskarte müssen die Effekte einzeln abgehandelt werden, da jeder Punkt, um den dir die Probe misslingt, dich vor die Wahl stellt, entweder 1 Aktion zu verlieren oder 1 Horror zu nehmen. Jede Instanz muss einzeln abgehandelt werden, auch wenn das endgültige Resultat nur das Nehmen von Horror ist.</i>"
+   },
+   {
+      "id":"Bonded",
+      "title":"Gebunden",
+      "text":"Karten mit dem \"Gebunden\" Schlüsselwort sind mit einer anderen Spielerkarte verknüpft. Sie haben keine Stufe und sind daher bei der Zusammenstellung der Decks nicht verfügbar. Stattdessen werden sie von der Karte ins Spiel gebracht, an die sie gebunden sind (deren Name steht in Klammern hinter dem Schlüsselwort).\n\nFalls ein Deck eine Karte enthält, die 1 oder mehr gebundene Karten beschwört, sollten diese gebundenen Karten zu Beginn des Spiels beiseitegelegt werden.\n\nFalls eine Schwächekarte mit dem Schlüsselwort Gebunden dem Deck, der Hand, der Bedrohungszone oder der Spielzone eines Ermittlers hinzugefügt wird, bleibt sie (anders als andere Schwächen) für den Rest der Kampagne <b>nicht</b> Teil des Ermittlerdecks. Zu Beginn jedes Spiels wird sie mit den anderen gebundenen Karten des Ermittlers beiseitegelegt.\n\n<i>Beispiel: [Hope](/card/06031), [Zeal](/card/06032) und [Augur](/card/06033) haben alle das Schlüsselwort \"Gebunden (Miss Doyle)\". Dies bedeutet, dass alle diese Karten an die Karte [Miss Doyle](/card/06030) gebunden sind. Hope, Zeal und Augur haben keine Stufe und sind daher nicht verfügbar, wenn du dein Deck zusammenstellst. Miss Doyle bringt jede dieser Karten ins Spiel, sobald sie gespielt wird. Daher sollte ein Spieler, der Miss Doyle in seinem Deck hat, Hope, Zeal und Augur zu Beginn des Spiels beiseitelegen. Diese Karten sind nicht Teil des Ermittlerdecks und zählen daher auch nicht gegen die Deckgröße des Ermittlers.</i>\n\nFalls ein Ermittlerdeck eine Karte enthält, die 1 oder mehr gebundene Karten beschwört, sollten diese Karten zu Beginn des Spiels beiseitegelegt werden. Die Kartenanzahl jeder auf diese Weise beiseitegelegten Karten entspricht der Anzahl an Kopien, die in dem Produkt, aus der sie stammen, ursprünglich enthalten waren. Dabei spielt es keine Rolle, wie viele Kopien der Karten, die jene gebundene Karte beschwören können, in dem Ermittlerdeck enthalten sind.\n\n<i>Beispiel: Ein Ermittler darf zu Beginn des Spiels nur 3 Kopien von [Besänftigende Melodie](/card/05314) beiseitelegen. Dagegen darf ein Ermittler zu Beginn des Spiels nur 1 Kopie von [Essenz des Traums](/card/06113) beiseitelegen, unabhängig davon, wie viele Kopien von [Traumtagebuch](/card/06112) sein Deck enthält.</i>"
+   },
+   {
+      "id":"Enemy_Engagement",
+      "title":"Gegner in einen Kampf verwickeln",
+      "text":"Solange eine Gegnerkarte im Spiel ist, ist sie entweder in einen Kampf mit einem Ermittler verwickelt (und liegt in der Bedrohungszone dieses Ermittlers) oder sie befindet sich an einem Ort (und liegt an diesem Ort). Jeder Gegner in der Bedrohungszone eines Ermittlers gilt als am selben Ort wie dieser Ermittler. Sollte sich der Ermittler bewegen, bleibt der Gegner mit ihm in einem Kampf verwickelt und bewegt sich gleichzeitig mit dem Ermittler an den neuen Ort.\n\nImmer wenn sich ein spielbereiter, nicht in einen Kampf verwickelter Gegner am selben Ort wie ein Ermittler befindet, verwickelt er den Ermittler in einen Kampf und wird in dessen Bedrohungszone platziert. Falls sich mehrere Ermittler am selben Ort wie ein spielbereiter, nicht in einen Kampf verwickelter Gegner befinden, entscheidet die Beute-Anweisung des Gegners darüber, welchen dieser Ermittler der Gegner in einen Kampf verwickelt. Es gibt keine Obergrenze für die Anzahl der Gegner, die mit einem Ermittler in einen Kampf verwickelt sein können.\n\n<i>Beispiel: Ein spielbereiter, nicht in einen Kampf verwickelter Gegner verwickelt einen Ermittler in einen Kampf, falls:</i>\n\n- <i>Er am selben Ort erscheint, an dem sich der Ermittler befindet.</i>\n\n- <i>Er sich an denselben Ort bewegt, an dem sich der Ermittler befindet.</i>\n\n- <i>Ein Ermittler sich an denselben Ort bewegt, an dem sich der Gegner befindet.</i>\n\nEin erschöpfter, nicht in einen Kampf verwickelter Gegner verwickelt keinen Ermittler in einen Kampf, aber falls ein erschöpfter Gegner, der sich am selben Ort befindet wie ein Ermittler, spielbereit gemacht wird, verwickelt er den Ermittler sofort in einen Kampf.\n\n\n- <i>Hinweis: Ein Gegner mit dem Schlüsselwort Zurückhaltend verwickelt Ermittler nicht wie oben angegeben in einen Kampf.</i>\n\nSiehe \"[In einen Kampf verwickeln (Aktion)](#Engage_Action)\"."
+   },
+   {
+      "id":"Enemy_Cards",
+      "title":"Gegnerkarten",
+      "text":"Gegnerkarten stehen für Schurken, Kultisten, Nichtsnutze, fürchterliche Monster und die unvorstellbarsten Wesenheiten aus anderen Dimensionen oder dem Kosmos. Sobald ein Ermittler eine Gegnerkarte zieht, muss er diesen Gegner erscheinen lassen und dabei die Erscheinen-Anweisung der Karte beachten (siehe \"[Erscheinen](#Spawn)\"). Falls der Gegner keine Erscheinen-Anweisung enthält, erscheint er mit dem Ermittler, der auf diese Karte getroffen ist, in einen Kampf verwickelt und wird in die Bedrohungszone dieses Ermittlers platziert.\n\nSiehe \"[1.4 Jeder Ermittler zieht 1 Begegnungskarte](#Mythos_Phase)\".\n\n\n- Ein spielbereiter, nicht in einen Kampf verwickelter Gegner verwickelt einen Ermittler in einen Kampf, wenn er sich am selben Ort wie dieser befindet (siehe \"[Gegner in einen Kampf verwickeln](#Enemy_Engagement)\").\n\n\n- Falls ein Ermittler mit einem Gegner in einen Kampf verwickelt ist und eine Aktion für etwas anderes als kämpfen, entkommen oder die Aktivierung einer Verhandlung- oder Aufgeben-Fähigkeit nimmt, macht jeder dieser Gegner einen Gelegenheitsangriff (siehe \"[Gelegenheitsangriff](#Attack_of_Opportunity)\").\n\n\n- Gegner mit dem Schlüsselwort Jäger bewegen sich in der Gegnerphase (siehe \"[III. Gegnerphase](#Enemy_Phase)\").\n\n\n- In einen Kampf verwickelte Gegner greifen während der Gegnerphase an (siehe \"[III. Gegnerphase](#Enemy_Phase)\")."
+   },
+   {
+      "id":"Enemy_Phase_Placeholder",
+      "title":"Gegnerphase",
+      "text":"Siehe \"[III. Gegnerphase](#Enemy_Phase)\"."
+   },
+   {
+      "id":"Sanity_and_Horror",
+      "title":"Geistige Gesundheit und Horror",
+      "text":"Geistige Gesundheit steht für die mentale und emotionale Widerstandskraft einer Karte. Horror hält fest, welcher Schaden der Seele einer Karte durch die Konfrontation mit den Mächten des Mythos zugefügt wurde.\n\n\n- Sobald eine Karte Horror nimmt, werden Horrormarker in Höhe der gerade genommenen Horrormenge auf die Karte platziert (siehe \"[Schaden/Horror zufügen](#Dealing_Damage_Horror)\").\n\n\n- Falls ein Ermittler Horror in Höhe seiner geistigen Gesundheit (oder mehr) hat, ist dieser Ermittler besiegt. Sobald ein Ermittler besiegt worden ist, scheidet er aus dem Szenario aus (siehe \"[Ausscheiden](#Elimination)\").\n\n\n- Im Kampagnenspiel erleidet ein Ermittler, der durch Horror in Höhe seiner geistigen Gesundheit besiegt worden ist, 1 seelisches Trauma. Durch das Erleiden seelischer Traumata kann ein Ermittler wahnsinnig werden (siehe \"[Kampagnenspiel](#Campaign_Play)\").\n\n\n- Falls eine Vorteilskarte mit einem Wert für geistige Gesundheit Horror in Höhe ihrer geistigen Gesundheit (oder mehr) hat, ist sie besiegt und wird auf den Ablagestapel ihres Besitzers gelegt.\n\n\n- Die \"verbliebene geistige Gesundheit\" einer Karte ist ihr Grundwert für geistige Gesundheit abzüglich der Menge Horror darauf, plus oder minus aktiver Modifikatoren für geistige Gesundheit.\n\n\n- Eine Vorteilskarte ohne Wert für geistige Gesundheit gilt nicht als eine Karte mit einer geistigen Gesundheit von 0, sie kann keine geistige Gesundheit erhalten und ihr kann kein Horror zugewiesen werden.\n\nSiehe auch \"[Direkter Schaden, Direkter Horror](#Direct_Damage_Direct_Horror)\"."
+   },
+   {
+      "id":"Attack_of_Opportunity",
+      "title":"Gelegenheitsangriff",
+      "text":"Jedes Mal wenn ein Ermittler mit einem oder mehreren spielbereiten Gegnern in einen Kampf verwickelt ist und eine andere Aktion nimmt als <b>Kampf</b> oder <b>Entkommen</b> oder eine <b>Verhandeln</b>- oder <b>Aufgeben</b>-Fähigkeit aktiviert, führt jeder dieser Gegner einen Gelegenheitsangriff gegen den Ermittler durch; die Reihenfolge der Angriffe bestimmt dabei der Ermittler. Jeder Angriff fügt dem Ermittler den Schaden und Horror des Gegners zu.\n\n\n- Ein Gelegenheitsangriff wird sofort, nachdem alle Kosten für das Initiieren der Aktion, die diesen Angriff provoziert hat, gezahlt worden sind, aber bevor die Effekte dieser Aktion angewendet werden, durchgeführt.\n\n\n- Eine Fähigkeit, die mehr als eine Aktion kostet, provoziert nur einen Gelegenheitsangriff von jedem Gegner, der in einen Kampf verwickelt ist.\n\n\n- Ein Gegner wird nicht erschöpft, solange er einen Gelegenheitsangriff macht.\n\n\n- Nachdem alle Gelegenheitsangriffe gemacht worden sind, wird das Spiel mit der Abhandlung der Aktion, welche die Angriffe initiiert hat, fortgesetzt.\n\n\n- Im Bezug auf Kartenfähigkeiten zählen Gelegenheitsangriffe als Gegnerangriffe.\n\nEin Gelegenheitsangriff wird nur dann ausgelöst, sobald 1 oder mehrere der Aktionen eines Ermittlers dazu ausgegeben oder verwendet werden, um eine Fähigkeit oder Aktion auszulösen. [free]-Fähigkeiten mit fettgedruckten Aktionskennzeichen provozieren keinen Gelegenheitsangriff."
+   },
+   {
+      "id":"Concealed_X",
+      "title":"Getarnt X",
+      "cycle":[
+         "tskc"
+      ],
+      "text":"Getarnt X ist ein Schlüsselwort, das sich auf manchen Gegnerkarten in der Kampagne <i>Die scharlachroten Schlüssel</i> befindet. Getarnte Gegner stellen versteckte Gegner dar, deren wahrer Aufenthaltsort nicht bekannt ist, bis die Ermittler es schaffen, ihren Aufenthaltsort – und in manchen Fällen auch ihre wahre Identität – zu enttarnen.\n\nEnthält ein Szenario 1 oder mehr getarnte Gegner, werden die Ermittler angewiesen, eine Reihe von getarnten Mini-Karten beiseitezulegen. Diese Mini-Karten sind doppelseitig. Ihre verdeckte Seite stellt den möglichen Ort eines getarnten Gegners dar. Die aufgedeckte Seite enthüllt die wahre Natur einer Mini-Karte – den wahren Aufenthaltsort eines Gegners oder nur einen Köder!\n\nSobald ein Ermittler einen Gegner mit dem Schlüsselwort Getarnt X zieht (oder dazu angewiesen wird, das Schlüsselwort Getarnt auf einem Gegner abzuhandeln), erscheint jener Gegner nicht an einem Ort, sondern in einer Spielzone, die sich oberhalb des Agendadecks befindet. Diese Spielzone wird \"Die Schatten\" genannt: In ihr befinden sich Gegner, von deren Existenz die Ermittler zwar wissen, aber deren Aufenthaltsort auf der Karte noch unbekannt ist. Der Ermittler nimmt dann die beiseitegelegte getarnte Mini-Karte, die jenen Gegner zeigt, sowie X Köder (X ist der auf dem Gegner angegebene Wert hinter dem Schlüsselwort Getarnt). Er mischt die Mini-Karten zusammen und bringt sie so ins Spiel, dass er sie so gleichmäßig wie möglich auf die Orte im Spiel verteilt, beginnend mit den Orten, die zu ihm nächstgelegen sind. Dann mischt er an jedem dieser Orte, an denen sich zuvor bereits getarnte Mini-Karten befunden haben, all jene Karten noch einmal zusammen.\n\n<i>Beispiel: Amina zieht [Agentin der Coterie (A)](/card/09716a) mit dem Schlüsselwort Getarnt 2. Zuerst erscheint die Agentin der Coterie in den Schatten. Dann nimmt sie die beiseitegelegte Mini-Karte Agentin der Coterie (A) und 2 Köder, mischt sie verdeckt zusammen und platziert je 1 Karte auf den 3 zu ihr nächstgelegenen Orten. Hätten sich an einem dieser Orte bereits 1 oder mehr verdeckte Mini-Karten befunden, würde Amina sie jetzt mit der neuen Mini-Karte zusammenmischen.</i>\n\nFür Gegner in den Schatten gelten folgende zusätzliche Regeln:\n\n\n= Gegner in den Schatten gelten als im Spiel, befinden sich aber nicht an einem bestimmten Ort. Sie können sich nicht bewegen, solange sie sich in den Schatten befinden.\n\n\n= Gegner in den Schatten können als \"nächstgelegener\" Gegner infrage kommen, aber nur, falls sich keine anderen Gegner an Orten im Spiel befinden.\n\n\n= Gegner in den Schatten können durch Spielerkarteneffekte keinen Schaden nehmen und das Spiel nicht verlassen.\n\nSiehe auch \"[Getarnte Mini-Karten](#Concealed_Mini_Cards)\""
+   },
+   {
+      "id":"Concealed_Mini_Cards",
+      "title":"Getarnte Mini-Karten",
+      "cycle":[
+         "tskc"
+      ],
+      "text":"Solange sich getarnte Mini-Karten im Spiel befinden, stellen sie den möglichen Aufenthaltsort eines Gegners in den Schatten dar. Um gegen einen solchen Gegner vorgehen zu können, muss zuerst sein wahrer Aufenthaltsort entdeckt werden, indem seine Mini-Karte enttarnt wird. Das kann auf drei Weisen passieren: Kampf, Entkommen oder Ermitteln.\n\n\n= Getarnte Mini-Karten sind keine Gegner und können nicht wie Gegner in einen Kampf verwickelt werden. Allerdings darf ein Ermittler am gleichen Ort wie eine getarnte Mini-Karte versuchen, diese zu enttarnen, indem er sie erfolgreich angreift oder ihr erfolgreich entkommt (als ob sie ein mit ihm in einen Kampf verwickelter Gegner wäre) oder indem er an diesem Ort erfolgreich ermittelt. Die Schwierigkeit, eine getarnte Mini-Karte erfolgreich anzugreifen oder ihr zu entkommen, entspricht dem Schleierwert ihres Ortes.\n\n\n-- Um eine getarnte Mini-Karte zu enttarnen, darf ein Ermittler stattdessen auch Kartenfähigkeiten verwenden, durch die er einem Gegner automatisch entkommt, die einem Gegner Schaden zufügen oder durch die er an einem Ort Hinweise entdeckt.\n\n\n= Falls sich ein Ermittler dazu entscheidet, eine getarnte Mini-Karte zu enttarnen, ersetzt jener Effekt die ursprünglichen Effekte der Aktion oder der Fähigkeit, welche sie enttarnt. <i>(Das heißt: Wird die Mini-Karte eines Gegners durch Entkommen oder durch Schaden enttarnt, wird dem entsprechenden Gegner nicht entkommen bzw. nimmt der Gegner keinen Schaden. Wird eine Mini-Karte durch das Entdecken von Hinweisen oder durch Ermitteln enttarnt, werden keine Hinweise entdeckt.)</i>\n\n\n= Falls eine getarnte Mini-Karte enttarnt wird <i>(auf eine beliebige oben genannte Weise)</i>, wird sie auf ihre aufgedeckte Seite umgedreht.\n\n\n-- Falls es ein Köder ist, wird er ohne Effekt als nicht im Spiel befindlich beiseitegelegt.\n\n\n-- Falls es eine Mini-Karte eines Gegners ist, ist jener Gegner jetzt enttarnt. Der entsprechende Gegner in den Schatten wird auf dem Ort der Mini-Karte platziert, dann wird jene Mini-Karte als nicht im Spiel befindlich beiseitegelegt. <i>(Jener Gegner befindet sich nicht länger in den Schatten, sondern am Ort, wo sich seine Mini-Karte befunden hat.)</i> Falls sich dann keine weiteren Gegner in den Schatten befinden, werden alle verbliebenen getarnten Mini-Karten im Spiel als nicht im Spiel befindlich beiseitegelegt.\n\n\n= Es darf pro Effekt nur 1 Mini-Karte enttarnt werden, außer es ist ausdrücklich etwas anderes angegeben. <i>(Das heißt: Ein Effekt, der jedem Gegner an einem Ort 3 Schaden zufügt, enttarnt nicht alle getarnten Mini-Karten an jenem Ort, sondern nur eine.)</i>\n\n<i>Beispiel: In den Schatten befindet sich eine [Agentin der Coterie](/card/09716a) und eine [Attentäterin der Coterie](/card/09727a). An Kymanis Ort und an einem damit verbundenen Ort befindet sich je 1 getarnte Mini-Karte. (1) Zuerst spielt Kymani ein Ereignis, das an Kymanis Ort einen Hinweis entdecken lässt. Aber statt einen Hinweis zu entdecken, entscheidet sich Kymani, die getarnte Mini-Karte an diesem Ort zu enttarnen, und dreht sie um. Es ist ein Köder, der ohne Effekt beiseitegelegt wird. (2) Als Nächstes bewegt sich Kymani an den verbundenen Ort mit der anderen getarnten Mini-Karte und versucht, sie durch eine Entkommen-Aktion zu enttarnen. Kymani ist erfolgreich, dreht die Mini-Karte um und deckt eine Attentäterin der Coterie auf! (3) Die Mini-Karte wird beiseitegelegt und der Gegner Attentäterin der Coterie wird aus den Schatten an Kymanis Ort bewegt, wo er mit Kymani in einen Kampf verwickelt wird. Weil sich noch ein weiterer Gegner in den Schatten befindet, werden die anderen getarnten Mini-Karten im Spiel nicht aus dem Spiel entfernt.</i>\n\n<b>>FAQ:</b>\n\n\n- <i>F: Wie viele getarnten Mini-Karten kann ich enttarnen, wenn ich eine Fähigkeit mit mehreren Effekten abhandle, wie z. B. [Machtwort](/card/09081) mit den Befehlen Zungenbrecher bzw. Dreimal ausgesprochen oder [Einbruchdiebstahl](/card/07114)?</i>\n\nA: Eine Fähigkeit, die mehrere Effekte hat, um einen Gegner zu enttarnen, kann nur einen dieser Effekte für die Enttarnung verwenden. Eine getarnte Mini-Karte darf enttarnt werden, indem man sie erfolgreich angreift, ihr erfolgreich/automatisch entkommt, erfolgreich an ihrem Ort ermittelt, ihr automatisch Schaden zufügt, oder in ihrem Ort automatisch einen Hinweis entdeckt. Ein beliebiger dieser Effekte kann durch die Enttarnung einer Mini-Karte ersetzt werden. Durch einen solchen Effekt kann nur 1 Mini-Karte gleichzeitig enttarnt werden. <i>Beispiel: Einbruchsdiebstahl hat zwei Effekte: Ermitteln und, falls erfolgreich, einem Gegner entkommen. Einer dieser Effekte darf durch die Enttarnung einer getarnten Mini-Karte ersetzt werden, aber nicht beide. Auf ähnliche Weise funktioniert Zungenbrecher auf Machtwort, wenn du damit die Befehle \"Verrat!\" und \"Beichte!\" erteilst: entweder kann der Schaden oder das Entdecken des Hinweises durch die Enttarnung ersetzt werden. Der andere Effekt wird normal abgehandelt. Dies trifft auch zu, wenn du mit Dreifach ausgesprochen 2 Befehle an 3 Gegner erteilst: dabei darf nur 1 einzige getarnte Mini-Karte enttarnt werden, auch wenn der Effekt bei 3 verschiedenen Gegnern abgehandelt wird.</i>\n\n\n- <i>F: Zählt eine getarnte Mini-Karte im Bezug auf Karteneffekte, die einen Gegner an meinem Ort verlangen, als ein Gegner?</i>\n\nA: Nein. Eine getarnte Mini-Karte kann angegriffen werden oder ihr entkommen werden, \"als ob sie ein mit dir im Kampf verwickelter Gegner wäre\", aber für alle andere Effekte gilt sie nicht als Gegner an diesem Ort. <i>Beispiel: Falls [Trish Scarborough](/card/07003) einen Hinweis an einem Ort mit einer getarnten Mini-Karte aber ohne Gegner entdeckt, kann sie ihre [reaction]-Fähigkeit nicht auslösen, weil der Hinweis nicht an einem Ort \"mit einem Gegner\" entdeckt wurde. Zudem können Effekte, die einen Ermittler \"einen Gegner wählen\" lassen, wie z. B. [Schwäche ausnutzen](/card/09105), nicht verwendet werden, um eine getarnte Mini-Karte zum Ziel zu wählen.</i>"
+   },
+   {
+      "id":"Killed_Insane_Investigators",
+      "title":"Getötete/Wahnsinnige Ermittler",
+      "text":"Im Kampagnenspiel müssen Ermittler, die getötet oder wahnsinnig geworden sind, im Kampagnenlogbuch notiert werden und können für den Rest der Kampagne nicht mehr verwendet werden.\n\n\n- Ein Ermittler mit körperlichen Traumata in Höhe seiner aufgedruckten Ausdauer (oder höher) wird getötet.\n\n\n- Ein Ermittler mit seelischen Traumata in Höhe seiner aufgedruckten geistigen Gesundheit (oder höher) wird wahnsinnig.\n\n\n- Ein Ermittler kann auch durch Kartenfähigkeiten oder die Auf lösung eines Szenarios getötet oder wahnsinnig werden.\n\n\n- In Einzelszenarien besteht praktisch kein Unterschied zwischen getötet, wahnsinnig oder besiegt werden.\n\nSiehe \"[Kampagnenspiel](#Campaign_Play)\"."
+   },
+   {
+      "id":"Massive",
+      "title":"Gewaltig",
+      "text":"Gewaltig ist eine Schlüsselwortfähigkeit. Ein spielbereiter Gegner mit dem Schlüsselwort Gewaltig wird behandelt, als sei er mit jedem Ermittler am selben Ort wie er in einen Kampf verwickelt.\n\n\n- Ein erschöpfter Gegner mit dem Schlüsselwort Gewaltig wird nicht behandelt, als sei er mit Ermittlern am selben Ort wie er in einen Kampf verwickelt.\n\n\n- Ein Gegner mit dem Schlüsselwort Gewaltig kann nicht in die Bedrohungszone eines Ermittlers platziert werden.\n\n\n- Sobald ein Gegner mit dem Schlüsselwort Gewaltig während der Gegnerphase angreift, wird sein (vollständiger) Angriff gegen jeden Ermittler, mit dem er in einen Kampf verwickelt ist, nacheinander abgehandelt. Der Ermittlungsleiter wählt die Reihenfolge, in der die Angriffe abgehandelt werden. Der Gegner mit Gewaltig wird nicht erschöpft, bis sein letzter Angriff der Phase abgehandelt worden ist.\n\n\n- Sobald ein Gegner mit dem Schlüsselwort Gewaltig einen Gelegenheitsangriff durchführt, wird dieser Angriff nur gegen den Ermittler abgehandelt, der den Angriff provoziert hat.\n\n\n- Ein Gegner mit Gewaltig bewegt sich nicht gemeinsam mit einem mit ihm in einen Kampf verwickelten Ermittler, der sich vom Ort des Gegners mit Gewaltig wegbewegt.\n\n\n- Falls einem Ermittler eine Kampfprobe gegen einen Gegner mit Gewaltig misslingt, wird den mit dem Gegner in einen Kampf verwickelten Ermittlern kein Schaden zugefügt."
+   },
+   {
+      "id":"Winning_and_Losing",
+      "title":"Gewinnen und Verlieren",
+      "text":"Jedes Szenario hat mehrere verschiedene mögliche Enden.\n\nDas Szenendeck steht für den Fortschritt, den die Ermittler in einem Szenario machen können. Einige Anweisungen im Szenendeck (sowie auf anderen Begegnungskartentypen) enthalten Auf lösungspunkte in folgendem Format: \"(<b>→A#</b>)\". Das vorrangige Ziel der Spieler ist es, im Szenendeck vorzurücken, bis eine (hoffentlich vorteilhafte) Auf lösung erreicht wird. Sollte das Szenendeck eine Auf lösung hervorrufen, haben die Spieler das Szenario abgeschlossen (und vielleicht sogar gewonnen). Anweisungen für die Abhandlung der angegebenen Auf lösung befinden sich im Kampagnenhandbuch im Abschnitt \"Achtung! Nicht vor Ende des Szenarios weiterlesen.\"\n\nDas Agendadeck steht für den Fortschritt und die Ziele der bösen Mächte, denen die Ermittler in einem Szenario gegenüberstehen. Einige Anweisungen im Agendadeck (sowie auf anderen Begegnungskartentypen) enthalten ebenfalls Auf lösungspunkte in folgendem Format: \"(<b>→A#</b>)\". Sollte das Agendadeck eine (normalerweise finsterere) Auf lösung hervorrufen, haben die Spieler das Szenario verloren. Anweisungen für die Abhandlung der angegebenen Auf lösung befinden sich im Kampagnenhandbuch im Abschnitt \"Achtung! Nicht vor Ende des Szenarios weiterlesen.\"\n\nSollte das Szenario ohne Auf lösung enden (<i>zum Beispiel, falls alle Ermittler ausgeschieden sind oder aufgegeben haben</i>), befinden sich Anweisungen für die Abhandlung im Kampagnenhandbuch im Abschnitt \"Achtung! Nicht vor Ende des Szenarios weiterlesen.\"\n\n\n- Falls die Spieler eine Kampagne spielen, fahren sie unabhängig vom Ausgang dieses Szenarios mit dem nächsten Szenario in der Kampagne fort. Auch wenn die Spieler ein Szenario \"verlieren\", setzen sie die Kampagne trotzdem fort (allerdings mit den negativen Konsequenzen ihrer Niederlage).\n\n\n- Wird ein Einzelszenario gespielt, können die Spieler das Szenario gewinnen oder verlieren. Sie gewinnen, falls sie auf einer Szenenkarte eine Auf lösung abschließen. Jede andere Auf lösung gilt als Niederlage (siehe \"[Einzelspielszenario](#Standalone_Mode)\").\n\nSiehe \"[Szenendeck und Agendadeck](#Act_Deck_and_Agenda_Deck)\"."
+   },
+   {
+      "id":"Base_Value",
+      "title":"Grundwert",
+      "text":"Der Grundwert ist der Wert eines Elementes, bevor Modifikatoren angewendet werden. Wenn nicht anders angegeben, ist der Grundwert eines Elementes, das von einer Karte abgeleitet ist, der auf dieser Karte aufgedruckte Wert."
+   },
+   {
+      "id":"Hand_Size",
+      "title":"Handkartenlimit",
+      "text":"Siehe \"[IV. Unterhaltsphase](#Upkeep_Phase)\"."
+   },
+   {
+      "id":"Story_Cards",
+      "title":"Handlungskarten",
+      "cycle":[
+         "ptc",
+         "rtptc",
+         "tfa",
+         "rttfa",
+         "tcu",
+         "rttcu",
+         "tde",
+         "tdea",
+         "tdeb",
+         "eoe",
+         "tskc",
+         "fof",
+         "gob"
+      ],
+      "text":"Handlungskarten sind eine Kartenart in der Kampagne <i>Der Pfad nach Carcosa</i>. Diese Karten dienen als neue Möglichkeit, die Kampagne mit noch mehr erzählter Handlung zu füllen und sie befinden sich normalerweise auf der Rückseite einer anderen Szenariokarte. Sobald die Spieler die Anweisung erhalten, eine Handlungskarte abzuhandeln, wird der Handlungstext auf der Karte vorgelesen und falls vorhanden der Spieltext auf dieser Karte abgehandelt."
+   },
+   {
+      "id":"Heal",
+      "title":"Heilen",
+      "text":"\"Heilen\" ist eine Anweisung, die eine angegebene Menge Schaden oder eine angegebene Menge Horror von einer Karte entfernt.\n\n\n- Falls eine Karte um mehr Schaden oder Horror geheilt wird, als sie aktuell auf sich hat, wird so viel von der angegebenen Menge wie möglich entfernt."
+   },
+   {
+      "id":"Haunted",
+      "title":"Heimgesucht",
+      "cycle":[
+         "tcu",
+         "rttcu"
+      ],
+      "scenarios":[
+         "laid_to_rest"
+      ],
+      "text":"Heimgesucht ist eine Fähigkeit auf einigen Orten. Immer wenn einem Ermittler eine Fertigkeitsprobe misslingt, solange er an einem Ort ermittelt, muss der Ermittler alle \"<b>Heimgesucht</b>\"-Fähigkeiten auf jenem Ort abhandeln, nachdem alle Ergebnisse jener Fertigkeitsprobe angewendet worden sind.\n\nEin Ort gilt in Hinblick auf andere Karteneffekte als \"heimgesucht\", falls er mindestens 1 \"<b>Heimgesucht</b>\"-Fähigkeit (aufgedruckt oder aus einer anderen Quelle) aufweist."
+   },
+   {
+      "id":"Clues",
+      "title":"Hinweise",
+      "text":"Hinweise stellen den Fortschritt dar, den die Ermittler bei der Lösung eines Geheimnisses, der Aufdeckung einer Verschwörung und/oder dem Vorrücken im Szenario machen können.\n\n\n- Wenn ein Ermittler zum ersten Mal einen Ort betritt, wird dieser Ort enthüllt (auf die Vorderseite gedreht) und es werden Hinweise in Höhe des Hinweiswertes des Ortes auf ihn platziert (aus dem Markervorrat). Die meisten Hinweiswerte sind Werte \"pro Ermittler ([per_investigator])\" . Dies kann auch in der Vorbereitung passieren.\n\n\n- Man kann einen Hinweis auf einem Ort entdecken, indem an einem Ort erfolgreich ermittelt wird (siehe \"[Ermitteln (Aktion)](#Investigate_Action)\" ), oder durch die Fähigkeit einer Karte. Falls ein Ermittler einen Hinweis entdeckt, nimmt er den Hinweis von dem Ort und platziert ihn auf seine Ermittlerkarte unter seiner Kontrolle.\n\n\n- Falls es keine \"<b>Ermittlungsziel</b> – \"- -Voraussetzungen für das Vorrücken der aktuellen Szene gibt, dürfen die Ermittler während des Ermittlerzugs eines beliebigen Ermittlers die benötigte Anzahl Hinweise von ihren Ermittlerkarten ausgeben (normalerweise als Wert \"pro Ermittler\" angegeben), um im Szenendeck vorzurücken. Dies passiert normalerweise als [free]-Spielerfähigkeit. Ein oder alle Ermittler dürfen eine beliebige Anzahl Hinweise zur Gesamtzahl der Hinweise beitragen, die benötigt werden, um im Szenendeck vorzurücken.\n\n\n- Eine Kartenfähigkeit, die sich auf Hinweise \"an einem Ort\" bezieht, bezieht sich auf die noch nicht entdeckten Hinweise, die sich aktuell auf dem Ort befinden.\n\nSiehe auch \"[Szenendeck und Agendadeck](#Act_Deck_and_Agenda_Deck)\", \"[Marker, keine mehr übrig](#Tokens)\"."
+   },
+   {
+      "id":"Clues_on_Player_Cards",
+      "title":"Hinweise auf Spielerkarten",
+      "text":"Manche Karteneffekte wie z. B. auf [Kate Winthrop](/card/10004) können Hinweise auf Karten platzieren, die von einem Ermittler kontrolliert werden. Hinweise, die auf Spielerkarten liegen, werden weiterhin von dem entsprechenden Spieler kontrolliert und können von ihm ganz normal ausgegeben werden. Falls ein Spieleffekt dazu führt, dass eine Karte mit Hinweisen darauf das Spiel verlässt oder die Kontrolle über die Karte wechselt, wird jeder Hinweis auf der Karte auf seinem Ort platziert, an dem sich die Karte befindet."
+   },
+   {
+      "id":"Record_in_your_Campaign",
+      "title":"\"Im Kampagnenlogbuch wird notiert ...\"",
+      "text":"Oft werden die Spieler dazu angewiesen, einen Schlüsselphrase im Kampagnenlogbuch zu notieren. Dieser sollte, falls nicht anders angegeben, unter \"Kampagnennotizen\" vermerkt werden. Weil die Spieler zu einem späteren Zeitpunkt in der Kampagne dazu angewiesen werden könnten, das Kampagnenlogbuch nach dieser Phrase zu überprüfen, sollte der Begriff ohne Veränderungen so notiert werden wie angegeben.\n\n<i>Beispiel: Falls die Spieler dazu angewiesen werden, im Kampagnenlogbuch zu notieren, dass \"die Ermittler vier Stunden zu spät waren\", sollte nicht aufgeschrieben werden, dass \"die Ermittler ziemlich spät waren\". Die genaue Stundenangabe könnte nämlich in einem späteren Szenario noch wichtig werden.</i>"
+   },
+   {
+      "id":"In_Play_and_Out_of_Play",
+      "title":"Im Spiel/Nicht im Spiel",
+      "text":"Die Karten, die ein Spieler in seiner Spielzone kontrolliert, gelten als im Spiel.\n\nDie aktuelle Szene, die aktuelle Agenda, jeder Ort in der Spielzone und jede Begegnungskarte in der Bedrohungszone eines Ermittlers oder an einem Ort gelten alle als im Spiel.\n\nNicht im Spiel bezieht sich auf Karten auf der Hand eines Spielers, in einem Deck, auf einem Ablagestapel, im Siegpunktestapel und beiseitegelegte oder aus dem Spiel entfernte Karten.\n\n\n- Eine Karte kommt ins Spiel, sobald sie von einer nicht im Spiel befindlichen Zone zu einer Zone wechselt, die im Spiel ist.\n\n\n- Eine Karte verlässt das Spiel, sobald sie von einer Zone, die im Spiel ist, zu einer nicht im Spiel befindlichen Zone wechselt.\n\n\n- Marker auf Karten, die im Spiel sind, gelten als im Spiel. Ressourcen im Ressourcenvorrat jedes Ermittlers gelten ebenfalls als im Spiel."
+   },
+   {
+      "id":"Immune",
+      "title":"Immun",
+      "text":"Falls eine Karte immun gegen bestimmte Effekt-Arten ist (<i>zum Beispiel \"Immun gegen Verratskarteneffekte\" oder \"Immun gegen Spielerkarteneffekte\"</i>), kann sie nicht für Effekte dieser Art gewählt oder von ihnen betroffen werden. Nur die Karte selbst ist geschützt; Spielelemente, die in direktem Zusammenhang mit der immunen Karte stehen (wie angehängte Vorteilskarten, Marker auf der Karte oder Fähigkeiten, deren Quelle die immune Karte ist), sind selbst nicht immun.\n\n\n- Falls eine Karte eine Immunität gegen einen Effekt erhält, werden bestehende andauernde Effekte, die bereits vorher auf die Karte angewendet worden sind, nicht entfernt. Falls eine Karte eine Immunität gegen einen Effekt verliert, werden bestehende andauernde Effekte dieser Art nicht auf die Karte angewendet.\n\n\n- Immunität beschützt eine Karte nur vor Effekten. Sie beschützt eine Karte nicht vor Kosten."
+   },
+   {
+      "id":"In_Player_Order",
+      "title":"In Spielerreihenfolge",
+      "text":"Falls die Spieler angewiesen werden eine Reihe von Handlungen \"in Spielerreihenfolge\" durchzuführen, führt der Ermittlungsleiter seinen Teil der Handlungen zuerst durch und die anderen Spieler sind im Uhrzeigersinn danach an der Reihe. Der Begriff \"der nächste Spieler\" bezieht sich in diesem Zusammenhang auf den nächsten Spieler, der (im Uhrzeigersinn) in Spielerreihenfolge handelt."
+   },
+   {
+      "id":"Engage_Action",
+      "title":"In einen Kampf verwickeln (Aktion)",
+      "text":"\"In einen Kampf verwickeln\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf.\n\nUm einen Gegner am selben Ort in einen Kampf zu verwickeln, platziert ein Ermittler den gewählten Gegner in seine Bedrohungszone <i>(z. B. um einen Gegner mit Zurückhaltend in einen Kampf zu verwickeln oder um einen Gegner in einen Kampf zu verwickeln, der erschöpft oder mit einem anderen Ermittler in einen Kampf verwickelt ist)</i>. Der Ermittler und der Gegner sind jetzt in einen Kampf verwickelt.\n\n\n- Ein Ermittler darf die Aktion \"in einen Kampf verwickeln\" durchführen, um einen Gegner in einen Kampf zu verwickeln, der am selben Ort mit einem anderen Ermittler in einen Kampf verwickelt ist. Der Gegner löst sich gleichzeitig vom vorherigen Ermittler und verwickelt den Ermittler, der die Aktion durchführt, in einen Kampf.\n\n\n- Ein Ermittler kann die Aktion \"in einen Kampf verwickeln\" nicht verwenden, um einen Gegner in einen Kampf zu verwickeln, mit dem er bereits in einen Kampf verwickelt ist.\n\nSobald ein Ermittler einen Gegner in einen Kampf verwickelt, hat jener Gegner jenen Ermittler ebenfalls in einen Kampf verwickelt, und umgekehrt. Zwischen \"einen Gegner in einen Kampf verwickeln\" und \"von einem Gegner in einen Kampf verwickelt werden\" besteht kein Unterschied. Effekte, die durch ”Nachdem dich ein Gegner in einen Kampf verwickelt hat\" ausgelöst werden, werden zur gleichen Zeit ausgelöst, wie Effekte, die durch \"Nachdem du einen Gegner in einen Kampf verwickelt hast\" ausgelöst werden."
+   },
+   {
+      "id":"Customizable",
+      "title":"Individualisierbar",
+      "cycle":[
+         "tskc"
+      ],
+      "text":"Individualisierbar ist ein Schlüsselwort, das auf einigen Spielerkarten in der Erweiterung <i>Die scharlachroten Schlüssel</i> zu finden ist. Individualisierbare Karten sind anfänglich eher unscheinbar, können im Verlauf einer Kampagne aber ihr volles Potenzial entfalten. Durch das Ausgeben von Erfahrungspunkten kann jede dieser Karten speziell auf das Deck eines Ermittlers zugeschnitten werden.\n\nJede individualisierbare Karte beginnt bei Stufe 0 und hat einen eigenen Verbesserungsbogen, auf dem aufgeführt ist, welche Verbesserungen mit Erfahrungspunkten erworben werden können. Vor jeder Verbesserung sind 1 oder mehr Kästchen angegeben.\n\nKästchen dürfen nur vor oder nach einem Szenario angekreuzt werden, wenn dein Deck verbessert wird oder neue Karten für ein Deck erworben werden (außer ein Karteneffekt besagt etwas anderes). Das Ausgeben von 1 Erfahrungspunkt erlaubt es einem Ermittler, 1 Kästchen auf einem Verbesserungsbogen einer seiner Karten anzukreuzen.\n\nUm eine Verbesserung zu erwerben, muss der Ermittler alle Kästchen einer Verbesserung angekreuzt haben. Hat ein Ermittler eine Verbesserung erworben, hat <i>jede seiner Kopien</i> der entsprechenden Karte jene Verbesserung (und die damit verbundene Kartenfähigkeit) erhalten.\n\n<i>Beispiel: Die [Rüstung des Jägers](/card/09021) hat die folgende Verbesserung: \"<b>Haltbar</b>. Rüstung des Jägers bekommt +2 Ausdauer.\" Wenn erst 1 Erfahrungspunkt ausgegeben wurde, um eines der beiden Kästchen vor \"Haltbar\" anzukreuzen, ist die Verbesserung noch nicht erworben worden. Erst wenn beide Kästchen angekreuzt wurden (was insgesamt 2 Erfahrungspunkte kostet), ist die Verbesserung erworben worden. Beide Kopien von Rüstung des Jägers im Deck des Ermittlers profitieren von dieser Verbesserung.</i>\n\n\n= Die Kartenstufe einer individualisierbaren Karte entspricht der Hälfte der angekreuzten Kästchen auf ihrem Verbesserungsbogen (aufgerundet). (Eine individualisierbare Karte mit 3 angekreuzten Kästchen hat z. B. eine Kartenstufe von 2.)\n\n<i>Hinweis: Das kann dazu führen, dass manche Ermittler eine individualisierbare Karte ab einem bestimmten Punkt nicht weiter verbessern können, falls ihre Deckbau-Optionen ihnen verbieten würden, eine Karte mit einer bestimmten Stufe in ihr Deck aufzunehmen.</i>\n\n\n= Auf einem Verbesserungsbogen dürfen nicht mehr als 10 Kästchen angekreuzt werden. <i>(Das heißt, dass maximal 10 Erfahrungspunkte für eine bestimmte individualisierbare Karte ausgegeben werden können und die Maximalstufe 5 ist.)</i>\n\n\n= Das Ausgeben von Erfahrungspunkten für 1 oder mehr Verbesserungen einer individualisierbaren Karte, die sich bereits im Deck eines Ermittlers befindet, gilt im Bezug auf Karteneffekte als \"Verbessern\" einer Karte.\n\n\n= Ein Ermittler darf direkt 1 oder mehr Kopien einer neuen individualisierbaren Karte mit 1 oder mehr Verbesserungen erwerben, indem er nur die Erfahrungspunkte zahlt, die nötig sind, um diese Verbesserungen zu erwerben. <i>(Dies zählt als Erwerb einer neuen Karte, nicht als Verbesserung einer bereits existierenden Karte.)</i>\n\n\n= Die Verbesserungen einer individualisierbaren Karte gelten jederzeit als auf der Karte selbst befindlich (auch wenn sich die Karte in einer Zone befindet, die nicht im Spiel ist, wie z. B. auf der Hand oder dem Ablagestapel eines Ermittlers).\n\n\n= Das Ausgeben von 1 oder mehr Erfahrungspunkten für Verbesserungen auf dem Verbesserungsbogen einer individualisierbaren Karte ist permanent und kann nicht rückgängig gemacht werden.\n\n\n= Während des Spiels sollte der Verbesserungsbogen in einer nicht im Spiel befindlichen Zone stets griff bereit liegen. <i>(Wenn mit undurchsichtigen Hüllen gespielt wird, kann der Ermittler den Verbesserungsbogen hinter die Karte schieben, die er modifiziert, um so schnellen Zugriff darauf zu haben.)</i>"
+   },
+   {
+      "id":"Put_into_Play",
+      "title":"Ins Spiel bringen",
+      "text":"Einige Kartenfähigkeiten bewirken, dass eine Karte \"ins Spiel gebracht wird\". Diese Fähigkeiten bringen die Karte direkt aus einer Zone außerhalb des Spiels ins Spiel.\n\n\n- Die Ressourcenkosten der Karte, die ins Spiel gebracht wird, <b>werden nicht bezahlt</b>.\n\n\n- Falls von der \"Ins Spiel bringen\"-Fähigkeit nichts anders angegeben wird, werden diese Karten in einer Zone ins Spiel gebracht, welche die normalen Spielregeln für das Spielen oder (im Fall von Begegnungskarten) Ziehen dieser Karte erfüllt.\n\n\n- Eine Karte, die ins Spiel gebracht worden ist, gilt nicht als gespielt oder gezogen."
+   },
+   {
+      "id":"Enters_Play",
+      "title":"Ins Spiel kommen",
+      "text":"Der Begriff \"ins Spiel kommen\" bezieht sich auf jeden Zeitpunkt, an dem eine Karte aus einer Zone außerhalb des Spiels auf eine Spielzone übergeht (siehe \"[Im Spiel/Nicht im Spiel](#In_Play_and_Out_of_Play)\").\n\n\n- Falls eine Fähigkeit (entweder auf der Karte selbst oder von einer anderen Karte) eine Karte in einem anderen Zustand als durch die Regeln angegeben ins Spiel kommen lässt, gibt es keinen Übergang zu diesem Status. Sie kommt einfach in diesem Zustand ins Spiel."
+   },
+   {
+      "id":"Joes_Hunch_Deck",
+      "title":"Joes \"Spürnase-Deck\"",
+      "text":"[Joe Diamond](/card/05002) hat als Privatdetektiv gelernt, seinen Instinkten zu trauen, und verfügt deshalb über ein separates Spürnase-Deck, das in Schritt 4 der Vorbereitung für jedes Szenario erstellt wird. Die Karten in diesem Spürnase-Deck werden aus Joes Deck gewählt und zählen damit bei der Bestimmung seiner Deckgröße (40 Karten) mit. Bezieht sich etwas auf Joes \"Deck\", dann bezieht es sich damit (mit Ausnahme dieser Vorbereitungsanweisungen) immer auf sein normales Ermittlerdeck und nicht auf sein Spürnase-Deck. Für Joes Spürnase-Deck gibt es keinen Ablagestapel. Karten vom Spürnase-Deck werden auf den normalen Ablagestapel abgelegt, sobald sie gespielt werden."
+   },
+   {
+      "id":"Wild_Skill_Icons",
+      "title":"Joker-Fertigkeitssymbol ([wild])",
+      "text":"Ein Joker-Fertigkeitssymbol ([wild]) auf einer Spielerkarte darf zur Übereinstimmung als jedes andere Fertigkeitssymbol verwendet werden, welches für Kartenfähigkeiten oder zum Beitragen einer Fertigkeitsprobe benötigt wird. Sobald Joker-Fertigkeitssymbole zum Abhandeln einer Kartenfähigkeit verwendet werden, muss der Spieler ansagen, welchem Fertigkeitssymbol sie zum Zeitpunkt der der Verwendung der Karte entsprichen.\n\nJoker-Fertigkeitsymbole, die zu einer Fertigkeitsprobe beitragen, gelten für den Zweck von Kartenfähigkeiten als \"übereinstimmend\"."
+   },
+   {
+      "id":"Hunter",
+      "title":"Jäger",
+      "text":"Jäger ist eine Schlüsselwortfähigkeit.\n\nWährend der Gegnerphase (im [Rahmenschritt 3.2](#Enemy_Phase)) bewegt sich jeder spielbereite, nicht in einen Kampf verwickelte Gegner mit dem Schlüsselwort Jäger auf kürzestem Weg in Richtung des nächstgelegenen Ermittlers auf einen verbundenen Ort. Gegner an einem Ort mit einem oder mehreren Ermittlern bewegen sich nicht.\n\n\n- Falls es mehrere gleich weit entfernte Ermittler gibt, die alle als \"nächstgelegene Ermittler\" in Frage kommen, bewegt sich der Gegner auf den Ermittler zu, der seine \"Beute\"-Anweisung am besten erfüllt. Falls dies keiner tut oder falls der Gegner keine Beute-Anweisung hat, darf der Ermittlungsleiter entscheiden, in Richtung welches Ermittlers sich der Gegner bewegt.\n\n\n- Falls sich ein Jäger-Gegner auf einen Ort bewegen müsste, der Weg auf diesen Ort aber durch eine Kartenfähigkeit versperrt ist, bewegt sich der Gegner nicht.\n\nSiehe auch \"[Beute](#Prey)\"."
+   },
+   {
+      "id":"Campaign_Play",
+      "title":"Kampagnenspiel",
+      "text":"Eine Kampagne ist eine Reihe von miteinander verbundenen Szenarien, in denen jeder Spieler von einem Szenario zum nächsten denselben Ermittler spielt. Im Verlauf der Kampagne erhält der Ermittler Erfahrungspunkte und Traumata, was sich durch Veränderungen seines Decks widerspiegelt. Jede Entscheidung, die in einer Kampagne getroffen worden ist, kann in späteren Szenarien Auswirkungen haben. \n\nSobald man eine Kampagne beginnt, werden die Anweisungen für die Vorbereitung der Kampagne im Kampagnenleitfaden befolgt. Nachdem man ein Szenario in einer Kampagne durchgespielt hat, werden die Ergebnisse im Kampagnenlogbuch notiert.",
+      "rules":[
+         {
+            "id":"Experience",
+            "title":"Erfahrung",
+            "text":"Nachdem die Ermittler die Ergebnisse eines Szenarios notiert haben, können sie mit ihrer gewonnenen Erfahrung neue Karten für ihre Decks erwerben. Dazu werden die folgenden Schritte in angegebener Reihen- folge durchgeführt:\n\n1. <b>Erfahrungspunkte zählen:</b> Jeder Ermittler verdient Erfahrungspunkte in Höhe der Summe der Siegpunktewerte auf allen Karten im Siegpunktestapel, modifiziert durch Boni und Mali, die im Kampagnenleitfaden für diese Auflösung angegeben sind. Diese Summe wird zu eventuell noch nicht ausgegebenen Erfahrungspunkten des Ermittlers addiert, die er in vorherigen Szenarien dieser Kampagne gewonnen hat.\n\n2. <b>Neue Karten erwerben:</b> Nun dürfen neue Karten erworben und dem Deck des Spielers hinzugefügt werden, indem man Erfahrungspunkte in Höhe der Kartenstufe ausgibt (erkennbar an der Anzahl der weißen Punkte oben links auf der Karte). Beim Erwerben neuer Karten beachtet man folgende Regeln:\n\n\n-- Die Deckbaurichtlinien des Ermittlers (auf der Rückseite der Ermittlerkarte) müssen beim Erwerb neuer Karten beachtet werden. Man darf nur Karten erwerben, auf die der Ermittler Zugriff hat. Die Anforderungen für die Deckgröße müssen ebenfalls beachtet werden, indem für jede (nicht dauerhafte) Karte, die erworben und dem Deck hinzugefügt worden ist, eine andere Karte aus dem Deck entfernt wird. Schwächekarten und Karten, die dem Deck eines Ermittlers hinzugefügt werden müssen, dürfen nicht für neu erworbene Karten entfernt werden.\n\n\n-- Jede Karte kostet Erfahrungspunkte in Höhe der Kartenstufe, <i>bis zu einem Minimum von 1</i> (der Kauf einer Karte der Stufe Null kostet trotzdem 1 Erfahrungspunkt). Die Anzahl der weißen Punkte unter den Kosten einer Karte gibt die Stufe der Karte an.\n\n\n-- Beim Kauf einer neuen Karte während eines Kampagnenspiels muss ein Ermittler mindestens 1 Erfahrungspunkt bezahlen. Daraus folgt, dass Karten der Stufe 0 bei Erwerb ebenfalls 1 Erfahrungspunkt kosten. Dieses Minimum wird nur beim Kauf neuer Karten angewendet. Es verändert nicht dauerhaft die Kartenstufe oder die Erfahrungspunktekosten und trifft nicht zu, sobald eine Karte zu einer höherstufigen Version \"verbessert\" wird.\n\n\n-- Sobald man eine Karte erwirbt, die eine höherstufige Version einer Karte mit demselben Kartennamen ist, darf der Ermittler diese Karte \"verbessern\", indem er nur die Differenz der Erfahrung zwischen den beiden Karten zahlt (bis zu einem Minimum von 1) und die niedrigerstufige Version aus seinem Deck entfernt.\n\n\n-- Neue Karten werden einzeln erworben (oder verbessert). Falls ein Ermittler mehr als 1 Kopie einer neuen Karte erwerben möchte, muss er für jede Kopie einzeln zahlen und für jede erworbene Kopie eine Karte aus seinem Deck entfernen.\n\n\n-- Ein Spieler kann sein Deck im Verlauf einer Kampagne nur durch die oben angegebenen Schritte und durch besondere Anweisungen im Kampagnenleitfaden verändern.\n\n3. <b>Nicht ausgegebene Erfahrungspunkte notieren:</b> Jeder Ermittler notiert seine nicht ausgegebenen Erfahrungspunkte im Kampagnenlogbuch. Diese Erfahrungspunkte können zu einem späteren Zeitpunkt in der Kampagne ausgegeben werden."
+         },
+         {
+            "id":"Trauma",
+            "title":"Trauma",
+            "text":"Trauma steht für dauerhaften Schaden an der Ausdauer oder der Psyche eines Ermittlers. \n\nFalls ein Ermittler in einem Szenario besiegt wird, scheidet dieser Ermittler aus dem Szenario, aber nicht unbedingt aus der Kampagne aus. \n\nFalls ein Ermittler durch Schaden in Höhe seiner Ausdauer besiegt worden ist, erleidet er 1 körperliches Trauma (wird im Kampagnenlogbuch notiert). Für jedes körperliche Trauma des Ermittlers beginnt dieser jedes künftige Szenario mit 1 Schaden. Falls ein Ermittler körperliche Traumata in Höhe seiner aufgedruckten Ausdauer hat, wird der Ermittler <b>getötet</b>. \n\nFalls ein Ermittler durch Horror in Höhe seiner geistigen Gesundheit besiegt worden ist, erleidet er 1 seelisches Trauma (wird im Kampagnenlogbuch notiert). Für jedes seelische Trauma des Ermittlers, beginnt dieser jedes künftige Szenario mit 1 Horror. Falls ein Ermittler seelische Traumata in Höhe seiner aufgedruckten geistigen Gesundheit hat, ist der Ermittler <b>wahnsinnig</b> geworden. \n\nFalls ein Ermittler besiegt worden ist, indem er gleichzeitig Schaden in Höhe seiner Ausdauer *und* Horror in Höhe seiner geistigen Gesundheit erhalten hat, wählt er, welches Trauma er erleidet. \n\nFalls ein Ermittler getötet oder wahnsinnig geworden ist, muss der Spieler einen neuen Ermittler für das nächste Szenario wählen und für diesen ein neues Deck erstellen. Getötete oder wahnsinnige Ermittler können für den Rest der Kampagne nicht verwendet werden (siehe \"[Getötete/Wahnsinnige Ermittler](#Killed_Insane_Investigators)\").\n\nFalls ein Spieler einen neuen Ermittler wählen möchte und sich keine weiteren Ermittler im Kartenpool befinden, haben die Spieler verloren und die Kampagne endet."
+         },
+         {
+            "id":"Defeat_by_Card_Ability",
+            "title":"Besiegt durch eine Kartenfähigkeit",
+            "text":"Ein Ermittler kann durch eine Kartenfähigkeit besiegt werden. Ein besiegter Ermittler scheidet aus dem Spiel aus (siehe \"[Ausscheiden](#Elimination)\"). Sollte dies eintreten, befolgt man die Anweisungen der Kartenfähigkeit, um festzustellen, ob dies langfristige Konsequenzen zur Folge hat.\n\n"
+         },
+         {
+            "id":"Advancing_to_Next_Scenario",
+            "title":"Zum nächsten Szenario vorrücken",
+            "text":"Nachdem man ein Szenario abgeschlossen hat, die Auflösung durchgeführt, das Kampagnenlogbuch auf den neusten Stand gebracht und neue Karten erworben hat, rückt man zum nächsten Szenario (in der Reihenfolge) der Kampagne vor, falls die Auflösung des Szenarios die Ermittler nicht direkt zu einem anderen Szenario leitet."
+         },
+         {
+            "id":"Joining_or_Leaving_a_Campaign",
+            "title":"Einer Kampagne beitreten oder sie verlassen",
+            "text":"Hat eine Kampagne erst einmal begonnen, können die Spieler zwischen zwei Szenarien der Kampagne beitreten oder sie verlassen. \n\nFalls ein Spieler eine Kampagne verlässt, werden die Informationen über diesen Spieler nicht aus dem Kampagnenlogbuch gelöscht, da er zu einem späteren Zeitpunkt wieder zwischen zwei Szenarien einsteigen darf. \n\nFalls ein neuer Spieler einer Kampagne beitritt, muss er einen Ermittler wählen, der in dieser Kampagne zuvor noch nicht verwendet worden ist. Dieser Spieler beginnt das Spiel, als ob es sich für ihn um das erste Szenario der Kampagne handeln würde, ohne Erfahrung und ohne Traumata."
+         },
+         {
+            "id":"Transferring_Investigators_to_a_New_Campaign",
+            "title":"Ermittler in eine neue Kampagne übernehmen",
+            "text":"Dieser Abschnitt erweitert die Möglichkeiten, Ermittler aus einer beendeten Kampagne in eine neue Kampagne zu übernehmen, die im Abschnitt \"Das ist das Ende … oder?\" des Kampagenenleitfadens von <i>Die Nacht des Zeloten</i> beschrieben sind.\n\n<i>Hinweis: Die Standardregeln besagen, dass jeder Spieler eine Kampagne frisch von vorne mit einem neuen Deck und mit 0 Erfahrungspunkten startet. Im Folgenden wird eine optionale Variante beschrieben, die mit großer Wahrscheinlichkeit die Spielbalance beeinflusst. Nur unerschrockene Spieler, die das Chaos wirklich nicht fürchten, sollten diese Variante wählen.</i>\n\nWenn 1 oder mehr Ermittler aus einer abgeschlossenen Kampagne in eine neue Kampagne übernommen werden, sollten folgende Regeln beachtet werden:\n\n\n- Es müssen nicht alle überlebenden Ermittler aus der alten Kampagne übernommen werden. Man kann die neue Kampagne problemlos mit ein paar alten und ein paar neuen Ermittlern beginnen.\n\n\n- Die Decks der Ermittler bleiben unverändert. Dies beinhaltet alle in der alten Kampagne verdienten Storyvorteils- und Schwächekarten, sowie alle erhaltenen Erfahrungspunkte und erlittenen Traumata. Auch alles, was im Kampagnenlogbuch unter \"Verdiente Storyvorteile/Schwächen\" notiert ist, wird in die neue Kampagne übernommen.\n\n\n- Alle anderen Notizen im Kampagnenlogbuch werden gelöscht und nicht in die neue Kampagne übertragen.\n\n\n- Der Chaosbeutel wird zurückgesetzt. Alle zusätzlichen Chaosmarker, die dem Chaosbeutel in der alten Kampagne hinzugefügt worden sind, werden aus dem Chaosbeutel entfernt.\n\n\n- Falls ein Ermittler eine Fähigkeit hat, die \"zu Beginn der Kampagne\" oder \"beim Deckbau\" eintritt (<i>Beispiel: die Bonus-Erfahrungspunkte von [Pater Mateo](/card/04004)</i>), wird diese Fähigkeit nicht ein weiteres Mal ausgelöst, wenn ein Ermittler in eine neue Kampagne übernommen wird.\n\n\n- Karten und Kampagnenleitfäden werden in der Annahme geschrieben, dass Ermittler nicht von einer Kampagne in eine andere Kampagne übernommen werden. Aus diesem Grund werden die Kampagnen manchmal als \"die Kampagne\" bezeichnet <i>(Beispiel: \"…für den Rest der Kampagne …\")</i>. Im Allgemeinen sollte jede Kampagne als ihre eigene angesehen , wenn man solche Effekte interpretiert. Dennoch sollten manche Effekte so interpretiert werden, dass sie Teil einer ununterbrochenen Gesamtkampagne sind. Darunter fallen Regeln, wie verdiente Schwäche-oder Storyvorteilskarten gehandhabt werden, oder zusätzliche Regeln, an die sich ein bestimmter Ermittler halten muss <i>Beispiel: \"…für den Rest der Kampagne darf der Träger der Schwäche X nur noch Französisch sprechen.\"</i>"
+         }
+      ]
+   },
+   {
+      "id":"Fight_Action",
+      "title":"Kampf (Aktion)",
+      "text":"\"Kampf\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf.\n\nUm gegen einen Gegner an seinem Ort zu kämpfen, handelt ein Ermittler einen Angriff gegen den Gegner ab, indem er eine Kampfprobe gegen den Kampfwert dieses Gegners ablegt (siehe \"[Fertigkeitsproben](#Skill_Tests)\").\n\nFalls die Probe gelingt, ist der Angriff erfolgreich und dem angegriffenen Gegner wird Schaden zugefügt. Normalerweise wird durch einen Angriff 1 Schaden zugefügt. Einige Waffen, Zauber oder andere Spezialangriffe können diesen Schaden modifizieren. (Dies passiert in Schritt 7 der Fertigkeitsprobe \"[FP.7 Ergebnis der Fertigkeitsprobe anwenden](#Skill_Test_Timing)\")\n\nFalls die Probe misslingt, wird dem angegriffenen Gegner kein Schaden zugefügt. Falls aber einem Ermittler diese Probe gegen einen Gegner, der mit einem einzelnen anderen Ermittler in einen Kampf verwickelt ist, misslingt, wird der Schaden dem Ermittler zugefügt, der mit dem Gegner in einen Kampf verwickelt ist.\n\n\n- Ein Ermittler darf gegen einen beliebigen Gegner an seinem Ort kämpfen: den Gegner, mit dem er in einen Kampf verwickelt ist, einen Gegner am selben Ort, der nicht in einen Kampf verwickelt ist, oder einen Gegner, der mit einem anderen Ermittler am selben Ort in einen Kampf verwickelt ist."
+   },
+   {
+      "id":"Cannot",
+      "title":"Kann nicht/Können nicht",
+      "text":"Der Begriff \"kann nicht\" hat absolute Gültigkeit und kann nicht von anderen Fähigkeiten widerrufen werden."
+   },
+   {
+      "id":"Drawing_Cards",
+      "title":"Karten ziehen",
+      "text":"Sobald ein Spieler angewiesen wird eine oder mehrere Karten zu ziehen, zieht er diese Karten oben von seinem Ermittlerdeck und fügt sie seiner Hand hinzu. \n\nSobald ein Spieler angewiesen wird eine oder mehrere Begegnungskarten zu ziehen, zieht er diese Karten oben vom Begegnungsdeck und handelt diese nach den Regeln für das Ziehen von Begegnungskarten im Rahmenereignisschritt \"[1.4 Jeder Ermittler zieht 1 Begegnungskarte](#Mythos_Phase)\".\n\n\n- Sobald ein Spieler zwei oder mehr Karten als Ergebnis einer einzigen Fähigkeit oder eines Spielschrittes zieht, werden diese Karten gleichzeitig gezogen. Falls ein Deck währenddessen leer wird, wird es zunächst neu gemischt und dann werden die restlichen Karten gezogen.\n\n\n- Es gibt kein Limit, wie viele Karten ein Spieler in jeder Runde ziehen darf.\n\n\n- Falls ein Ermittler mit einem leeren Ermittlerdeck eine Karte ziehen muss, mischt er seinen Ablagestapel zurück in sein Deck und zieht dann die Karte. Nachdem das Ziehen vollständig abgeschlossen ist, nimmt er 1 Horror. \n\nFalls eine Karte ausdrücklich der Hand eines Ermittlers hinzugefügt wird, ohne das Wort \"ziehen\" zu verwenden, zählt es nicht als \"Ziehen\" einer Karte im Bezug auf andere Karteneffekte.\n\n<i>Hinweis: Manche Fähigkeiten (wie z. B. Enthüllen-Fähigkeiten auf Schwächen und [[Dilemma]]-Karten werden ausgelöst, unabhängig davon, ob die Karte \"gezogen\" oder \"der Hand hinzugefügt\" wurde.</i>"
+   },
+   {
+      "id":"Cardtypes",
+      "title":"Kartentypen",
+      "text":"Informationen über die Kartentypen des Spiels und ihren genauen Aufbau befinden sich in Anhang IV (siehe \"[Anhang IV: Aufbau der Karten](#Appendix_IV_Card_Anatomy)\").\n\n\n- Falls eine Fähigkeit dafür sorgt, dass eine Karte ihren Kartentyp ändert, verliert sie alle anderen Kartentypen, die sie möglicherweise hat, und funktioniert genau wie andere Karten des neuen Kartentyps.\n\nSiehe auch \"[Ereigniskarten](#Event_Cards)\", \"[Fertigkeitskarten](#Skill_Cards)\", \"[Gegnerkarten](#Enemy_Cards)\", \"[Ortskarten](#Location_Cards)\", \"[Verratskarten](#Treachery_Cards)\", \"[Vorteilskarten](#Asset_Cards)\"."
+   },
+   {
+      "id":"Control",
+      "title":"Kontrolle",
+      "text":"Siehe \"[Besitz und Kontrolle](#Ownership_and_Control)\"."
+   },
+   {
+      "id":"Controlling_and_Attaching_Permanent_Cards",
+      "title":"Kontrolle und Anhängen von Dauerhaft-Karten",
+      "text":"Eine Karte mit dem Schlüsselwort Dauerhaft kann die Spielzone des Spielers, der sie kontrolliert, nicht verlassen, außer der Effekt einer Szenariokarte weist dazu an. Karten mit dem Schlüsselwort Dauerhaft können nicht an Karten in der Spielzone eines Ermittlers angehängt werden. Ermittler können nicht die Kontrolle über Dauerhaft-Karten eines anderen Ermittlers übernehmen. \n\n<i>Beispiel: [Sündenfresser](/card/09094) kann z. B. nicht an [Elle Rubash](/card/09092) angehängt werden, auch wenn sich auf Sündenfresser 1 oder mehr Verderben befindet.</i>"
+   },
+   {
+      "id":"Copy",
+      "title":"Kopie",
+      "text":"Eine Kopie einer Karte wird durch ihren Kartennamen bestimmt. Eine zweite Kopie einer Karte ist eine andere Karte mit demselben Kartennamen, unabhängig von Kartentyp, Text, Bild oder anderen Eigenschaften der Karte."
+   },
+   {
+      "id":"Costs",
+      "title":"Kosten",
+      "text":"Es gibt zwei Arten von Kosten im Spiel: Ressourcenkosten und Fähigkeitskosten. \n\nDie Ressourcenkosten einer Karte entsprechen ihrem numerischen Wert, der (in Ressourcen) bezahlt werden muss, um diese Karte von der Hand zu spielen. Um die Ressourcenkosten zu bezahlen, nimmt ein Ermittler eine bestimmte Anzahl Ressourcen aus seinem Ressourcenvorrat und legt sie in den Markervorrat zurück. \n\nEinige ausgelöste Kartenfähigkeiten haben das Format \"Kosten: Effekt\". In diesem Fall gibt der Teil vor dem Doppelpunkt die Kosten der Fähigkeit an, die bezahlt werden müssen, sowie Auslösebedingungen, die erfüllt sein müssen, um die Fähigkeit auszulösen. Der Teil nach dem Doppelpunkt ist der Effekt.\n\n\n- Falls mehrere Kosten für eine einzelne Karte oder Fähigkeit bezahlt werden müssen, müssen diese Kosten gleichzeitig bezahlt werden.\n\n\n- Nur der Spieler, der eine Karte oder Fähigkeit kontrolliert, darf ihre Kosten bezahlen. Es dürfen keine Spielelemente verwendet werden, die andere Spieler kontrollieren, um Kosten zu bezahlen.\n\n\n- Sobald Karten erschöpft, geopfert oder anderweitig verwendet werden, um Kosten zu bezahlen, dürfen nur Karten im Spiel und unter der Kontrolle ihres Besitzers verwendet werden, falls die Kosten nicht ausdrücklich den Status außerhalb des Spiels angeben.\n\n\n- Falls zum Bezahlen von Kosten ein Spielelement benötigt wird, das nicht im Spiel ist, darf der Spieler, der die Kosten bezahlt, nur Spielelemente verwenden, die sich in seinen Spielzonen befinden (wie seine Hand oder sein Deck), um die Kosten zu bezahlen.\n\n\n- Falls die Ermittler angewiesen werden Kosten als Gruppe zu bezahlen, darf jeder Ermittler (oder jeder Ermittler der durch die von der Fähigkeit definierten Gruppe) zu den Kosten beitragen.\n\n\n- Eine Fähigkeit kann nicht initiiert werden und ihre Kosten nicht bezahlt werden, falls das Abhandeln ihrer Effekte den Spielstatus nicht ändern.\n\n\n- Falls ein Ermittler als Kosten Schaden oder Horror nimmt und einen Teil davon auf eine Vorteilskarte umverteilt, gelten die Kosten trotzdem als bezahlt.",
+      "rules":[
+         {
+            "id":"Ignoring_All_Costs",
+            "title":"\"Alle Kosten ignorieren\"",
+            "text":"Manche Karten wie z. B. [Wissen ist Macht](/card/05231) oder [Wort des Leids](/card/09012) erlauben es dem Ermittler, eine Karte zu spielen oder eine Fähigkeit auf einer Vorteilskarte zu aktivieren, wobei er \"alle Kosten ignoriert\". Diese Effekte ignorieren nur die Kosten zur Initiierung einer Fähigkeit. Zusätzliche Kosten müssen noch immer gezahlt werden, sobald die Fähigkeit abgehandelt wird – in anderen Worten: Alles vor dem Doppelpunkt des Effekts wird ignoriert, aber alle zusätzlichen Kosten nach dem Doppelpunkt müssen ganz normal gezahlt werden.\n\n<i>Beispiel: Falls ein Ermittler Wissen ist Macht verwendet, um die [action]-Fähigkeit auf [Altes Buch des Wissens](/card/01031) zu aktivieren, erlaubt ihm Wissen ist Macht, die Aktionskosten und das Erschöpfen des Buches zu ignorieren, um seine Fähigkeit zu aktivieren und das Deck nach 1 Karte zu durchsuchen. Die zusätzlichen Kosten (das Ausgeben von 1 Geheimnis), um gesuchte Karte zu spielen, bleiben bestehen. Auf gleiche Weise erlaubt es Wort des Leids, die Aktionskosten auf [Irdische Seelenruhe](/card/08117) zu ignorieren und die Probe abzulegen. Zum Heilen eines Ermittlers müssen dennoch zusätzlich Ladungen ausgegeben werden.</i>"
+         }
+      ]
+   },
+   {
+      "id":"Blank",
+      "title":"Leer",
+      "text":"Falls das aufgedruckte Textfeld einer Karte durch eine Fähigkeit behandelt wird, als ob es \"leer\" wäre, wird dieses Textfeld behandelt, als ob es keinen aufgedruckten Inhalt hätte. Text und/oder Symbole, die aus anderen Quellen stammen, werden dadurch nicht geleert.\n\n\n- Das Textfeld einer Karte enthält Merkmale, Schlüsselwörter, Kartentexte und Fähigkeiten."
+   },
+   {
+      "id":"Empty_Location",
+      "title":"Leerer Ort",
+      "text":"Ein leerer Ort ist ein Ort, an dem sich keine Gegner oder Ermittler befinden."
+   },
+   {
+      "id":"Limbo",
+      "title":"Limbus",
+      "text":"Solange die Effekte einer Ereignis- oder Verratskarte abgehandelt werden, oder solange eine Fertigkeitskarte zu einer Fertigkeitsprobe beigetragen wird, ist die Karte weder im Spiel noch auf dem Ablagestapel oder auf der Hand eines Ermittlers. Für diese Regelklarstellung befindet sich die Karte in einem Übergangszustand, im sogenannten \"Limbus\".\n\nEine Ereigniskarte betritt den Limbus in Schritt 3 der Initiierungssequenz, nachdem die Kosten bezahlt und Gelegenheitsangriffe abgehandelt worden sind (siehe Anhang I \"[Abfolge einer Initiierung](#Appendix_I_Initiation_Sequence)\"). Eine Verratskarte betritt den Limbus, nachdem sie gezogen worden ist, während ihre Enthüllung-Fähigkeit abgehandelt wird. Eine Fertigkeitskarte betritt den Limbus, sobald sie zu einer Fertigkeitsprobe beigetragen wird. Solange sich die Karte im Limbus befindet, wird sie normalerweise auf den Tisch gelegt, um anzuzeigen, das ihre Effekte gerade abgehandelt werden. Die Karte gilt nicht mehr als auf der Hand eines Ermittlers, befindet sich aber auch noch nicht auf einem Ablagestapel. Sie ist spieltechnisch auch nicht im Spiel und zählt nicht für andere Karteneffekte, die sich auf Karten im Spiel beziehen, auch wenn ihre Effekte den Spielstatus verändern. Nachdem die Effekte der <i>vollständig</i> abgehandelt worden sind, wird die Karte auf den entsprechen den Ablagestapel gelegt und befindet sich dann nicht mehr im Limbus. Falls die Effekte der Karte dazu führen, dass die Karte das Spiel betritt (wie z. B. durch das Anhängen an ein anderes Spielelement oder das Platzieren in der Bedrohungszone oder in der Spielzone eines Ermittlers), verlässt die Karte den Limbus und betritt gleichzeitig das Spiel."
+   },
+   {
+      "id":"Lola_and_Roles",
+      "cycle":[
+         "ptc"
+      ],
+      "title":"Lola und die \"Rollen\"",
+      "text":"Als gefeierte Schauspielerin kann Lola Hayes viele verschiedene Rollen spielen. Zu Beginn jedes Szenarios muss Lola, nachdem die Ermittler ihre Starthand gezogen haben, eine Rolle wählen (Neutral, Wächter, Sucher, Schurke, Mystiker oder Überlebender). Lola kann nur ihrer Rolle entsprechende und neutrale Karten spielen und zu einer Fertigkeitsprobe beitragen oder [action]-, [fast]- und [reaction]-Fähigkeiten auf neutralen Karten oder Karten, die ihrer Rolle entsprechen, auslösen. Diese Einschränkung gilt nur für Spielerkarten, nicht für Begegnungskarten oder Schwächen. Es ist zu beachten, dass anhaltende oder <b>Erzwungen</b>-Fähigkeiten auch auf Karten aktiv bleiben, die nicht Lolas Rolle entsprechen."
+   },
+   {
+      "id":"Tokens",
+      "title":"Marker, keine mehr übrig",
+      "text":"Es gibt keine Begrenzungen für die Anzahl der Marker (jeder Art), die sich zu einem Zeitpunkt in der Spielzone befinden können. Falls die Spieler keine von den mitgelieferten Markern mehr übrig haben, können andere Marker, Zähler oder Münzen verwendet werden, um den aktuellen Spielstatus festzuhalten."
+   },
+   {
+      "id":"Remember_that",
+      "title":"\"Merke dir, dass ...\"",
+      "text":"Manchmal weist eine Szenariokarte die Ermittler an sich eine Schlüsselphrase zu \"merken\", oftmals nach einer Aktion oder einer Entscheidung, die sie innerhalb eines Szenarios gemacht oder getroffen haben. Diese Phrase könnte während des Szenarios erneut aufkommen und zusätzliche oder andere Effekte auslösen. Dieser Begriff muss nicht im Kampagnenlogbuch notiert werden, da er nur während dieses Szenarios oder dessen Auflösung eine Rolle spielen könnte. Die Spieler müssen sich eine solche Anweisung nicht länger \"merken\", sobald das Szenario abgeschlossen ist, in dem sie aufgekommen ist. Falls ein solcher \"Merken\"-Effekt das Wort \"du\" verwendet, bezieht sich dieser auf den Ermittler, der den Effekt abhandelt."
+   },
+   {
+      "id":"Traits",
+      "title":"Merkmale",
+      "text":"Die meisten Karten haben 1 oder mehrere Merkmale, die oben im Textfeld in fett-kursiv gedruckt sind.\n\n\n- Merkmale haben keinen eigenständigen Effekt auf das Spiel. Stattdessen beziehen sich einige Kartenfähigkeiten auf Karten, die spezielle Merkmale besitzen."
+   },
+   {
+      "id":"Modifiers",
+      "title":"Modifikatoren",
+      "text":"Einige Fähigkeiten modifizieren Werte oder Mengen von Eigenschaften. Der Spielstatus fragt ständig variable Werte und Mengen ab und bringt (falls nötig) die modifizierten Werte auf den neusten Stand.\n\nImmer wenn ein neuer Modifikator angewendet (oder entfernt) wird, wird das gesamte Ergebnis komplett neu berechnet, ausgehend vom nicht modifizierten Grundwert und unter Beachtung aller Modifikatoren.\n\n\n- Sobald ein Wert berechnet wird, gelten alle Modifikatoren als gleichzeitig angewendet. Bei der Berechnung werden jedoch alle Modifikatoren, die etwas addieren oder subtrahieren, durchgeführt, bevor ein Wert verdoppelt oder halbiert wird.\n\n\n- Bruchzahlen werden aufgerundet, nachdem alle Modifikatoren angewendet worden sind.\n\n\n- Eine Mengenangabe auf einer Karte (wie ein Eigenschaftswert, ein Symbol, die vorhandene Anzahl eines Merkmals oder Schlüsselwortes) kann nicht funktional unter Null fallen. Negative Modifikatoren, die über die aktuelle Anzahl des Wertes hinausgehen, werden zwar angewendet, aber ein negatives Ergebnis wird nach der Anwendung aller Modifikatoren behandelt, als ob der Wert Null wäre.\n\n<i>Beispiel: Hans-Werner legt eine Beweglichkeitsprobe ab und deckt einen Chaosmarker mit dem Wert –8 auf. Sobald dieser Modifikator auf seine Beweglichkeit von 4 angewendet wird, würde dies seinen Fertigkeitswert auf –4 senken. Seine Beweglichkeit kann aber nicht so weit gesenkt werden, dass sie funktional unter Null liegen würde. Auch wenn der Modifikator von –8 existiert, wird seine Beweglichkeit wie Null behandelt. Falls Hans-Werner nun [Glückspilz!](/01080) spielen würde, um einen Bonus von +2 zu erhalten, würde dieser Bonus allerdings nicht auf den funktionalen Wert der Fertigkeit von Null angewendet, sondern gemeinsam mit allen anderen aktiven Modifikatoren. Hans-Werners Beweglichkeit würde dann folgendermaßen berechnet werden: Grundfertigkeitswert 4, –8 durch den Chaosmarker, +2 durch \"Glückspilz!\" was ein Ergebnis von –2 ergeben würde, was immer noch wie Null behandelt wird.)</i>"
+   },
+   {
+      "id":"Mulligan",
+      "title":"Mulligan",
+      "text":"Nachdem ein Spieler während der Vorbereitung seine Starthand gezogen hat, erhält dieser Spieler einmalig einen Mulligan: Er darf eine beliebige Anzahl der gezogenen Karten auswählen, die er nicht auf seiner Starthand behalten will. Diese Karten werden beiseitegelegt und er zieht genauso viele Karten nach und fügt sie seiner Starthand hinzu. Die beiseitegelegten Karten werden dann zurück in das Deck dieses Spielers gemischt.\n\n\n- Die Spieler nehmen ihren Mulligan (oder verzichten darauf) in Spielerreihenfolge."
+   },
+   {
+      "id":"Multiclass_Cards",
+      "title":"Multi-Klassen-Karten",
+      "text":"Eine Multi-Klassen-Karte ist ein Karte, die statt nur einem mehrere Klassensymbole aufweist. Sie gilt als Karte jede dieser Klassen. <i>Beispiel: Eine Karte mit einem Schurken-([rogue])-Symbol und einem Wächter-([guardian])-Symbol ist für alle Zwecke sowohl eine Schurkenkarte als auch eine Wächterkarte</i>. Normalerweise kann eine solche Karte in das Deck eines Ermittlers aufgenommen werden, falls der Ermittler zu einer der Klassen der Karte Zugriff hat.\n\nFalls ein Ermittler begrenzten Zugriff zu einer der Klassen auf einer Multi-Klassen-Karte hat und unbegrenzten Zugriff zu einer anderen Klasse auf der Karte, verbraucht sie dennoch einen der begrenzten Slots des Ermittlers, es sei denn, die Deckbau-Optionen beinhalten das Wort \"andere(r)\" (siehe [Deckbau-Optionen](#Deckbuilding_Options)).\n\nDer folgende Abschnitt stellt klar, wie Multi-Klassen-Karten bei bestimmten Deckbau-Optionen eines Ermittlers funktionieren.\n\n\n- <b>Ermittler mit unbegrenztem Zugriff zu mehr als 1 Klasse</b> <i>(z. B. alle Ermittler aus dem Grundspiel, [Minh Thi Phan](/card/03002), [Sefina Rousseau](/card/03003), [William Yorick](/card/03005), [Leo Anderson](/card/04001), [Joe Diamond](/card/05002), [Preston Fairmont](/card/05003), [Diana Stanley](/card/05004))</i>: Eine Multi-Klassen-Karte kann in das Deck des Ermittlers aufgenommen werden, falls sie zu <i>einem</i> der aufgezählten Klassen gehört.\n\n\n- <b>Ermittler aus der Erweiterung <i>Das Vermächtnis</i> von Dunwich</b> <i>(z. B. [Zoey Samaras](/card/02001), [Rex Murphy](/card/02002), [Jenny Barnes](/card/02003), [Jim Culver](/card/02004), [\"Ashcan\" Pete](/card/02005))</i>: Eine Multi-Klassen-Karte verbraucht nicht 1 der 5 \"klassenfremden\" Slots, falls 1 seiner Klassen zu der Klasse gehört, zu welcher der Ermittler unbegrenzten Zugriff hat. Eine Karte kann nicht mehr als 1 \"klassenfremden\" Slot einnehmen, unabhängig davon, wie viele Klassensymbole auf der Karte zu finden sind.\n\n\n- <b>Ermittler mit unbegrenztem Zugriff zu 1 Klasse und begrenztem Zugriff zu 1 oder mehr \"anderen\" Klassen</b> <i>(z. B. [Marie Lambeau](/card/05006), [Finn Edwards](/card/04003), [Carolyn Fern](/card/05001), Ermittler aus der Erweiterung \"Am Rande der Welt\")</i>: Eine Multi-Klassen-Karte verbraucht nicht 1 der begrenzen Slots des Ermittlers, weil sie in die unbegrenzte Kategorie fällt (siehe [Deckbau-Optionen](#Deckbuilding_Options)).\n\n\n- <b>Ermittler mit unbegrenztem Zugriff zu 1 Klasse und begrenztem Zugriff zu einer zweiten Klasse ohne das Wort ”andere(r)\" zu benutzten</b> <i>(z. B. [Norman Withers](/card/08004))</i>: Eine Multi-Klassen-Karte verbraucht 1 der begrenzten Slots des Ermittlers, selbst wenn sie ebenfalls in die unbegrenzte Kategorie fällt.\n\n\n- <b>[Lola Hayes](/card/03006)</b>: Eine Multi-Klassen-Karte zählt bei den Deckbau-Optionen als eine Karte für jede ihrer Klassen."
+   },
+   {
+      "id":"Mythos_Phase_Placeholder",
+      "title":"Mythosphase",
+      "text":"Siehe \"[I. Mythosphase](#Mythos_Phase)\"."
+   },
+   {
+      "id":"Must",
+      "title":"Müssen",
+      "text":"Falls ein Ermittler angewiesen wird, dass er zwischen mehreren Optionen wählen \"muss\", ist er verpflichtet eine Option zu wählen, welche die Möglichkeit hat, den Spielstatus zu verändern.\n\n\n- Falls eine Form des Wortes \"müssen\" fehlt, sobald eine Auswahl zwischen mehreren Möglichkeiten getroffen wird, kann man bei der Abhandlung dieses Effektes jede Möglichkeit wählen – selbst eine Möglichkeit, die den Spielstatus nicht ändert."
+   },
+   {
+      "id":"After",
+      "title":"Nachdem",
+      "text":"Das Wort \"nachdem\" bezieht sich auf den Zeitpunkt direkt nachdem die angegebene Timing-Vorgabe oder auslösende Bedingung vollständig abgehandelt worden ist.\n\n<i>Beispiel: Eine Fähigkeit mit dem Text: \"Nachdem du eine Gegnerkarte gezogen hast\" wird sofort initiiert, nachdem alle Schritte für das Ziehen einer Gegnerkarte abgehandelt worden sind – seine Enthüllungsfähigkeit abgehandelt worden ist, Monster erschienen sind, u. s. w.</i>\n\nSiehe auch \"[Fähigkeiten](#Ability)\", \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
+   },
+   {
+      "id":"Surge",
+      "title":"Nachrüsten",
+      "text":"Nachrüsten ist eine Schlüsselwortfähigkeit.\n\nNachdem eine Begegnungskarte mit dem Schlüsselwort Nachrüsten gezogen und abgehandelt worden ist, muss ein Ermittler eine weitere Karte vom Begegnungsdeck ziehen.\n\n\n- Falls eine Karte mit Nachrüsten während der Vorbereitung gezogen wird, handelt man das Schlüsselwort Nachrüsten ab."
+   },
+   {
+      "id":"Nearest",
+      "title":"Nächstgelegen",
+      "text":"Einige Karten beziehen sich auf die \"nächstgelegene\" Entität. Nächstgelegen bezieht sich auf die Entität der angegebenen Art an dem Ort, der mit den wenigsten Verbindungen erreicht werden kann, selbst wenn eine oder mehrere dieser Verbindungen durch eine andere Kartenfähigkeit blockiert sind. Der Weg zur nächstgelegenen Entität ist der \"kürzeste\" Weg zu dieser Entität."
+   },
+   {
+      "id":"Location_Cards",
+      "title":"Ortskarten",
+      "text":"Ortskarten stehen für die Orte, welche die Ermittler im Verlauf eines Szenarios erkunden.\n\n\n- Die kleinen Ermittlerkarten werden verwendet, um anzuzeigen, an welchem Ort sich der jeweilige Ermittler befindet.\n\n\n- Solange sich ein Ermittler an einem Ort befindet, befindet sich der entsprechende Ermittler, alle seine Vorteilskarten und jede Karte in der Bedrohungszone dieses Ermittlers am selben Ort.\n\n\n- Orte kommen mit dem Spielstatus \"verhüllt\" ins Spiel, also mit der Seite ohne Schleier- und/oder Hinweiswert nach oben. Zu diesem Zeitpunkt wird die enthüllte Seite noch nicht gelesen.\n\n\n- Das erste Mal wenn ein Ermittler einen Ort betritt, wird der entsprechende Ort enthüllt, indem er auf die andere Seite gedreht wird, und es werden Hinweise entsprechend des Hinweiswertes des Ortes auf ihn platziert (dies kann auch während der Vorbereitung passieren). Die meisten Hinweiswerte sind Werte \"pro Ermittler\" ([per_investigator]).\n\n\n- Ein Ort, dessen Seite mit Schleier-/Hinweiswert oben liegt, hat den \"enthüllten\" Status.",
+      "rules":[
+         {
+            "id":"Being_at_No_Location",
+            "title":"An keinem Ort",
+            "text":"Ermittler und Gegner müssen sich während des Spiels immer an einem Ort befinden, es sei denn, ein Spieltext gibt etwas anderes an. Falls ein Effekt (wie z. B. ein \"Kann sich nicht bewegen\"-Effekt) dazu führt, dass sich ein Ermittler oder Gegner an keinem Ort befinden würde, wird der Effekt ignoriert."
+         }
+      ]
+   },
+   {
+      "id":"Partner",
+      "title":"Partner",
+      "cycle":[
+         "eoe"
+      ],
+      "text":"Partner ist eine Schlüsselwortfähigkeit in der Erweiterung <i>Am Rande der Welt</i>, die sich auf den 9 Storyvorteilskarten im <i>Expeditionsteam</i>-Begegnungsset befindet. Jede dieser Vorteilskarten repräsentiert einen mächtigen Verbündeten, der die Ermittler in den Szenarien der Kampagne <i>Am Rande der Welt</i> begleiten kann, um die Erfolgschancen der Expedition zu verbessern. Allerdings birgt das Mitbringen einer Vorteilskarte mit dem Partner-Schlüsselwort die Gefahr, diese dauerhaft zu verlieren.\n\n\n= Zu Beginn jedes Szenarios der Kampagne <i>Am Rande der Welt</i> hat jeder Ermittler die Möglichkeit, eine Vorteilskarte mit dem Schlüsselwort Partner zu wählen und ins Spiel zu bringen. Vorteilskarten mit dem Schlüsselwort Partner können keinem Ermittlerdeck hinzugefügt werden. Jedes Mal, wenn ein Ermittler die Möglichkeit hat, einen Partner zu wählen, darf er einen anderen (oder keinen) Partner wählen.\n\n\n= Eine Vorteilskarte mit dem Schlüsselwort Partner bleibt so lange im Spiel, bis sie besiegt wird (sie kann z. B. nicht durch Karteneffekte abgelegt werden, außer sie wird explizit besiegt). Falls ein Ermittler besiegt wird, gilt jede Vorteilskarte mit dem Schlüsselwort Partner, die er bei sich hat, ebenfalls als besiegt.\n\n\n= Falls eine Vorteilskarte mit dem Schlüsselwort Partner besiegt wird, wird sie aus dem Spiel entfernt. Dann wird der Name des Charakters im Abschnitt \"Expeditionsteam\" des Kampagnenlogbuchs durchgestrichen.\n\n\n= Schaden oder Horror auf einer Vorteilskarte mit dem Schlüsselwort Partner wird am Ende des Spiels im Abschnitt \"Expeditionsteam\" des Kampagnenlogbuchs notiert. <i>(Der Kampagnenleitfaden weist die Ermittler an, wann dies geschieht.)</i>\n\n\n= Falls ein Ermittler in einem Szenario aufgibt, verlässt die Partner-Vorteilskarte das Spiel, gilt aber nicht als besiegt. Sämtlicher Schaden und Horror, der auf ihr liegt, verbleibt dort und wird am Ende des Spiels im Kampagnenlogbuch notiert."
+   },
+   {
+      "id":"Patrol",
+      "cycle":[
+         "side",
+         "eoe",
+         "tskc",
+         "fof"
+      ],
+      "scenarios":[
+         "fortune_and_folly_part_1",
+         "fortune_and_folly_part_2"
+      ],
+      "title":"Patrouille",
+      "text":"Einige Gegner im Szenario <i>Mord im Excelsior-Hotel</i> haben das Schlüsselwort Patrouille und dahinter einen Zielort in Klammern. Während der Gegnerphase (siehe \"[III. Gegnerphase](#Enemy_Phase)\") bewegt sich jeder spielbereite, nicht in einen Kampf verwickelte Gegner mit dem Schlüsselwort Patrouille auf kürzestem Weg in Richtung seines Zielortes zu einem verbundenen Ort.\n\n\n= Falls es mehrere Orte gibt, die als Zielort infrage kommen, entscheidet der Ermittlungsleiter, auf welchen dieser Orte sich der Gegner zubewegt.\n\n\n= Falls sich ein Gegner mit dem Schlüsselwort Patrouille auf einen Ort bewegen müsste, der Weg aber durch eine Kartenfähigkeit versperrt ist, bewegt sich der Gegner nicht."
+   },
+   {
+      "id":"Priority_of_Simultaneous_Resolution",
+      "title":"Priorität bei gleichzeitiger Abhandlung",
+      "text":"Falls ein Effekt gleichzeitig Auswirkungen auf mehrere Spieler hat, aber die Spieler individuell Entscheidungen treffen müssen, um den Effekt abzuhandeln, trifft man diese Entscheidungen in Spielerreihenfolge. Sobald alle notwendigen Entscheidungen getroffen sind, wird der Effekt gleichzeitig auf alle betroffenen Entitäten angewendet.\n\n\n- Falls man zwei oder mehr erzwungene Fähigkeiten (einschließlich aufgeschobene Effekte) gleichzeitig abhandeln würde, bestimmt der Ermittlungsleiter, in welcher Reihenfolge man die Fähigkeiten abhandelt.\n\n\n- Falls man zwei oder mehr anhaltende Fähigkeiten und/oder anhaltende Effekte nicht gleichzeitig anwenden kann, bestimmt der Ermittlungsleiter die Reihenfolge, in der man sie anwendet."
+   },
+   {
+      "id":"Per_Investigator",
+      "title":"Pro Ermittler ([per_investigator])",
+      "text":"Sobald das [per_investigator]-Symbol nach einem Wert erscheint, wird dieser Wert mit der Anzahl der Spieler multipliziert, die zu Beginn des Szenarios im Spiel waren.\n\n\n- Die Multiplikation \"pro Ermittler\" erfolgt vor allen anderen Modifikatoren und das Ergebnis dieser Multiplikation wird behandelt, als wäre es der aufgedruckte Wert dieser Karte.\n\n\n- Bei Text, der den Begriff \"pro Ermittler\" enthält, zählt man die Anzahl der Ermittler zu Beginn des Szenarios und er wird vor allen anderen Modifikatoren angewendet.\n\n\n- Falls Ermittler aus dem Szenario ausgeschieden sind, zählen sie bei der Bestimmung des Wertes \"pro Ermittler\" weiterhin mit."
+   },
+   {
+      "id":"Reaction_Opportunities",
+      "title":"Reaktions-([reaction])-Möglichkeiten",
+      "text":"Sobald eine Auslösebedingung abgehandelt wird, haben die Ermittler die Möglichkeit, als Reaktion zu dieser Auslösebedingung [reaction]-Fähigkeiten abzuhandeln. Erst nachdem alle Ermittler die Möglichkeit zur Reaktion gehabt haben, wird das Spiel fortgesetzt.\n\nVerwendet man eine [reaction]-Fähigkeit als Reaktion auf eine Auslösebedingung, verhindert das nicht, dass andere [reaction]-Fähigkeiten als Reaktion auf dieselbe Auslösebedingung verwendet werden können.\n\n<i>Beispiel: [Roland Banks](/card/01001) hat gerade einen Gegner besiegt und möchte seine [reaction]-Fähigkeit auslösen: \"Nachdem du einen Gegner besiegt hast: Entdecke 1 Hinweis an deinem Ort.\" Er entdeckt an seinem Ort 1 Hinweis. Dann darf er als Reaktion auf das Besiegen des gleichen Gegners [Beweise!](/card/01022) spielen. Beide Karten haben die gleiche Auslösebedingung (\"Nachdem du einen Gegner besiegt hast\"), aber das Auslösen einer dieser Reaktionen hindert Roland nicht daran, die andere auch auszulösen.</i>"
+   },
+   {
+      "id":"Resources",
+      "title":"Ressourcen",
+      "text":"Ressourcen bieten den Ermittlern Möglichkeiten, neue Karten zu erwerben, die ihnen im weiteren Spielverlauf dann zur Verfügung stehen: Vorräte, Geld, Werkzeuge, Wissen, Spruchkomponenten, u.s.w.\n\n\n- Um eine Karte zu spielen oder eine Fähigkeit zu verwenden, die Ressourcenkosten hat, muss ein Ermittler ihre Ressourcenkosten bezahlen, indem er die angegebene Anzahl Ressourcen aus seinem Ressourcenvorrat nimmt und sie zurück in den Markervorrat legt (siehe \"[Kosten](#Costs)\").\n\n\n- Ressourcen kann man durch die Ressourcen-Aktion erhalten (siehe \"[Ressourcen (Aktion)](#Resource_Action)\").\n\n\n- Die Ermittler erhalten außerdem in jeder Unterhaltsphase 1 Ressource (siehe \"[4.4 Jeder Ermittler zieht 1 Karte und erhält 1 Ressource](#Upkeep_Phase)\").\n\n\n- Falls sich eine Fähigkeit auf die Anzahl \"Ressourcen, die du hast\", \"deiner Ressourcen\" oder einer Kombination aus beidem bezieht, bezieht sie sich nur auf die Anzahl der Ressourcen im Ressourcenvorrat jenes Ermittlers. Ressourcen auf anderen Karten, die der Ermittler kontrolliert, zählen nicht zu der Gesamtmenge, es sei denn es wird ausdrücklich erwähnt.\n\nSiehe auch \"[Marker, keine mehr übrig](#Tokens)\"."
+   },
+   {
+      "id":"Resource_Action",
+      "title":"Ressourcen (Aktion)",
+      "text":"\"Ressource\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlerphase nehmen darf.\n\nSobald ein Ermittler diese Aktion nimmt, erhält dieser Ermittler eine Ressource, die er aus dem Markervorrat nimmt und seinem Ressourcenvorrat hinzufügt."
+   },
+   {
+      "id":"Collection",
+      "title":"Sammlung",
+      "text":"Falls eine Fähigkeit sich auf die Sammlung eines Spielers bezieht (<i>Beispiel: \"durchsuche die Sammlung\")</i>, wird die Kartensammlung verwendet, aus der das Spielerdeck des betreffenden Spielers gebaut wurde.\n\n<i>Beispiel: Hans-Werner und Rudolf verwenden jeweils ein Deck, das aus der Kartensammlung von Hans-Werner erstellt wurde. Falls Rudolf angewiesen wird \"die Sammlung zu durchsuchen\", durchsucht er Hans-Werners Sammlung.</i>"
+   },
+   {
+      "id":"Taking_Damage_Horror",
+      "title":"Schaden/Horror nehmen",
+      "text":"\"Du nimmst X Schaden\" ist eine Abkürzung für \"füge deinem Ermittler X Schaden zu\". \"Du nimmst X Horror\" ist eine Abkürzung für \"füge deinem Ermittler X Horror zu\".\n\nSiehe \"[Schaden/Horror zufügen](#Dealing_Damage_Horror)\"."
+   },
+   {
+      "id":"Dealing_Damage_Horror",
+      "title":"Schaden/Horror zufügen",
+      "text":"Ermittler können in diesem Spiel auf zwei Arten in Bedrängnis geraten: Durch Schaden und durch Horror. Schaden betrifft die Ausdauer eines Ermittlers, Horror die geistige Gesundheit.\n\nSobald einem Ermittler oder einem Gegner Schaden und/oder Horror zugefügt wird, befolgt man die nachstehenden Schritte in der angegebenen Reihenfolge:\n\n<b>1. Schaden/Horror zuweisen:</b> Man bestimmt die Menge an Schaden und/oder Horror, die zugefügt wird. Schadens- und/oder Horrormarker in Höhe des zugefügten Schadens/Horrors werden neben die Karte, welcher der Schaden/Horror zugefügt wird, platziert.\n\n\n-- Sobald einem Ermittler Schaden oder Horror zugefügt wird, darf dieser Ermittler ihn beliebigen gültigen Vorteilskarten zuweisen, die er kontrolliert. Damit eine Vorteilskarte gültig ist Schaden zugewiesen zu bekommen, muss sie Ausdauer haben. Damit sie gültig ist Horror zugewiesen zu bekommen, muss die Karte Geistige Gesundheit haben.\n\n\n-- Einer Vorteilskarte kann nicht mehr Schaden und/oder Horror zugewiesen werden, als nötig wäre, um diese Karte zu besiegen.\n\n\n-- Sämtlicher Schaden/Horror, der keiner Vorteilskarte zugewiesen werden kann, muss dem Ermittler zugewiesen werden.\n\n<b>2. Schaden/Horror anwenden:</b> Zugewiesener Schaden/Horror, der nicht verhindert worden ist, wird nun gleichzeitig auf alle Karten platziert, denen er zugewiesen worden ist. Falls in diesem Schritt kein Schaden/ Horror angewendet wird, ist kein Schaden/Horror erfolgreich zugefügt worden.\n\n\n-- Fähigkeiten, die zugeteilten Schaden und/oder Horror verhindern, senken oder umverteilen, werden zwischen Schritt 1 und Schritt 2 abgehandelt.\n\n\n-- Falls ein Ermittler, nachdem Schaden/Horror angewendet worden ist, Schaden in Höhe seiner Ausdauer oder höher oder Horror in Höhe seiner geistigen Gesundheit oder höher erhalten hat, ist er besiegt. Sobald ein Ermittler besiegt worden ist, scheidet er aus dem Szenario aus (siehe \"[Ausscheiden](#Elimination)\").\n\n\n-- Falls ein Gegner, nachdem Schaden/Horror angewendet worden ist, Schaden in Höhe seiner Ausdauer oder höher hat, ist er besiegt und wird auf den Begegnungs-Ablagestapel gelegt (oder auf den Ablagestapel ihres Besitzers, falls der Gegner eine Schwäche-Karte ist).\n\n\n-- Falls eine Vorteilskarte, nachdem Schaden/Horror angewendet worden ist, Schaden in Höhe ihrer Ausdauer oder höher oder Horror in Höhe ihrer geistigen Gesundheit oder höher hat, ist sie besiegt und wird auf den Ablagestapel ihres Besitzers gelegt.\n\n Siehe auch \"[Interpretation von \"du/dir\" im Bezug auf Schaden nehmen](#Interpreting_You_When_Taking_or_Being_Dealt_Damage)\"."
+   },
+   {
+      "id":"Keys2",
+      "cycle":[
+         "tskc"
+      ],
+      "title":"Schlüssel (Karte)",
+      "text":"Die Kampagne <i>Die scharlachroten Schlüssel</i> enthält einen neuen Kartentyp: Schlüssel. Schlüssel stellen mächtige Artefakte dar, die \"gewandelt\" werden können, um die Ermittler bei ihren Vorhaben zu unterstützen oder zu stören. Dies ist davon abhängig, an wen sie angehängt sind und ob ihre [[Stabil]]- oder [[Instabil]]-Seite nach oben zeigt.\n\n\n= Während der Auflösung eines Szenarios kann ein Schlüssel an einen bestimmten Träger gebunden werden, dessen Name im Kampagnenlogbuch notiert wird. Ein Schlüssel kann an einen Ermittler, eine Storyvorteilskarte oder einen Gegner gebunden werden.\n\n\n= Ein Schlüssel kommt immer angehängt an seinen Träger ins Spiel (der im Kampagnenlogbuch notiert ist). Zu Beginn jedes Szenarios hängt jeder Ermittler, der Träger von 1 oder mehr Schlüsseln ist, diese Schlüssel an seine Ermittlerkarte an. Immer wenn eine Storyvorteilskarte oder ein Gegner ins Spiel kommt, die bzw. der Träger von 1 oder mehr Schlüsseln ist, kommen diese Schlüssel angehängt an den jeweiligen Träger ebenfalls ins Spiel.\n\n\n-- Falls der Träger eines Schlüssels ein Ermittler oder eine Storyvorteilskarte ist, kommt der Schlüssel mit seiner [[Stabil]]-Seite nach oben ins Spiel.\n\n\n-- Falls der Träger eines Schlüssels ein Gegner ist, kommt der Schlüssel mit seiner [[Instabil]]-Seite nach oben ins Spiel.\n\n\n= Ein Schlüssel kann das Spiel nicht verlassen, es sei denn, sein Träger verlässt das Spiel. Falls der Träger von 1 oder mehr Schlüsseln das Spiel verlässt, wird jeder Schlüssel, den er kontrolliert, als nicht im Spiel befindlich beiseitegelegt. (Diese Schlüssel bleiben allerdings für zukünftige Szenarien an ihren jeweiligen Träger gebunden, außer es ist ausdrücklich etwas anderes angegeben.)\n\n\n= Solange ein Schlüssel an einen Ermittler angehängt ist, darf der Ermittler in einem beliebigen Spielerfenster die Wandel-Fähigkeit des Schlüssels als eine [fast]-Fähigkeit auslösen. Dies wird \"den Schlüssel wandeln\" genannt. Als Teil der Abhandlung dieser Fähigkeit weist der Schlüssel den Ermittler an, den Schlüssel auf seine andere Seite umzudrehen. Dadurch wird seine andere Wandel-Fähigkeit aktiv. Damit der Ermittler den Schlüssel wieder umdrehen kann, muss er die Wandel-Fähigkeit auf der [[Instabil]]-Seite des Schlüssels durchführen.\n\n\n-- Solange ein Schlüssel an eine Storyvorteilskarte angehängt ist, darf ihn ein beliebiger Ermittler, der diese Vorteilskarte kontrolliert, auf die gleiche Weise wie oben beschrieben wandeln.\n\n\n-- Jeder Schlüssel (nach Name), der an einen Ermittler oder eine Storyvorteilskarte angehängt ist, kann nur ein Mal pro Runde gewandelt werden.\n\n\n= Solange der Schlüssel unter der Kontrolle eines Gegners ist, wird seine Wandel-Fähigkeit nur abgehandelt, wenn ein Karten- oder Spieleffekt einen Ermittler dazu anweist, jenen Schlüssel zu wandeln. Der Schlüssel bleibt aber mit der [[Instabil]]-Seite nach oben liegen.\n\n\n-- Ein Schlüssel, der an einen Gegner angehängt ist, kann nicht auf seine [[Stabil]]-Seite umgedreht werden.\n\n\n-- Ein Schlüssel, der an einen Gegner angehängt ist, kann beliebig oft gewandelt werden.\n\n\n= Manche Karteneffekte drehen einen Schlüssel, der an einen Ermittler oder eine Storyvorteilskarte angehängt ist, direkt von ihrer [[Stabil]]-Seite auf ihre [[Instabil]]-Seite um oder umgekehrt. Das ist nicht dasselbe wie das Wandeln eines Schlüssels. Dadurch wird die Wandel-Fähigkeit nicht abgehandelt."
+   },
+   {
+      "id":"Keys",
+      "cycle":[
+         "tic",
+         "zrttic"
+      ],
+      "title":"Schlüssel (Marker)",
+      "text":"In der Erweiterung <i>Die Innsmouth-Verschwörung</i> werden Schlüsselmarker eingeführt. Diese stehen für wichtige Objekte oder Informationen, an welche die Spieler gelangen können und die sie während der Szenarien nutzen können.\n\nSchlüsselmarker haben zwei Seiten. Auf ihrer Rückseite (verdeckte Seite) haben alle 7 Schlüssel das gleiche universelle Schlüsselsymbol. Dadurch können sie zufällig gemischt werden, ohne dass die Ermittler wissen, welcher Marker welcher ist. Auf ihrer Vorderseite (offene Seite) ist jeder Schlüssel mit einer eigenen Farbe codiert.\n\nWerden in einem Szenario 1 oder mehr Schlüssel verwendet, weist die Vorbereitung des Szenarios die Spieler an, wie viele Schlüssel benötigt werden und ob diese verdeckt gemischt oder mit der Vorderseite nach oben beiseitegelegt werden. Schlüssel können durch verschiedene Karteneffekte ins Spiel kommen. Meistens werden sie dabei auf einem Gegner, einem Ort oder einer Storyvorteilskarte platziert. Ein Ermittler kann auf 3 Arten an Schlüssel gelangen:\n\n\n= Falls ein Ort mit einem Schlüssel darauf keine Hinweise mehr auf sich hat, darf ein Ermittler als [free]-Fähigkeit die Kontrolle über jeden Schlüssel an diesem Ort übernehmen.\n\n\n= Falls ein Ermittler einen Gegner mit einem Schlüssel darauf dazu bringt, das Spiel zu verlassen, muss jener Ermittler die Kontrolle über jeden Schlüssel übernehmen, den jener Gegner auf sich hatte. (Falls ein solcher Gegner das Spiel auf andere Weise verlässt, werden die Schlüssel auf seinem Ort platziert.)\n\n\n= Manche Karteneffekte können es einem Ermittler erlauben, die Kontrolle über Schlüssel auf andere Arten zu übernehmen.\n\nSobald ein Ermittler die Kontrolle über einen Schlüssel übernimmt, wird der Marker auf die Vorderseite umgedreht (falls er verdeckt ist) und auf seiner Ermittlerkarte platziert. Falls ein Ermittler, der 1 oder mehr Schlüssel kontrolliert, aus dem Spiel ausscheidet, wird jeder seiner Schlüssel auf seinem Ort platziert. Als [action]-Fähigkeit darf ein Ermittler eine beliebige Anzahl seiner Schlüssel einem anderen Ermittler am selben Ort geben.\n\n<b>Schlüssel haben keinen eigenständigen Spieleffekt.</b> Manche Karteneffekte können sich aber ändern, je nachdem, welche Schlüssel ein Ermittler kontrolliert. Manchmal sind Schlüssel auch für den Fortschritt in einem Szenario nötig."
+   },
+   {
+      "id":"Keywords",
+      "title":"Schlüsselwörter",
+      "text":"Ein Schlüsselwort ist eine Kartenfähigkeit, die eine Karte mit speziellen Regeln versieht. Für jedes Schlüsselwort gibt es eigene Regeln, die im Abschnitt des jeweiligen Schlüsselwortes in diesem Glossar gefunden werden können. Die Schlüsselwörter in diesem Spiel sind: [Anwendungen](#Uses), [Gewaltig](#Massive), [Jäger](#Hunter), [Nachrüsten](#Surge), [Schnell](#Fast),   [Wagnis](#Peril), [Zurückhaltend](#Aloof), [Zurückschlagen](#Retaliate).\n\n\n- Außerdem gibt es zwei Schlüsselwörter beim Deckbau: [Außergewöhnlich](#Exceptional) und [Dauerhaft](#Permanent). Schlüsselwörter für den Deckbau beeinflussen die individuelle Gestaltung während des Baus und/ oder Hochstufens eines Decks. Während des Spiels haben sie keine Effekte. Im Grundspiel gibt es keine Karten mit den Schlüsselwörtern Außergewöhnlich oder Dauerhaft – diese Schlüsselwörter werden in zukünftigen Erweiterungen eingeführt.\n\n\n- Eine Karte, die dasselbe Schlüsselwort durch verschiedene Quellen mehrfach hat/erhält, funktioniert, als ob sie 1 Instanz dieses Schlüsselwortes hätte.\n\n\n- Die Initiierung eines Schlüsselwortes, welches eine Form des Wortes \"dürfen\" enthält, ist optional. Die Anwendung aller übrigen Schlüsselwörter ist verpf lichtend.\n\nSiehe \"[Fähigkeiten](#Ability)\"."
+   },
+   {
+      "id":"Fast",
+      "title":"Schnell",
+      "text":"Schnell ist eine Schlüsselwortfähigkeit. Das Spielen einer Karte mit Schnell kostet keine Aktion und sie wird nicht durch die Aktion \"Spielen\" gespielt.\n\n\n- Eine Ereigniskarte mit Schnell darf jederzeit nach den Anweisungen zum Spielen der Karte von der Hand eines Spielers gespielt werden. Falls die Anweisungen Angaben wie \"sobald/nachdem\" in Verbindung mit einer Timing-Vorgabe enthalten, darf die Karte gespielt werden, als ob der beschriebene Zeitpunkt die Auslösebedingung für das Spielen dieser Karte wäre. Falls die Anweisungen eine Dauer oder einen Zeitraum enthalten, darf die Karte in jedem Spielerfenster innerhalb dieses Zeitraums gespielt werden. Falls die Anweisungen sowohl eine Angabe über einen Zeitpunkt, als auch über eine Dauer oder einen Zeitraum enthalten, darf die Karte immer dann gespielt werden, sobald die angegebene Auslösebedingung innerhalb dieses Zeitraums auftritt.\n\n\n- Eine Vorteilskarte mit Schnell darf von einem Ermittler in jedem Spielerfenster in seinem Zug gespielt werden.\n\n\n- Weil Karten mit Schnell keine Aktionen kosten, um gespielt zu werden, provozieren sie keine Gelegenheitsangriffe (siehe \"[Gelegenheitsangriff](#Attack_of_Opportunity)\")."
+   },
+   {
+      "id":"Elusive",
+      "cycle":[
+         "fhv"
+      ],
+      "title":"Schwer zu fassen",
+      "text":"Schwer zu fassende Gegner sind solche Gegner, die den Kontakt zu Ermittlern vermeiden wollen, um ihre eigenen Ziele zu verfolgen oder um einfach zu überleben.\n\nFalls ein spielbereiter Gegner mit dem Schlüsselwort Schwer zu fassen angreift oder angegriffen wird, löst sich jener Gegner nach der Abhandlung des Angriffs sofort von allen Ermittlern, bewegt sich an einen verbundenen Ort (falls möglich an einen Ort ohne Ermittler) und wird erschöpft.\n\n\n- Dieser Effekt geschieht unabhängig davon, ob der Gegner mit dem angreifenden oder angegriffenen Ermittler in einen Kampf verwickelt ist oder nicht."
+   },
+   {
+      "id":"Difficulty_skill_tests",
+      "title":"Schwierigkeit (Fertigkeitsprobe)",
+      "text":"Die Schwierigkeit einer Fertigkeitsprobe ist die Zahl, die ein Ermittler mit seinem modifizierten Fertigkeitswert zu erreichen oder zu übertreffen versucht, damit er die Probe besteht.\n\n\n- Sobald man einen Gegner angreift, wird als Grundschwierigkeit für die Fertigkeitsprobe der Kampfwert des Gegners verwendet.\n\n\n- Sobald man an einem Ort ermittelt, wird als Grundschwierigkeit für die Fertigkeitsprobe der Schleierwert des Ortes verwendet.\n\n\n- Beim Versuch, einem Gegner zu entkommen, wird als Grundschwierigkeit der Entkommen-Wert des Gegners verwendet.\n\n\n- Beim Abhandeln einer Fertigkeitsprobe, die durch eine Kartenfähigkeit erzeugt wird, steht die Grundschwierigkeit in Klammern hinter der Angabe, auf welche Fertigkeit die Probe abgelegt wird. <i>Beispiel: Intellekt (3).</i>\n\nSiehe \"[Timing für Fertigkeitsproben](#Skill_Test_Timing)\" für die vollständigen Regeln für Fertigkeitsproben."
+   },
+   {
+      "id":"Difficulty_level",
+      "title":"Schwierigkeits(grad)",
+      "text":"In Arkham Horror: Das Kartenspiel gibt es vier Schwierigkeitsgrade: Einfach, Normal, Schwer und Experte. Die Spieler wählen zu Beginn einer Kampagne oder eines Einzelszenarios den gewünschten Schwierigkeitsgrad. Der Abschnitt Kampagnenvorbereitung im Kampagnen- oder Szenarioführer gibt an, welche Chaosmarker beim Spiel für die jeweiligen Schwierigkeitsgrade in den Chaosbeutel gelegt werden sollen.\n\n\n- Beim Spiel mit dem Schwierigkeitsgrad Einfach oder Normal wird die Seite \"Einfach/Normal\" der jeweiligen Szenarioübersichtskarte verwendet. Beim Spiel mit dem Schwierigkeitsgrad Schwer oder Experte wird stattdessen die Seite \"Schwer/Experte\" der jeweiligen Szenarioübersichtskarte verwendet."
+   },
+   {
+      "id":"Weakness",
+      "title":"Schwäche",
+      "text":"Schwäche ist eine Kartenunterart. Diese Karten stehen für die Charakterschwächen, Flüche, Wahnsinn, Verletzungen, Verpflichtungen, Gegner oder Storyelemente, die Teil der Hintergrundgeschichte eines Ermittlers sind oder im Verlauf einer Kampagne erworben werden. Schwächekarten werden unterschiedlich abgehandelt, abhängig von ihrem Kartentyp.\n\n\n- Sobald ein Ermittler eine Schwäche zieht, die eine Begegnungskarte ist (<i>zum Beispiel eine Gegner- oder Verratsschwäche</i>), handelt er diese Karte ab, als ob sie gerade vom Begegnungsdeck gezogen worden wäre.\n\n\n- Schwächen mit dem Kartentyp einer Begegnungskarte (wie Gegner- oder Verratskarten) gelten als Spielerkarten, solange sie sich im Deck ihres Trägers befinden, und gelten als Begegnungskarten, solange sie abgehandelt werden und wenn sie erst einmal ins Spiel gekommen sind. Bevor eine Schwäche mit einem Kartentyp einer Begegnungskarte abgehandelt wird, gilt sie noch als eine Spielerkarte.\n\n\n- Sobald ein Ermittler eine Schwäche zieht, die eine Spielerkarte ist (<i>zum Beispiel eine Vorteils-, Ereignis- oder Fertigkeitsschwäche</i>), handelt er sämtliche Enthüllungseffekte auf der Karte ab und fügt sie der Hand des Ermittlers hinzu. Die Karte darf dann wie jede andere Spielerkarte ihrer Art verwendet werden.\n\n\n- Falls eine Schwächekarte anders als durch das Ziehen einer Karte auf die Hand des Ermittlers kommt, muss der Ermittler die Karte abhandeln (einschließlich aller Enthüllungsfähigkeiten), als ob er sie gerade gezogen hätte.\n\n\n- Der Träger einer Schwäche ist der Ermittler, der das Spiel mit dieser Schwäche in seinem Deck oder seiner Spielzone begonnen hat.\n\n\n- Falls eine Schwäche einem Spielerdeck oder einer Hand während des Durchspielens eines Szenarios hinzugefügt wird, bleibt sie für den Rest der Kampagne Teil des Decks dieses Ermittlers (außer wenn sie durch eine Kartenfähigkeit oder eine Szenarioauflösung aus der Kampagne entfernt wird).\n\n\n- Ein Spieler kann sich nicht dafür entscheiden, eine Schwächekarte von seiner Hand abzulegen, falls eine Karte nicht ausdrücklich etwas anderes besagt.\n\n\n- Schwächen, die Begegnungskarten sind, werden wie andere Begegnungskarten nicht von einem Spieler kontrolliert. Schwächen, die Spielerkarten sind, werden von ihrem Träger kontrolliert.\n\n\n- Einige Karten- und Spieltexte beziehen sich auf \"Grundschwächen\". Eine Grundschwäche kann man an dem Begriff \"Grundschwäche\" und dem unten abgebildeten Symbol erkennen.",
+      "rules":[
+         {
+            "id":"Weakness_Events",
+            "title":"Schwäche-Ereignisse und \"Änderung des Spielstatus\"",
+            "text":"Manche Schwäche-Ereignisse (<i>wie z.B. [Quantenparadox](/card/09125)</i>) verändern den Spielstatus nicht im traditionellen Sinne, sobald sie gespielt werden. Nichtsdestotrotz haben sie negative Effekte, falls sie sich auf der Hand befinden. Diese Schwäche-Ereignisse dürfen gespielt werden, um die negativen Effekte zu vermeiden."
+         }
+      ]
+   },
+   {
+      "id":"Self_Referential_Text",
+      "title":"Selbstreferenzieller Text",
+      "text":"Sobald sich der Text einer Kartenfähigkeit auf ihren eigenen Namen bezieht, bezieht er sich nur auf die Karte selbst, nicht auf andere Kopien der Karte (nach Name).\n\n Selbstreferenzielle Fähigkeiten, die das Wort \"diese(r)\" verwenden (z. B. \"diese Karte\") beziehen sich nur auf die Karte mit dieser Fähigkeit, nicht auf andere Kopien dieser Karte."
+   },
+   {
+      "id":"Victory_Display_Victory_Points",
+      "title":"Siegpunkte, Siegpunktestapel",
+      "text":"Einige Begegnungskarten sind Siegpunkte wert. Der Text <b>Sieg X</b> zeigt an, das eine Karte X Siegpunkte wert ist.\n\nEine Begegnungskarte, die Siegpunkte wert ist und die durch einen Ermittler überwunden wird, wird bis zum Ende des Szenarios auf den Siegpunktestapel gelegt. Der Siegpunktestapel ist eine Zone außerhalb des Spiels, die sich alle Spieler teilen. Sobald ein Szenario beendet wird, liefern die Karten im Siegpunktestapel Erfahrungspunkte, die verwendet werden können, um das Deck eines Ermittlers zu verbessern (siehe \"[Kampagnenspiel](#Campaign_Play)\").\n\n\n- Wird ein Siegpunkte-Gegner besiegt, wird die Karte auf den Siegpunktestapel statt auf den Ablagestapel platziert.\n\n\n- Am Ende eines Szenarios wird jeder enthüllte Siegpunkte-Ort im Spiel, der keine Hinweise hat, auf den Siegpunktestapel platziert.\n\n\n- Ist die Abhandlung einer Siegpunkte-Verratskarte abgeschlossen, wird sie auf den Siegpunktestapel statt auf den Ablagestapel platziert."
+   },
+   {
+      "id":"Signature_Cards",
+      "title":"Signaturkarten",
+      "text":"Die \"Signaturkarten\" eines Ermittlers sind die Karten, die nur diesem Ermittler zur Verfügung stehen und in keinem Deck eines anderen Ermittlers enthalten sein dürfen. Das schließt Karten mit dem Text \"Nur für das Deck von (Name des Ermittlers)\" sowie die Nicht-Grundschwächen, die unter \"Deckbau-Voraussetzungen\" aufgeführt sind ein. Diese Karten dürfen nur in das Deck des jeweiligen Ermittlers eingebaut werden.\n\nSignaturkarten haben die folgenden zusätzlichen Regeln:\n\n\n- Die Anzahl der Signaturkarten, die unter \"Deckbau-Voraussetzungen\" eines Ermittlers aufgeführt ist, entspricht der genauen Anzahl an Kopien, die davon ins Deck des Ermittlers aufgenommen werden müssen. Falls keine Anzahl angeben ist, dann ist die Anzahl 1.\n\n<i>Beispiel: Unter \"Deckbau-Voraussetzungen\" von [Roland Banks](/card/01001) sind folgende Karten aufgeführt: \"[Rolands 38er Spezial](/card/01006), [Vertuschen](/card/01007), 1 zufällige Grundschwäche.\" Roland Banks muss genau 1 Kopie seiner Signaturkarten (Rolands 38er Spezial und Vertuschen) in sein Deck aufnehmen. Er darf nicht mehr als eine Kopie jeder dieser Karten aufnehmen.</i>\n\n\n- Ein Ermittler kann Signaturkarten eines anderen Ermittlers nicht spielen, kann die Signaturkarten eines anderen Ermittlers im Spiel nicht kontrollieren und kann die Signaturkarten eines anderen Ermittlers auf seiner eigenen Hand nicht besitzen. Falls ein Spieleffekt einen Spieler zwingen sollte, die Kontrolle über eine Karte zu übernehmen, an die eine Signaturkarte eines anderen Ermittlers angehängt ist, wird jene Signaturkarte abgelegt.\n\n<i>Beispiel: Roland hat seine Rolands 38er Spezial im Spiel. Er hat die Karte [Zusammenarbeit](/card/02018), die ihm erlaubt mit Ermittlern am gleichen Ort Vorteilskarten zu tauschen oder sie ihnen zu geben. Weil Rolands 38er Spezial aber eine von Rolands Signaturkarten ist, kann er sie anderen Ermittlern nicht geben.</i>\n\n\n- Signaturkarten müssen sich nicht an gewöhnliche Deckbau-Voraussetzungen halten und zählen nicht gegen Deckbau-Einschränkungen, falls andere Karten den gleichen Namen wie sie haben"
+   },
+   {
+      "id":"Slots",
+      "title":"Slots",
+      "text":"Jeder Ermittler hat eine Anzahl bestimmter Slots, die mit Karten gefüllt werden können. Jede Vorteilskarte in der Spiel- oder Bedrohungszone eines Ermittlers mit einem Slotsymbol befindet sich auf einem Slot dieser Art. Slots begrenzen die Anzahl der Vorteilskarten, die ein Ermittler gleichzeitig im Spiel haben kann.\n\nDie Slots, die einem Ermittler normalerweise zur Verfügung stehen, sind:\n\n\n- <b>1 Zubehörslot</b>\n\n\n- <b>1 Körperslot</b>\n\n\n- <b>1 Verbündeter-Slot</b>\n\n\n- <b>2 Handslots</b>\n\n\n- <b>2 arkane Slots</b>\n\n\n- <b>1 Tarotslot</b>\n\nFalls eine Vorteilskarte kein Slotsymbol hat, benötigt sie keinen der oben genannten Slots. Es gibt keine Begrenzung für die Anzahl von Vorteilskarten ohne Slotsymbol, die ein Ermittler im Spiel haben kann.\n\nFalls durch das Spielen oder das Kontrolle Erhalten einer Vorteilskarte ein Ermittler sein Limit der Slotart jener Vorteilskarte überschreitet, muss er andere Vorteilskarten, die er kontrolliert, wählen und ablegen. Dies geschieht zum selben Zeitpunkt, zu dem die neue Vorteilskarte ins Spiel kommt.",
+      "rules":[
+         {
+            "id":"Shifting_Slots",
+            "title":"Verändernde Slots",
+            "text":"Manche Karteneffekte erlauben es einem Ermittler, Vorteilskarten einer Slotart in den Slot einer anderen Art zu legen, oder Vorteilskarten einer bestimmten Slotart in die einer seiner anderen Slots zu legen. Manche Karteneffekte können auch dazu führen, dass für bestimmte Vorteilskarten gar keine Slots benötigt werden. Der Ermittler muss aber dennoch zum Zeitpunkt des Spielens einer Vorteilskarte festlegen, welchen Slot jene Vorteilskarte einnimmt. Das kann später nicht mehr verändert werden, außer Inhalt oder Menge des Slots eines Ermittlers verändern sich. In dem Fall darf er dann neu festlegen, welche Vorteilskarte sich in welchem Slot befindet.\n\n<i>Beispiel: Kōhaku hat [Okkultes Reliquiar](/card/10132) im Spiel und spielt [Gesegnete Klinge](/card/07018). Er entscheidet sich, durch Okkultes Reliquiar einen zusätzlichen Handslot zu erhalten, um Gesegnete Klinge dort hineinzulegen. Wenn er später eine weitere Gesegnet-Karte spielt, wie z. B. [Geweihter Spiegel](/card/05313), kann er sich entscheiden, dass die neue Karte den zusätzlichen Slot einnimmt (im Zubehörslot). Die Gesegnete Klinge legt er dann in einen seiner normalen Handslots.</i>"
+         }
+      ]
+   },
+   {
+      "id":"When",
+      "title":"Sobald",
+      "text":"Das Wort \"sobald\" bezieht sich auf den Moment direkt nachdem die angegebene Timing-Vorgabe oder Auslösebedingung initiiert worden ist, aber bevor die Auswirkungen auf den Spielstatus abgehandelt werden. Die Abhandlung einer \"sobald\"-Fähigkeit unterbricht die Abhandlung ihrer Timing-Vorgabe oder Auslösebedingung.\n\n<i>Beispiel: Eine Fähigkeit, die besagt \"Sobald du eine Gegnerkarte ziehst\", wird sofort initiiert, nachdem man die Gegnerkarte gezogen hat, aber bevor ihre Enthüllungsfähigkeit, ihr Erscheinen u. s. w. abgehandelt werden.</i>\n\nSiehe auch \"[Fähigkeiten](#Ability)\", \"[Priorität bei gleichzeitiger Abhandlung](#Priority_of_Simultaneous_Resolution)\"."
+   },
+   {
+      "id":"Game",
+      "title":"Spiel",
+      "text":"Ein \"Spiel\" besteht aus einem einzelnen Szenario, nicht aus einer gesamten Kampagne. In einer Kampagne bedeutet der Beginn eines neuen Szenarios auch den Beginn eines neuen Spiels."
+   },
+   {
+      "id":"Ready",
+      "title":"Spielbereit",
+      "text":"Eine Karte in aufrechter Position, sodass der Spieler, der die Karte kontrolliert, den Text von links nach rechts lesen kann, gilt als spielbereit.\n\n\n- Spielbereit ist der normale Zustand einer Karte, in dem sie ins Spiel kommt.\n\n\n- Sobald eine erschöpfte Karte spielbereit gemacht wird, wird sie in die aufrechte Position zurückgedreht. Diese Karte ist dann im spielbereiten Status.\n\n\n- Eine spielbereite Karte kann nicht erneut spielbereit gemacht werden (sie muss zuerst erschöpft werden, normalerweise durch einen Spielschritt oder eine Kartenfähigkeit)."
+   },
+   {
+      "id":"Play",
+      "title":"Spielen",
+      "text":"Um eine Karte zu spielen, muss ein Ermittler die Ressourcenkosten der Karte bezahlen und sonstige Einschränkungen und Bedingungen der Karte beachten. Die meisten Karten können nur durch die Verwendung einer Spielen-Aktion gespielt werden (siehe \"[Spielen (Aktion)](#Play_Action)\").\n\nKarten mit dem Schlüsselwort Schnell werden nicht während einer Spielen-Aktion gespielt. Eine solche Karte darf immer gespielt werden, wenn ihre angegebene Auslösebedingung erfüllt ist, oder, falls sie keine Auslösebedingung hat, während eines passenden Spielerfensters (siehe \"[Schnell](#Fast)\").\n\nImmer wenn eine Ereigniskarte gespielt wird, werden ihre Effekte abgehandelt und sie wird dann auf den Ablagestapel ihres Besitzers gelegt.\n\nImmer wenn eine Vorteilskarte gespielt wird, wird sie in die Spielzone des Ermittlers platziert und bleibt solange im Spiel, bis eine Fähigkeit oder ein Spieleffekt dafür sorgt, dass sie das Spiel verlässt. Die meisten Vorteilskarten benötigen einen oder mehrere Slots, solange sie sich im Spiel befinden (siehe \"[Slots](#Slots)\").\n\nFertigkeitskarten werden nicht \"gespielt\". Diese Karten werden von der Hand eines Spielers zu Fertigkeitsproben <i>beigetragen</i>, um ihre Fähigkeiten zu nutzen.\n\nSiehe auch \"[Anhang I: Abfolge einer Initiierung](#Appendix_I_Initiation_Sequence)\", \"[Spieleinschränkungen, Berechtigungen und Anweisungen](#Play_Restrictions_Permissions_and_Instructions)\"."
+   },
+   {
+      "id":"Play_Action",
+      "title":"Spielen (Aktion)",
+      "text":"\"Spielen\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf.\n\nSobald ein Ermittler diese Aktion nimmt, sucht er eine Vorteils- oder Ereigniskarte auf seiner Hand aus, zahlt die Ressourcenkosten und spielt sie (siehe \"[Spielen](#Play)\").\n\n\n- Karten mit dem Schlüsselwort \"Schnell\" werden nicht unter Verwendung dieser Aktion gespielt (siehe \"[Schnell](#Fast)\").\n\n\n- Fertigkeitskarten werden nicht \"gespielt\". Diese Karten werden von der Hand eines Spielers zu Fertigkeitsproben beigetragen, um ihre Fähigkeiten zu nutzen.",
+      "rules":[
+         {
+            "id":"Play_Restrictions_Permissions_and_Instructions",
+            "title":"Spieleinschränkungen, Berechtigungen und Anweisungen",
+            "text":"Viele Karten und Fähigkeiten enthalten spezielle Anweisungen, wann oder wie sie verwendet oder nicht verwendet werden dürfen, oder Angaben zu speziellen Bedingungen, die erfüllt sein müssen, um sie zu verwenden. Um eine solche Fähigkeit zu verwenden oder eine solche Karte zu spielen, müssen alle Spieleinschränkungen beachtet werden.\n\nEine Berechtigung ermöglicht es einem Spieler, außerhalb der normalen Timing-Angaben durch die Spielregeln diese Karte zu spielen oder diese Fähigkeit zu nutzen.\n\nEine Spielanweisung beschreibt den Zeitpunkt oder den Zeitraum, an/in dem eine Ereigniskarte gespielt werden darf"
+         }
+      ]
+   },
+   {
+      "id":"Replacing_an_Opening_Hand",
+      "title":"Starthand ersetzten",
+      "text":"Falls eine Fähigkeit die Starthand eines Ermittlers mit einem anderen Set aus Karten ersetzt, zählt jenes Set Karten als die neue Starthand, was Effekte betrifft, welche die Anzahl der Karten auf der Starthand verändern würden.\n\nFalls eine Fähigkeit die Starthand eines Ermittlers mit einer Anzahl Karten, die er aus einem größeren Set Karten \"behält\", ersetzt, verändert ein Effekt, der die Anzahl an Startkarten eines Ermittlers verändert, sowohl die Anzahl gezogener Karten, um die Starthand zu ersetzen, als auch die Anzahl Karten, die aus dem größeren Set als seine neue Starthand \"behalten\" werden dürfen.\n\n<i>Beispiel: Die Fähigkeit von [Sefina Rousseau](/card/03003) lautet: \"Sobald du deine Starthand ziehen würdest: Ziehe stattdessen 13 Karten. Wähle bis zu 5 Ereignisse, platziere sie unter diese Karte und behalte 8 Karten als Starthand. Lege die übrigen Karten ab.\" Falls ein Karten- oder Spieleffekt die Karten von Sefinas Starthand verändert, würde er sowohl die Anzahl der durch ihrer Fähigkeit gezogenen Karten als auch die Anzahl der Karten verändern, die sie auf ihrer Starthand behalten würde.</i>"
+   },
+   {
+      "id":"Instead",
+      "title":"Statt/anstatt",
+      "text":"Die Wörter \"statt\" und \"anstatt\" zeigen einen Ersatzeffekt an. Ein Ersatzeffekt ist ein Effekt, der die Abhandlung einer ausgelösten Bedingung mit einer anderen Abhandlung ersetzt.\n\n\n- Falls mehrere Ersatzeffekte aufgrund derselben Auslösebedingung initiiert werden und so ein Konf likt entsteht, wie die Auslösebedingung abgehandelt wird, wird der neueste Ersatzeffekt für die Abhandlung der Auslösebedingung verwendet.\n\n\n- Das Wort \"würde\" wird verwendet, um die Auslösebedingung einiger Fähigkeiten zu definieren, und setzt eine höhere Priorität dieser Fähigkeiten gegenüber Fähigkeiten mit derselben Auslösebedingung ohne das Wort \"würde\". \n\n<i>Beispiel: \"Sobald X passieren würde\" wird vor \"Sobald X passiert\" abgehandelt.</i>\n\n\n- Falls ein Ersatzeffekt, der das Wort \"würde\" verwendet, das Wesen einer Auslösebedingung verändert, wird die ursprüngliche Auslösebedingung durch die neue Auslösebedingung ersetzt. Es dürfen keine weiteren Fähigkeiten angewendet werden, die sich auf die ursprüngliche Auslösebedingung beziehen."
+   },
+   {
+      "id":"Flavor_Text",
+      "title":"Stimmungstext",
+      "text":"Stimmungstext ist zusätzlicher Text auf einer Karte, der thematischen Kontext zu der Karte und/oder ihrer Fähigkeit bietet. Stimmungstext interagiert in keiner Weise mit dem Spiel."
+   },
+   {
+      "id":"Search",
+      "title":"Suchen",
+      "text":"Sobald ein Spieler angewiesen wird eine Karte zu suchen, darf dieser Spieler alle Karten in der Zone, in der gesucht wird, ansehen, ohne diese Karten für andere Spieler zu enthüllen.\n\n\n- Falls ein Effekt ein ganzes Deck durchsuchen lässt, muss man das Deck nach Abschluss der Suche mischen.\n\n\n- Sobald ein Suchen-Effekt abgehandelt wird, ist ein Spieler verpflichtet das gesuchte Objekt zu finden, falls sich ein oder mehrere gültige Objekte in der Zone befinden, in der man sucht.\n\n\n- Solange man gerade in einer Anzahl Karten sucht, werden diese Karten nicht als Karten behandelt, die ihre ursprüngliche Spielzone verlassen haben.",
+      "rules":[
+         {
+            "id":"Looking_At_Searching_And_Finding",
+            "title":"\"Ansehen\", \"Durchsuchen\" und \"Finden\"",
+            "text":"Diese drei Begriffe beziehen sich alle auf das Durchsehen von Karten, die sich nicht im Spiel befinden (normalerweise Karten im Deck eines Ermittlers oder im Begegnungsdeck), beziehen sich aber nicht aufeinander.\n\n<i>Beispiel: Falls sich ein Ermittler \"die obersten 3 Karten seines Deck ansieht\", ist dies kein Durchsuchen-Effekt. Eine Karte zu \"finden\", bezieht sich normalerweise auch nicht auf das Durchsuchen von Spielzonen, die sich nicht im Spiel befinden, und ist demnach auch kein Durchsuchen-Effekt.</i>"
+         },
+         {
+            "id":"Searching_During_Setup",
+            "title":"Durchsuchen bei der Vorbereitung",
+            "text":"Falls ein Ermittler bei der Vorbereitung angewiesen wird, ein Deck nach 1 oder mehr Karten zu durchsuchen, können Fähigkeiten, die beim Durchsuchen eines Decks ausgelöst werden würden (<i>wie z. B. die [reaction]-Fähigkeit auf [Mandy Thompson](/card/06002) oder Fähigkeiten auf [[Forschung]]-Karten</i>), nicht ausgelöst werden, da das Spiel noch nicht begonnen hat."
+         }
+      ]
+   },
+   {
+      "id":"Act_Deck_and_Agenda_Deck",
+      "title":"Szenendeck und Agendadeck",
+      "text":"Das Szenendeck steht für den Fortschritt, den die Ermittler in einem Szenario machen können. Das Agendadeck steht für den Fortschritt und die Ziele der finsteren Mächte, denen die Ermittler in einem Szenario gegenüberstehen.\n\nDas Vorrücken im Szenendeck ist normalerweise gut für die Ermittler, ein Vorrücken im Agendadeck hingegen schlecht.\n\n\n- Im Szenendeck rücken die Ermittler vor, falls sie als Gruppe die erforderliche Anzahl Hinweise ausgeben (die auf der Szenenkarte angegeben ist). Eine Szenenkarte kann hierfür einen festen Wert (wie zum Beispiel \"4\") oder einen Wert pro Ermittler (erkennbar an dem [per_investigator]-Symbol) angeben. Dies passiert normalerweise als [free]-Spielerfähigkeit. Ein oder alle Ermittler können eine beliebige Anzahl Hinweise zur Gesamtzahl der Hinweise beitragen, die benötigt werden, um von einer Szene aus vorzurücken. Falls die Szene eine \"<b>Ermittlungsziel</b> –\"-Anweisung enthält, überschreibt diese das Ausgeben von Hinweisen oder fügt zusätzliche Voraussetzungen hinzu.\n\n\n- Das Agendadeck rückt vor, falls sich die erforderliche Anzahl Verderbensmarker im Spiel befindet (Verderbensmarker auf der Agendakarte und Verderbensmarker auf anderen Karten im Spiel), die auf der Agendakarte angegeben ist. Eine Agendakarte kann einen festen Wert oder einen Wert pro Ermittler angeben. Falls die Agendakarte eine \"<b>Ermittlungsziel</b> –\"-Anweisung enthält, überschreibt diese die Verderbensmarker-Voraussetzung oder sie fügt zusätzliche Voraussetzungen hinzu.\n\n\n- Die oberste Szenen-/Agendakarte des Szenen-/Agendadecks bezeichnet man als \"aktuelle\" Szene/\"aktuelle\" Agenda.\n\nUm im Szenendeck oder Agendadeck vorzurücken, werden folgende Schritte in der angegebenen Reihenfolge befolgt: \n\n1. Alle Marker werden von der Karte, von der aus vorgerückt werden soll, entfernt. Falls im Agendadeck vorgerückt wird, werden alle Verderbensmarker von jeder Karte im Spiel entfernt. \n\n2. Die Karte, von der aus vorgerückt wird, wird umgedreht und man folgt den Anweisungen auf der Rückseite (\"b\"-Seite).\n\n\n-- Falls die Rückseite der Szenen- oder Agendakarte eine Begegnungskarte ist, folgt man den Regeln für das Ziehen des entsprechenden Begegnungskartentyps. Ansonsten folgt man einfach den Anweisungen auf der Karte. \n\n3. Manchmal gibt die Szenen-/Agendakarte, von der aus vorgerückt wird, an, welche Karte zur nächsten Szene/Agenda wird. Falls sie dies nicht tut, wird die nächste Karte im Deck automatisch zur \"aktuellen\" Szene/Agenda. Wenn eine neue Karte zur aktuellen Szene/Agenda wird, wird die Karte, von der aus vorgerückt wird, gleichzeitig aus dem Spiel entfernt.\n\n\n-- Einige Anweisungen im Szenen- oder Agendadeck (sowie auf anderen Begegnungskartentypen) enthalten Auflösungspunkte in folgendem Format: \"(→<b>A#</b>).\" Falls ein Auflösungspunkt erreicht wird, endet das Szenario. Im Kampagnenleitfaden wird dann die entsprechende Auflösung nachgelesen.\n\nSiehe auch \"[Hinweise](#Clues)\", \"[Verderben](#Doom)\"."
+   },
+   {
+      "id":"List_of_Taboos",
+      "title":"Tabuliste",
+      "text":"Die Tabuliste besteht aus mehreren Karten mit optionalen Deckbau-Einschränkungen oder Textänderungen. Diese Liste wurde entwickelt, um eine gesunde Balance zwischen der Stärke von Ermittlern und der Schwierigkeit von Szenarien herzustellen und im Laufe der Zeit Änderungen beim Deckbau zu fördern. Die Tabuliste ist völlig optional. Ermittler sind nicht dazu gezwungen, sich an die Einschränkungen dieser Liste zu halten. Wenn sich ein Ermittler aber dazu entscheidet, eine der folgenden Änderungen zu verwenden, dann sollte er sich an alle Änderungen halten (er darf sich nicht aussuchen, nur Teile der Einschränkungen zu verwenden).\n\n<i>Beispiel: Entscheidet sich ein Spieler, den Mutiert-Text der Karte [35er Winchester](/card/06195) zu verwenden, dann darf er auch keine \"Verboten\"-Karten in sein Deck aufnehmen und er muss die in \"Verkettet / Unverkettet\" angegebenen Erfahrungspunkte-Änderungen beim Erwerb von Karten berücksichtigen.</i>",
+      "rules":[
+         {
+            "id":"Chained_Unchained",
+            "title":"Verkettet / Unverkettet",
+            "text":"Die Erfahrungspunkteposten der Karten auf dieser Liste sind um den unten angegebenen Wert entsprechend erhöht oder verringert. Die Kartenstufe jeder Karte bleibt gleich – nur die Erfahrungspunkte, die zum Erwerb ausgegeben werden müssen, sind verändert. Die veränderten Erfahrungspunkte sollten auch dann berücksichtigt werden, wenn man eine Karte auf dieser Liste verbessert oder eine Karte auf eine Karte auf dieser Liste verbessert."
+         },
+         {
+            "id":"Mutated",
+            "title":"Mutiert",
+            "text":"Karten auf dieser Liste haben einen zusätzlichen oder veränderten Kartentext, der unten angegeben ist."
+         },
+         {
+            "id":"Forbidden",
+            "title":"Verboten",
+            "text":"Karten auf dieser Liste können nicht in das Deck eines Ermittlers aufgenommen werden."
+         }
+      ]
+   },
+   {
+      "id":"Day_Night",
+      "title":"Tag [day] und Nacht [night]",
+      "cycle":[
+         "fhv"
+      ],
+      "text":"In der Kampagne <i>Das Fest von Hemlock Vale</i> könnt ihr bei Vorbereitungen dazu angewiesen werden, die Zeitmarker-Karte ins Spiel zu bringen. Finde dazu diejenige Zeitmarker-Karte, die zum aktuellen Tag und zur aktuellen Zeit passt (in den Begegnungssets Der erste Tag, Der zweite Tag oder Der letzte Tag), und platziere sie neben dem Agendadeck.\n\nManche Karten haben unterschiedliche Effekte, abhängig davon, ob das Szenario am Tag oder bei Nacht stattfindet. Texte nach dem Schlüsselwort (<b>Tag</b> [day]) oder (<b>Nacht</b> [night]) sind nur dann aktiv, wenn das Szenario oder Vorspiel am Tag bzw. bei Nacht stattfindet. Jede andere Fähigkeit, die nicht von diesen Schlüsselwörtern eingeleitet wird, ist unabhängig von der Tageszeit stets aktiv.\n\nVorbereitungen können besondere Anweisungen enthalten, abhängig vom aktuellen Tag und der aktuellen Zeit.\n\n<i>Beispiel: \"Falls es <b>Tag 2</b> ist, bringe [River Hawthorne](/card/10697) auf dem Dorfplatz ins Spiel.\" wird nur angewendet, falls das Szenario an <b>Tag 2</b> stattfindet, nicht in der <b>Nacht 2</b>.</i>"
+   },
+   {
+      "id":"Tarot Slot",
+      "title":"Tarotslot",
+      "cycle":[
+         "tcu"
+      ],
+      "text":"Der Tarotslot in der Erweiterung <i>Der gebrochene Kreis</i> wird eine neue Art von Slot für Vorteilskarten eingeführt: der Tarotslot. \n\nGenau wie andere Slots begrenzen auch Tarotslots die Anzahl der Vorteilskarten für diese Slotart, die ein Ermittler gleichzeitig im Spiel haben kann.\n\n<b>Normalerweise steht einem Ermittler nur ein Tarotslot zur Verfügung.</b>\n\nAlle anderen Regeln für Slots gelten auch für Tarotslots."
+   },
+   {
+      "id":"Tekelili",
+      "title":"Tekeli-li",
+      "cycle":[
+         "eoe"
+      ],
+      "text":"Die Kampagne <i>Am Rande der Welt</i> beinhaltet ein Begegnungsset aus 16 Schwächekarten, jede mit dem Namen \"Tekeli-li\". Diese Karten werden zu Beginn jedes Szenarios der Kampagne <i>Am Rande der Welt</i> gemischt, um ein spezielles \"Tekeli-li\"-Deck zu bilden.\n\nFalls eine dieser Karten dem Deck eines Ermittlers hinzugefügt wird, wird sie, wie eine normale Schwäche auch, Teil jenes Decks und verbleibt in jenem Ermittlerdeck von Szenario zu Szenario. Die Abhandlung jeder \"Tekeli-li\"-Schwäche weist den Ermittler jedoch an, diese unter das \"Tekeli-li\"-Deck zurückzuschicken (und damit aus dem eigenen Deck zu entfernen). Aus diesem Grund variiert die Anzahl der Karten im \"Tekeli-li\"-Deck, je nachdem, wie viele dieser Schwächen sich in jedem Ermittlerdeck befinden.\n\n<i>Hinweis: Auch wenn alle \"Tekeli-li\"-Karten den gleichen Namen haben, können ihre Effekte unterschiedlich sein.</i>"
+   },
+   {
+      "id":"Trauma_Placeholder",
+      "title":"Trauma",
+      "text":"Siehe \"[Trauma](#Trauma)\" im Bereich \"[Kampagnenspiel](#Campaign_Play)\"."
+   },
+   {
+      "id":"Bearer",
+      "title":"Träger",
+      "text":"Der Träger einer Schwäche ist der Ermittler, der das Spiel mit dieser Schwäche in seinem Deck oder seiner Spielzone begonnen hat.\n\nSiehe auch \"[Schwäche](#Weakness)\"."
+   },
+   {
+      "id":"Upkeep_Phase_Placeholdler",
+      "title":"Unterhaltsphase",
+      "text":"Siehe \"[IV. Unterhaltsphase](#Upkeep_Phase)\"."
+   },
+   {
+      "id":"Different",
+      "title":"\"Unterschiedlich\" und \"Verschieden\"",
+      "text":"Diese zwei Begriffe sind austauschbar. Manche Kartenfähigkeiten beziehen sich auf \"unterschiedliche\" bzw. \"verschiedene\" Karten. Unterschiedliche Karten sind Karten mit unterschiedlichen Namen (Untertitel ausgenommen).\n\n<i>Beispiel: Zwei Kopien von [Schutzsiegel](/card/01065) gelten nicht als unterschiedlich, auch wenn sie voneinander abweichende Kartenstufen aufweisen.</i>\n\nManche Kartenfähigkeiten beziehen sich auf \"unterschiedliche\" bzw. \"verschiedene\" Aktionen oder Fähigkeiten. Eine Aktion/Fähigkeit ist unterschiedlich von einer anderen Aktion/Fähigkeit, falls sie nicht identische, eigenständige Fähigkeiten auf der gleichen Karte oder Fähigkeiten auf zwei unterschiedlichen Karten sind.\n\n<i>Beispiel: Die zwei eigenständigen Kampf-Fähigkeiten auf [Vorschlaghammer](/card/08094) sind voneinander unterschiedlich, aber die zwei identischen Kampf-Fähigkeiten auf zwei Kopien von [Machete](/card/01020) unterscheiden sich nicht, genauso wenig wie zwei Basis-Kampfaktionen.</i>\n\n\n- Die Ausnahme dieser Regel sind Orte. Ortskarten stellen grundsätzlich eigene Orte dar und sind unterschiedlich bzw. verschieden von anderen Orten, auch wenn sie denselben Namen wie andere Orte haben."
+   },
+   {
+      "id":"Myriad",
+      "cycle":[
+         "tde"
+      ],
+      "title":"Unzählig",
+      "text":"Das Deck eines Ermittlers darf statt der üblichen 2 Kopien bis zu 3 Kopien einer Spielerkarte (nach Name) mit dem Schlüsselwort Unzählig enthalten. Zusätzlich gilt beim Erwerb einer Karte mit dem Schlüsselwort Unzählig, dass man bis zu 2 zusätzliche Kopien dieser Karte (der gleichen Stufe) erwerben darf, ohne ihre Erfahrungspunkte zu bezahlen.\n\nBeim Ermitteln der verwendeten Erfahrungspunkte im Deck eines Ermittlers zählt nur die erste Kopie einer Karte mit dem Schlüsselwort Unzählig zur Summe verwendeter Erfahrungspunkte mit. Weitere Kopien einer solchen Karte werden nicht mitgezählt."
+   },
+   {
+      "id":"Hidden",
+      "cycle":[
+         "ptc",
+         "rtptc",
+         "tcu",
+         "rttcu",
+         "tde",
+         "tdea",
+         "tdeb",
+         "tskc",
+         "zdm",
+         "zcf"
+      ],
+      "title":"Verborgen",
+      "text":"Verborgen-Karten haben Enthüllung-Fähigkeiten, die sie geheim der Hand des Spielers hinzufügen. Dies sollte geschehen, ohne den anderen Ermittlern die Karte oder ihren Text zu enthüllen.\n\n\n- Solange sich eine Verborgen-Karte auf der Hand eines Spielers befindet, wird sie so behandelt, als ob sie sich in seiner Bedrohungszone befände. Ihre anhaltenden Fähigkeiten sind aktiv und Fähigkeiten auf ihr können ausgelöst werden, aber nur von dem Spieler, der sie auf der Hand hat. \n\n\n- Solange sich eine Verborgen-Gegnerkarte auf deiner Hand befindet, gilt sie nicht als mit dir in einen Kampf verwickelt oder in deiner Bedrohungszone befindlich. Der Gegner greift nicht an, außer es ist etwas anderes angegeben. Seine anhaltenden Fähigkeiten sind aber aktiv und Fähigkeiten auf ihm können ausgelöst werden, aber nur von dir.\n\n\n- Eine Verborgen-Karte zählt bei der Bestimmung der Handkarten eines Spielers mit, kann aber nicht von der Hand abgelegt werden, außer auf die auf der Karte beschriebene Art. Sobald Verborgen-Karten abgelegt werden, werden sie auf den Begegnungs-Ablagestapel gelegt. Anders als Schwächen bleiben sie nicht Teil des Decks des Spielers.\n\nFür ein optimales Spielerlebnis sollten die Spieler ihre Charaktere \"verkörpern\" und keine Informationen über Verborgen-Karten auf ihrer Hand mit anderen Spielern teilen.",
+      "rules":[
+         {
+            "id":"Hidden_Cards_in_Hand_When_Eliminated",
+            "title":"Verborgene Karten auf der Hand beim Ausscheiden",
+            "text":"Sobald ein Ermittler aus dem Spiel ausscheidet, wird jede Begegnungskarte mit dem Schlüsselwort verborgen auf den Begegnungs-Ablagestapel gelegt, auf die gleiche Weise, wie Begegnungskarten in seiner Bedrohungszone."
+         }
+      ]
+   },
+   {
+      "id":"Doom",
+      "title":"Verderben",
+      "text":"Verderben steht für den Fortschritt der Mächte des Mythos bei der Durchführung ihrer üblen Rituale, der Beschwörung kosmischer Wesenheiten und/oder der Erfüllung der Agenda in einem Szenario.\n\n\n- Während jeder Mythosphase wird 1 Verderbensmarker auf die aktuelle Agenda platziert (siehe \"[I. Mythosphase](#Mythos_Phase)\").\n\n\n- Falls es keine \"<b>Ermittlungsziel</b> –\"-Voraussetzungen für das Vorrücken der aktuellen Agenda gibt und die angegebene Anzahl Verderbensmarker im Spiel ist (auf der Agenda und allen anderen Karten im Spiel), rückt man während des \"Verderbensschwellenwert überprüfen\"-Schrittes in der Mythosphase in der Agenda vor. Dies ist die einzige Möglichkeit, das Agendadeck vorzurücken, falls nicht eine Karte ausdrücklich angibt, dass sie das Agendadeck vorrückt.\n\n\n- Verderbensmarker auf Karten außer der Agenda (wie zum Beispiel auf Gegnern, Verbündeten oder Orten) zählen mit bei der Bestimmung der Verderbensmarker im Spiel.\n\nSiehe auch \"[Szenendeck und Agendadeck](#Act_Deck_and_Agenda_Deck)\", \"[Marker, keine mehr übrig](#Tokens)\"."
+   },
+   {
+      "id":"Vengeance_X",
+      "title":"Vergeltung X",
+      "cycle":[
+         "tfa",
+         "rttfa"
+      ],
+      "scenarios":[
+         "relics_of_the_past"
+      ],
+      "text":"Einige Begegnungskarten haben einen Vergeltungspunktewert. Der Text <b>Vergeltung X</b> zeigt an, dass eine Karte X Vergeltungspunkte wert ist.\n\nWie bei <b>Sieg X</b> wird eine Karte mit <b>Vergeltung X</b> bis zum Ende des Szenarios auf den Siegpunktestapel gelegt, sobald die Ermittler es schaffen, diese zu überwinden. Anders als bei Siegpunkten stehen die Vergeltungspunkte für die Wachsamkeit und Feindseligkeit des Vaters der Schlangen und es ist grundsätzlich eine gute Idee, das Ansammeln von Vergeltungspunkten zu vermeiden.\n\nVergeltungspunkte im Siegpunktestapel haben keine Auswirkungen auf das Spiel, außer wenn sich eine andere Begegnungskarte ausdrücklich auf sie bezieht.\n\n\n= Wird ein Gegner mit <b>Vergeltung X</b> besiegt, wird die Karte auf dem Siegpunktestapel statt auf dem Ablagestapel platziert.\n\n\n= Am Ende eines Szenarios wird jeder enthüllte Ort mit <b>Vergeltung X</b> im Spiel, auf dem sich keine Hinweise befinden, auf dem Siegpunktestapel platziert.\n\n\n= Ist die Abhandlung einer Verratskarte mit <b>Vergeltung X</b> abgeschlossen, wird sie auf dem Siegpunktestapel statt auf dem Ablagestapel platziert.\n\n\n= Karten, die Vergeltungspunkte wert sind, sind nicht auch Siegpunkte wert, es sei denn, die Karte hat sowohl <b>Sieg X</b> als auch <b>Vergeltung X</b>."
+   },
+   {
+      "id":"Parley",
+      "title":"Verhandlung",
+      "text":"Einige Fähigkeiten haben das Aktionskennzeichen Verhandlung. Solche Fähigkeiten können durch die Verwendung der Aktivieren-Aktion initiiert werden (siehe \"[Aktivieren (Aktion)](#Activate_Action)\")."
+   },
+   {
+      "id":"Treachery_Cards",
+      "title":"Verratskarten",
+      "text":"Verratskarten stehen für Flüche, Heimsuchungen, Wahnsinn, Hindernisse, Katastrophen und andere unerwartete Vorkommnisse, auf die ein Ermittler im Verlauf eines Szenarios treffen kann.\n\nSobald ein Ermittler eine Verratskarte zieht, muss er ihren Effekt abhandeln. Dann wird die Karte auf ihren Ablagestapel gelegt, falls durch die Fähigkeit nichts anderes angegeben wird.\n\nSiehe \"[1.4 Jeder Ermittler zieht 1 Begegnungskarte](#Mythos_Phase)\".",
+      "rules":[
+         {
+            "id":"Treachery_Subtitles",
+            "title":"Untertitel auf Verratskarten",
+            "text":"Verratskarten haben keinen speziellen Bereich für einen Untertitel. Falls der Name einer Verratskarte 1 oder mehr Worte in Klammern aufweist, gelten die Worte in Klammern als Untertitel. Andere Karten mit demselben Namen und unterschiedlichem Untertitel gelten noch immer als Kopien voneinander.\n\n<i>Beispiel: Sowohl [Rastlose Reise (Irrtum)](/card/06319) als auch [Rastlose Reise (Mühsal)](/card/06320) sind Kopien der Verratskarte Rastlose Reise.</i>"
+         }
+      ]
+   },
+   {
+      "id":"Seal",
+      "title":"Versiegeln",
+      "cycle":[
+         "zdm"
+      ],
+      "text":"Als zusätzliche Kosten, um eine Karte mit dem Schlüsselwort Versiegeln ins Spiel kommen zu lassen, muss der Spieler, der die Karte kontrolliert, den Chaosbeutel nach dem angegebenen Chaosmarker durchsuchen, ihn auf der Karte platzieren und damit versiegeln. Falls es möglich ist, unter mehreren Markern zu wählen, trifft der Spieler, der die Karte kontrolliert, diese Wahl. Falls sich der angegebene Marker nicht im Chaosbeutel befindet, kann die Karte nicht ins Spiel kommen. Ein versiegelter Chaosmarker gilt als nicht im Chaosbeutel befindlich und kann deshalb nicht als Teil einer Fertigkeitsprobe oder einer Fähigkeit aus dem Chaosbeutel enthüllt werden.\n\nSobald ein Chaosmarker \"freigesetzt\" wird, wird er zurück in den Chaosbeutel geschickt und gilt nicht länger als versiegelt.<b>Falls eine Karte mit einem oder mehreren versiegelten Chaosmarkern darauf aus irgendeinem Grund das Spiel verlässt, werden darauf versiegelte Chaosmarker sofort freigesetzt.</b>\n\nEinige Karten (unabhängig davon, ob sie selbst das Schlüsselwort Versiegeln haben) können auch Fähigkeiten haben, die einen oder mehrere Chaosmarker als Teil ihres Effektes versiegeln. Das geschieht ebenfalls auf die oben angegebene Weise: Der Chaosbeutel wird nach dem angegebenen Marker durchsucht, dieser wird dann aus dem Chaosbeutel entfernt und auf der Karte platziert. Falls sich der angegebene Marker nicht im Chaosbeutel befindet, misslingt der Effekt."
+   },
+   {
+      "id":"Asset_Cards",
+      "title":"Vorteilskarten",
+      "text":"Vorteilskarten stehen für Gegenstände, Verbündete, Talente, Zauber und andere Dinge, die dem Ermittler helfen oder von ihm in einem Szenario verwendet werden dürfen.\n\n\n- Sobald man eine Vorteilskarte spielt, platziert man sie in seine Spielzone. Normalerweise bleiben Vorteilskarten im Spiel, wenn sie nicht durch eine Kartenfähigkeit oder einen Spielschritt abgelegt werden.\n\n\n- Einige Vorteilskarten haben Werte für Ausdauer und/oder Geistige Gesundheit. Sobald einem Ermittler Schaden oder Horror zugefügt wird, darf dieser Ermittler einen Teil davon oder den kompletten Schaden oder Horror einer gültigen Vorteilskarte zuweisen, die er kontrolliert (siehe \"[Schaden/Horror zufügen](#Dealing_Damage_Horror)\").\n\n\n- Die meisten Vorteilskarten benötigen einen oder mehrere Slots, solange sie sich im Spiel befinden (siehe \"[Slots](#Slots)\").\n\n\n- Einige Vorteilskarten haben ein Begegnungssetsymbol und keine Stufenanzeige. Solche Vorteilskarten nennt man Storyvorteile. Storyvorteile sind Teil eines Begegnungssets und dürfen nicht zu Spielerdecks hinzugefügt werden, es sei denn, die Auflösung oder die Vorbereitung eines Szenarios erlaubt dies dem Spieler."
+   },
+   {
+      "id":"Peril",
+      "title":"Wagnis",
+      "text":"Wagnis ist eine Schlüsselwortfähigkeit.\n\nSolange das Ziehen einer Begegnungskarte mit dem Schlüsselwort Wagnis abgehandelt wird, kann sich ein Ermittler nicht mit anderen Spielern beraten. Diese Spieler können keine Karten spielen, Fähigkeiten auslösen oder Karten zu Fertigkeitsproben des Ermittlers beitragen, solange die Wagnis-Begegnung abgehandelt wird."
+   },
+   {
+      "id":"The_letter_X",
+      "title":"X (Buchstabe)",
+      "text":"Der Wert des Buchstaben X wird durch eine Kartenfähigkeit oder durch Wahl der Spieler definiert. Falls X nicht definiert ist, ist sein Wert 0.\n\n\n- Bei Kosten, die den Buchstaben X enthalten, ist X durch die Kartenfähigkeit oder die Wahl des Spielers definiert. Danach darf die zu zahlende Menge durch Effekte modifiziert werden, ohne dass dies den Wert von X verändert."
+   },
+   {
+      "id":"Draw_Action",
+      "title":"Ziehen (Aktion)",
+      "text":"\"Ziehen\" ist eine Aktion, die ein Ermittler in seinem Zug in der Ermittlungsphase nehmen darf. Sobald ein Ermittler diese Aktion nimmt, zieht er eine Karte von seinem Deck."
+   },
+   {
+      "id":"Target",
+      "title":"Ziel",
+      "text":"Der Begriff \"wählen\" zeigt an, dass man ein oder mehrere Ziele wählen muss, damit man eine Fähigkeit abhandeln kann. Der Spieler, der die Fähigkeit abhandelt, muss ein Spielelement (normalerweise eine Karte) wählen, welche die Zielvoraussetzungen der Fähigkeit erfüllt.\n\n\n- Falls eine Fähigkeit die Auswahl eines Zieles erfordert und es kein gültiges Ziel (oder nicht genügend gültige Ziele) gibt, kann die Fähigkeit nicht initiiert werden.\n\n\n- Falls es erforderlich ist, dass mehrere Ziele vom selben Spieler gewählt werden, werden diese gleichzeitig gewählt.\n\n\n- Ein Effekt, der \"eine beliebige Anzahl\" Ziele auswählen kann, wird nicht erfolgreich abgehandelt (und kann den Spielstatus nicht ändern), falls null dieser Ziele gewählt werden.\n\n\n- Eine Karte ist kein gültiges Ziel für eine Fähigkeit, falls die Abhandlung des Effektes dieser Fähigkeit den Zustand der Karte nicht ändern könnte.\n\n<i>Beispiel: Ein erschöpfter Gegner könnte nicht als Ziel eines Effektes gewählt werden, dessen Text lautet: \"wähle und erschöpfe einen Gegner\".</i>"
+   },
+   {
+      "id":"Aloof",
+      "title":"Zurückhaltend",
+      "text":"Zurückhaltend ist eine Schlüsselwortfähigkeit. Ein Gegner mit dem Schlüsselwort Zurückhaltend verwickelt Ermittler am selben Ort nicht automatisch in einen Kampf.\n\n\n- Sobald ein Gegner mit Zurückhaltend erscheint, erscheint dieser, ohne in einen Kampf verwickelt zu sein.\n\n\n- Ein Ermittler darf die Aktion \"In einen Kampf verwickeln\" oder eine Kartenfähigkeit verwenden, um einen Gegner mit Zurückhaltend in einen Kampf zu verwickeln.\n\n\n- Ein Ermittler kann einen Gegner mit Zurückhaltend nicht angreifen, solange dieser Gegner nicht mit einem Ermittler in einen Kampf verwickelt ist."
+   },
+   {
+      "id":"Retaliate",
+      "title":"Zurückschlagen",
+      "text":"Zurückschlagen ist eine Schlüsselwortfähigkeit.\n\nImmer wenn einem Ermittler eine Fertigkeitsprobe misslingt, während er einen spielbereiten Gegner mit dem Schlüsselwort Zurückschlagen angreift, führt dieser Gegner einen Angriff gegen den angreifenden Ermittler durch, nachdem alle Ergebnisse der Fertigkeitsprobe angewendet worden sind. Ein Gegner wird nicht erschöpft, nachdem er einen ZurückschlagenAngriff durchgeführt hat.\n\n\n- Dieser Angriff geschieht unabhängig davon, ob der Gegner mit dem angreifenden Ermittler in einen Kampf verwickelt ist oder nicht."
+   },
+   {
+      "id":"Additional_Costs",
+      "title":"Zusätzliche Kosten",
+      "text":"Manche Karten haben zusätzliche Kosten, die gezahlt werden müssen, um bestimmte Effekte oder Aktionen durchführen zu können. Diese werden in der Form von \"als zusätzliche Kosten um (spezieller Effekt/Aktion) musst du (zusätzliche Kosten)\" oder \"Du musst (als zusätzliche Kosten) um (speziellen Effekt/eine Aktion)\" angegeben. \n\nZusätzliche Kosten sind Kosten, die außerhalb des normalen Zeitpunkts zum Zahlen von Kosten gezahlt werden können (z. B. während des Abhandels eines Effekts). Falls ein Effekt, der zusätzliche Kosten voraussetzt, abgehandelt werden würde, müssen die zusätzlichen Kosten zu diesem Zeitpunkt gezahlt werden. Falls die zusätzlichen Kosten nicht gezahlt werden können, misslingt das Abhandeln dieses Teils des Effekts. \n\nZusätzliche Kosten müssen nicht gezahlt werden, sobald ein <b>Erzwungen</b>- Effekt oder eine verpflichtende Anweisung (wie etwa im Kampagnenleitfaden oder auf der Rückseite einer Szenen-oder Agendakarte) einen Ermittler dazu auffordert, einen Effekt abzuhandeln.\n\n<i>Beispiel: [\"Ashcan\" Pete](/card/02005) befindet sich auf dem [Miskatonic-Freigelände](/card/02048) und aktiviert [Dukes](/card/02014) zweite Fähigkeit, die lautet: \"[action] Erschöpfe Duke: <b>Ermitteln.</b> Du ermittelst mit einem Grund-[intellect]-Fertigkeitswert von 4. Du darfst dich sofort auf einen verbundenen Ort bewegen, bevor du mit diesem Effekt ermittelst.\" Pete zahlt die Kosten, um die Fähigkeit zu aktivieren, indem er eine Aktion ausgibt und Duke erschöpft. Dann handelt Pete die Fähigkeit ab, indem er sich zuerst zur [Orne-Bibliothek](/card/02050) bewegt und daraufhin ermittelt. Der Text der Orne-Bibliothek aber lautet: \"Du musst eine zusätzliche Aktion ausgeben, um in der Orne-Bibliothek zu ermitteln.\" Das fügt zusätzliche Kosten hinzu, die gezahlt werden müssen, um in der Orne-Bibliothek zu ermitteln. Diese zusätzlichen Kosten werden gezahlt, sobald die Ermitteln-Aktion abgehandelt werden würde, außerhalb des Zeitpunkts zum Zahlen von Kosten. Falls Pete die zusätzliche Aktion nicht zahlen kann, misslingt das Abhandeln dieses Teils von Petes Effekt und er kann nicht ermitteln.</i>"
+   },
+   {
+      "id":"Doubt_and_Conviction",
+      "title":"Zweifel und Überzeugung",
+      "cycle":[
+         "ptc",
+         "rtptc"
+      ],
+      "text":"Einige Szenario auflösungen und Zwischenspiele in der Kampagne <i>Der Pfad nach Carcosa</i> enthalten die Anweisung, dass die Spieler \"einen <b>Zweifel</b> ankreuzen\" oder \"eine <b>Überzeugung</b> ankreuzen\" sollen. Dazu wird einfach eines der Kästchen neben <b>Zweifel</b> oder <b>Überzeugung</b> unten im Kampagnenlogbuch angekreuzt.\n\nSpäter in der Kampagne werden sich einige Szenarien verändern, abhängig davon, ob die Ermittler \"mehr <b>Zweifel</b> als <b>Überzeugung</b>\" oder \"mehr <b>Überzeugung</b> als <b>Zweifel</b>\" haben. Die Ermittler haben mehr <b>Zweifel</b> als <b>Überzeugung</b>, falls die Zahl der angekreuzten Kästchen neben <b>Zweifel</b> höher als die Zahl der angekreuzten Kästchen neben <b>Überzeugung</b> ist (und umgekehrt). <b>Zweifel</b> und <b>Überzeugung</b> beziehen sich auf die Gruppe der Ermittler und sind nicht an spezielle Ermittler gebunden. <b>Zweifel</b> und <b>Überzeugung</b> haben keinen Effekt auf das Spiel, außer wenn im Kampagnenleitfaden oder durch einen Karteneffekt ausdrücklich darauf Bezug genommen wird."
+   },
+   {
+      "id":"Appendix_I_Initiation_Sequence",
+      "title":"Anhang I: Abfolge einer Initiierung",
+      "text":"Sobald ein Spieler eine ausgelöste Fähigkeit initiieren oder eine Karte spielen möchte, erklärt dieser Spieler zunächst seine Absicht. Es müssen zunächst zwei Bestätigungen erfolgen, ehe der Prozess der Initiierung einer Fähigkeit oder des Spielens einer Karte beginnen kann. Diese sind:\n\n\n- Spieleinschränkungen überprüfen: Man bestimmt, ob die Karte gespielt oder ob die Fähigkeit initiiert werden kann. (Dazu gehört auch sicherzustellen, dass die Abhandlung des Effektes die Möglichkeit hat, den Spielstatus zu ändern.) Falls die Spieleinschränkungen nicht erfüllt sind, wird der Prozess abgebrochen.\n\n\n- Kosten (möglicherweise mehrere) für das Spielen der Karte oder das Initiieren der Fähigkeit bestimmen. Falls sichergestellt ist, dass die Kosten (unter Beachtung von Modifikatoren) gezahlt werden können, wird mit den übrigen Schritten dieser Abfolge fortgefahren. \n\nSobald beide der oben angegebenen Bestätigungen erfolgt sind, werden folgende Schritte in der angegebenen Reihenfolge durchgeführt:\n\n1. Mögliche Modifikatoren auf die Kosten anwenden.\n\n2. Kosten bezahlen. Falls dieser Schritt erreicht wird und die Kosten nicht gezahlt werden können, wird dieser Prozess, ohne die Kosten zu bezahlen, abgebrochen.\n\n\n- Nach Abschluss dieses Schrittes werden mögliche Gelegenheitsangriffe abgehandelt.\n\n3. Es wird begonnen, die Karte zu spielen, oder versucht, die Fähigkeit zu initiieren.\n\n4. Die Effekte der Fähigkeit (falls nicht in Schritt 3 aufgehoben) beenden ihre Initiierung und werden abgehandelt. Gleichzeitig mit dem Ende dieses Schrittes betrachtet man die Karte als gespielt (und ins Spiel gebracht oder auf den Ablagestapel ihres Besitzers gelegt, falls sie eine Ereigniskarte ist) und die Fähigkeit gilt als abgehandelt.\n\n\n-- Falls sich die Fähigkeit, die initiiert wird, auf einer Karte im Spiel befindet, bricht man den Ablauf nicht ab, falls die Karte während des Ablaufs das Spiel verlässt."
+   },
+   {
+      "id":"Appendix_II_Timing_and_Gameplay",
+      "title":"Anhang II: Timing und Spiel",
+      "text":"Die \"[Timingstruktur: Phasenablauf](#Phase_Sequence_Timing)\" verdeutlicht die Phasen und Schritte einer Spielrunde. Immer wenn ein Ermittler eine Fertigkeitsprobe ablegt, wird die Timingstruktur für Fertigkeitsproben verwendet, die im Abschnitt \"[Timing für Fertigkeitsproben (FP)](#Skill_Test_Timing)\" genau erläutert wird.\n\nNummerierte Punkte in grauen Kästen nennt man Rahmenereignisse. Rahmenereignisse sind verpf lichtend eintretende Zeitpunkte, die durch die Spielstruktur vorgegeben sind.\n\nDie roten Kästen stellen Spielerfenster dar. Die Spieler dürfen [free] ausgelöste Fähigkeiten in diesen Fenstern verwenden.\n\nEinzelheiten zu jedem dieser Schritte befinden sich im Abschnitt \"[Genaue Erläuterung der Rahmenereignisse](#Framework_Event_Details)\".",
+      "rules":[
+         {
+            "id":"Phase_Sequence_Timing",
+            "title":"Timingstruktur: Phasenablauf",
+            "table":[
+               {
+                  "row":[
+                     {
+                        "text":"<b>I. Mythosphase</b> (diese Phase wird während der ersten Runde des Spiels übersprungen)"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"1.1 Runde beginnt. Mythosphase beginnt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"1.2 Auf der aktuellen Agenda 1 Verderbensmarker platzieren"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"1.3 Verderbensschwellenwert überprüfen."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"1.4 Jeder Ermittler zieht 1 Begegnungskarte."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"1.5 Mythosphase endet"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"grey",
+                        "text":"Das Spiel wird mit der Ermittlungsphase fortgesetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "text":"<b>II. Ermittlungsphase</b>"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"2.1 Ermittlungsphase beginnt"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"2.2 Zug des nächsten Ermittlers beginnt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"2.2.1 Der aktive Ermittler darf eine Aktion nehmen, falls möglich. Falls eine Aktion genommen wurde, kehrt man zum vorherigen Spielerfenster zurück. Falls keine Aktion genommen worden ist, wird das Spiel mit Schritt 2.2.2 fortgesetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"2.2.2 Zug des Ermittlers endet. Falls ein Ermittler seinen Zug in dieser Phase noch nicht genommen hat, wird das Spiel bei Schritt 2.2 fortgesetzt. Falls jeder Ermittler seinen Zug in dieser Phase genommen hat, wird das Spiel bei Schritt 2.3 fortgesetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"2.3 Ermittlungsphase endet"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"grey",
+                        "text":"Das Spiel wird mit der Gegnerphase fortgesetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "text":"<b>III. Gegnerphase</b>"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"3.1 Gegnerphase beginnt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"3.2 Jäger-Gegner bewegen sich."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"3.3 Der nächste Ermittler handelt die Angriffe der mit ihm in Kämpfe verwickelten Gegner ab. Falls ein Ermittler in dieser Phase noch keine Gegner-Angriffe abgehandelt hat, kehrt man zum vorherigen Spielerfenster zurück. Nachdem der letzte Ermittler Angriffe durch in Kämpfe verwickelte Gegner abgehandelt hat, wird das Spiel mit dem nächsten Spielerfenster fortgesetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"3.4 Gegnerphase endet."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"grey",
+                        "text":"Das Spiel wird mit der Unterhaltsphase fortgesetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "text":"<b>IV. Unterhaltsphase</b>"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"4.1 Unterhaltsphase beginnt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"4.2 Aktionen zurücksetzen."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"4.3 Alle erschöpften Karten spielbereit machen."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"4.4 Jeder Ermittler zieht 1 Karte und erhält1 Ressource."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"4.5 Jeder Ermittler überprüft sein Handkartenlimit."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"4.6 Unterhaltsphase endet. Runde endet."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"grey",
+                        "text":"Das Spiel wird mit der Mythosphase der nächsten Runde fortgesetzt."
+                     }
+                  ]
+               }
+            ]
+         },
+         {
+            "id":"Framework_Event_Details",
+            "title":"Genaue Erläuterung der Rahmenereignisse",
+            "text":"Dieser Abschnitt erläutert im Detail, wie die einzelnen Rahmenereignisschritte im Ablaufdiagramm abgehandelt werden. Die einzelnen Rahmenereignisse werden in der Reihenfolge erläutert, in der sie im Spiel auftreten.",
+            "rules":[
+               {
+                  "id":"Mythos_Phase",
+                  "title":"I. Mythosphase",
+                  "text":"<b>In der ersten Runde des Spiels wird die Mythosphase übersprungen.</b>\n\n<b>1.1 Mythosphase beginnt.</b>\n\nDieser Schritt stellt den formalen Beginn der Mythosphase dar. Da dies das erste Rahmenereignis der Runde ist, stellt er auch den formalen Beginn einer neuen Spielrunde dar. Der Beginn einer Phase ist ein wichtiger Meilenstein, auf den sich Kartentexte beziehen können. Dies geschieht entweder als der Zeitpunkt, an dem eine Fähigkeit abgehandelt werden darf oder muss oder als der Zeitpunkt, an dem ein aufgeschobener Effekt abgehandelt wird oder ein andauernder Effekt abläuft.\n\n<b>1.2 Auf der aktuellen Agenda 1 Verderbensmarker platzieren.</b>\n\nMan nimmt 1 Verderbensmarker aus dem Markervorrat und platziert ihn auf die aktuelle Agendakarte.\n\n<b>1.3 Verderbensschwellenwert überprüfen.</b>\n\nMan vergleicht die Gesamtzahl der Verderbensmarker im Spiel (auf der aktuellen Agenda und auf jeder anderen Karte im Spiel) mit dem Schwellenwert für Verderben auf der aktuellen Agenda. Falls die Anzahl der Verderbensmarker im Spiel den Schwellenwert für Verderben auf der aktuellen Agenda erreicht oder übertrifft, rückt man im Agendadeck vor.\n\nSobald man im Agendadeck vorrückt, werden alle Verderbensmarker aus dem Spiel entfernt und zurück in den Markervorrat gelegt. Die aktuelle Agenda wird umgedreht, der Storytext gelesen und die Anweisungen befolgt, um das Spiel fortzusetzen. Falls die Vorrückanweisungen nicht ausdrücklich etwas anderes sagen, wird die Vorderseite der als nächstes folgenden Agendakarte zur neuen aktuellen Agenda und die alte Agenda wird gleichzeitig aus dem Spiel entfernt.\n\n<i>Hinweis: Dies ist die einzige Möglichkeit, um im Agendadeck vorzurücken, falls nicht eine Karte ausdrücklich besagt, dass man im Agendadeck vorrückt.</i>\n\n<b>1.4 Jeder Ermittler zieht 1 Begegnungskarte.</b>\n\nIn Spielerreihenfolge zieht jeder Ermittler die oberste Karte des Begegnungsdecks, handelt Enthüllungsfähigkeiten auf dieser Karte ab und folgt den unten stehenden Anweisungen abhängig vom Kartentyp.\n\nImmer wenn ein Ermittler eine Begegnungskarte zieht, führt man die folgenden Schritte in der nachstehenden Reihenfolge durch:\n\n1. Karte vom Begegnungsdeck ziehen.\n\n2. Überprüfen, ob die gezogene Karte das Schlüsselwort Wagnis hat. (Falls die Karte das Schlüsselwort Wagnis hat, kann sich der Ermittler, der diese Karte gezogen hat, nicht mit anderen Spielern beraten. Die anderen Spieler können keine Karten spielen, Fähigkeiten auslösen oder Karten zu Fertigkeitsproben des Ermittlers beitragen, solange die Wagnis-Begegnung abgehandelt wird.)\n\n3. Enthüllungsfähigkeit auf der gezogenen Karte abhandeln.\n\n4. Falls die Karte ein <b>Gegner</b> ist, erscheint er unter Beachtung der Erscheinen-Anweisung auf der Karte. (Eine Erscheinen-Anweisung ist jeder Kartentext, dem das Wort \"Erscheinen\" vorausgeht.) Falls der Gegner keine Erscheinen-Anweisung hat, wird der Gegner mit dem Ermittler, der auf diese Karte getroffen ist, in einen Kampf verwickelt ins Spiel gebracht und in der Bedrohungszone dieses Ermittlers platziert.\n\nFalls die Karte ein <b>Verrat</b> ist, legt man sie auf den Begegnungs-Ablagestapel, falls die Fähigkeit nichts anderes angibt.\n\n5. Falls die gezogene Karte das Schlüsselwort Nachrüsten hat, muss der Ermittler eine weitere Karte ziehen. Dieser Ablauf wird dann erneut bei Schritt 1 gestartet.\n\n<b>1.5 Mythosphase endet.</b>\n\nDieser Schritt stellt das formale Ende der Mythosphase dar.\n\nDas Ende einer Phase ist ein wichtiger Punkt im Spiel, auf den sich Kartentexte beziehen können, entweder als der Zeitpunkt, an dem eine Fähigkeit abgehandelt werden darf oder muss, oder als der Zeitpunkt, an dem ein aufgeschobener Effekt abgehandelt wird oder ein andauernder Effekt abläuft."
+               },
+               {
+                  "id":"Investigation_Phase",
+                  "title":"II. Ermittlungsphase",
+                  "text":"<b>2.1 Ermittlungsphase beginnt.</b>\n\nDieser Schritt stellt den Beginn der Ermittlungsphase dar.\n\n<b>2.2 Zug des nächsten Ermittlers beginnt.</b>\n\nDie Ermittler dürfen ihre Züge in beliebiger Reihenfolge nehmen. Die Ermittler entscheiden, wer von ihnen seinen Zug nimmt. Diese Entscheidung stellt den Beginn des Zuges dieses Ermittlers dar. Der Ermittler, der gerade seinen Zug nimmt, wird aktiver Ermittler genannt.\n\nSobald ein Ermittler seinen Zug beginnt, muss dieser Ermittler seinen Zug vollständig abschließen, bevor ein anderer Ermittler seinen Zug nehmen darf. Jeder Ermittler nimmt 1 Zug pro Runde.\n\n<b>2.2.1 Der Ermittler nimmt eine Aktion, falls möglich.</b>\n\nWährend seines Zuges darf ein Ermittler drei Aktionen nehmen. Eine Aktion kann für eine der folgenden Handlungen verwendet werden:\n\n\n- An seinem Ort <b>ermitteln</b>.\n\n\n- Sich auf einen verbundenen Ort <b>bewegen</b>.\n\n\n- <b>Ziehen</b> (1 Karte ziehen).\n\n\n- <b>Ressource</b> (1 Ressource erhalten).\n\n\n- Eine Vorteils- oder Ereigniskarte von seiner Hand <b>spielen</b>.\n\n\n- Eine [action]-Kosten-Fähigkeit auf einer Karte im Spiel, die er kontrolliert, auf einer Begegnungskarte an seinem Ort, auf einer Karte in seiner Bedrohungszone, auf der aktuellen Szenenkarte oder auf der aktuellen Agendakarte <b>aktivieren</b>.\n\n\n- Gegen einen Gegner an seinem Ort <b>kämpfen</b>.\n\n\n- Einen Gegner an seinem Ort <b>in einen Kampf verwickeln</b>.\n\n\n- Versuchen einem Gegner, mit dem er in einen Kampf verwickelt ist, zu <b>entkommen</b>.\n\nDie drei Aktionen, die ein Ermittler während seines Zuges durchführt, dürfen eine beliebige Kombination aus den oben genannten Aktionen in beliebiger Reihenfolge sein. Es ist auch möglich, dieselbe Aktion drei Mal hintereinander durchzuführen.\n\n<b>Wichtig:</b> Sobald ein Ermittler mit einem oder mehreren spielbereiten Gegnern in einen Kampf verwickelt ist und etwas anderes macht, als die Aktion <b>Kampf</b> oder <b>Entkommen</b> zu nehmen oder eine <b>Verhandlungs-</b> oder <b>Aufgeben</b>-Fähigkeit zu aktivieren, kann jeder dieser Gegner einen Gelegenheitsangriff gegen den Ermittler durchführen. Die Reihenfolge der Angriffe wählt dabei der Ermittler.\n\nNachdem ein Ermittler eine Aktion genommen hat, kehrt man ins vorherige Spielerfenster zurück. Ein Ermittler darf seinen Zug vorzeitig beenden, falls er keine weiteren Aktionen durchführen möchte. Falls der Ermittler keine Aktion nehmen kann oder möchte, setzt man das Spiel mit Schritt 2.2.2 fort.\n\n<b>2.2.2 Der Zug des Ermittlers endet.</b>\n\nDie kleine Ermittlerkarte des aktiven Ermittlers wird auf ihre farblose Seite gedreht, um anzuzeigen, dass der Zug dieses Ermittlers abgeschlossen ist. Falls es einen Ermittler gibt, der seinen Zug in dieser Runde noch nicht genommen hat, wird das Spiel bei Schritt 2.2 fortgesetzt. Falls jeder Ermittler in dieser Runde seinen Zug genommen hat, wird das Spiel bei Schritt 2.3 fortgesetzt.\n\n<b>2.3 Ermittlungsphase endet.</b>\n\nDieser Schritt stellt das formale Ende der Ermittlungsphase dar."
+               },
+               {
+                  "id":"Enemy_Phase",
+                  "title":"III. Gegnerphase",
+                  "text":"<b>3.1 Gegnerphase beginnt.</b>\n\nDieser Schritt stellt den formalen Beginn der Gegnerphase dar.\n\n<b>3.2 Jäger-Gegner bewegen sich.</b>\n\nDas Schlüsselwort Jäger wird auf allen spielbereiten, nicht in einen Kampf verwickelten Gegnern abgehandelt, die das Schlüsselwort Jäger haben (siehe \"[Jäger](#Hunter)\").\n\n<b>3.3 Der nächste Ermittler handelt die Angriffe der mit ihm in Kämpfe verwickelten Gegner ab.</b>\n\nIn Spielerreihenfolge werden die Angriffe der mit in Kämpfe verwickelten Gegner abgehandelt. Jeder Spieler handelt dabei alle Gegner ab, mit denen er in einen Kampf verwickelt ist, ehe der nächste Spieler an der Reihe ist.\n\nJeder spielbereite, in einen Kampf verwickelte Gegner macht einen Angriff gegen den Ermittler, mit dem er in einen Kampf verwickelt ist. Sobald ein Gegner angreift, fügt er seinen Angriff (Schaden und Horror gleichzeitig) dem Ermittler zu, mit dem er in einen Kampf verwickelt ist. Nachdem er seinen Angriff vollständig zugefügt hat (und alle durch den Angriff ausgelöste Fähigkeiten), wird der Gegner erschöpft. Falls ein Ermittler mit mehreren Gegnern in einen Kampf verwickelt ist, wählt der angegriffene Ermittler die Reihenfolge der Angriffe.\n\nNachdem ein Ermittler die Angriffe der Gegner, mit denen er in einen Kampf verwickelt ist, abgehandelt hat, kehrt man zum vorherigen Spielerfenster zurück. Nachdem der letzte Ermittler die Angriffe der Gegner, mit denen er in einen Kampf verwickelt ist, abgehandelt hat, wird das Spiel mit dem nächsten Spielerfenster fortgesetzt.\n\n<b>3.4 Gegnerphase endet.</b>\n\n Dieser Schritt stellt das formale Ende der Gegnerphase dar"
+               },
+               {
+                  "id":"Upkeep_Phase",
+                  "title":"IV. Unterhaltsphase",
+                  "text":"<b>4.1 Unterhaltsphase beginnt.</b>\n\nDieser Schritt stellt den formalen Beginn der Unterhaltsphase dar.\n\n<b>4.2 Aktionen zurücksetzen.</b>\n\nDie kleinen Ermittlerkarten werden zurück auf ihre farbige Seite gedreht. Dies zeigt an, dass die Aktionen der Ermittler für ihren nächsten Zug zurückgesetzt worden sind.\n\n<b>4.3 Erschöpfte Karten spielbereit machen.</b>\n\nMan macht gleichzeitig alle erschöpften Karten spielbereit.\n\n<b>4.4 Jeder Ermittler zieht 1 Karte und erhält 1 Ressource.</b>\n\nIn Spielerreihenfolge zieht jeder Ermittler 1 Karte. Sobald die Karten gezogen worden sind, erhält jeder Ermittler 1 Ressource.\n\n<b>4.5 Jeder Ermittler überprüft sein Handkartenlimit.</b>\n\nIn Spielerreihenfolge wählt jeder Ermittler mit mehr als 8 Karten in der Hand so viele Karten aus und legt sie ab, bis er nur noch 8 Karten hat.\n\n<b>4.6 Unterhaltsphase endet.</b>\n\nDieser Schritt stellt das formale Ende der Unterhaltsphase dar.\n\nDa die Unterhaltsphase die letzte Phase der Runde ist, stellt dieser Schritt auch das formale Ende der Runde dar. Alle aktiven, andauernden \"bis zum Ende der Runde\"-Effekte laufen zu diesem Zeitpunkt ab.\n\nNachdem dieser Schritt abgeschlossen ist, geht das Spiel mit dem Beginn der Mythosphase der nächsten Spielrunde weiter."
+               }
+            ]
+         },
+         {
+            "id":"Skill_Test_Timing",
+            "title":"Timing für Fertigkeitsproben (FP)",
+            "table":[
+               {
+                  "row":[
+                     {
+                        "text":"Timing für Fertigkeitsproben (FP)"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.1 Fertigkeit für die Probe bestimmen. Die Probe auf diese Fertigkeit beginnt jetzt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.2 Karten von der Hand zu dieser Fertigkeitsprobe beitragen"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"red",
+                        "text":"[free] SPIELERFENSTER"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.3 Chaosmarker enthüllen"
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.4 Chaossymbol-Effekte abhandeln."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.5 Modifizierten Fertigkeitswert des Ermittlers bestimmen."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.6 Bestimmen, ob die Fertigkeitsprobe gelingt/misslingt."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.7 Ergebnis der Fertigkeitsprobe anwenden."
+                     }
+                  ]
+               },
+               {
+                  "row":[
+                     {
+                        "color":"green",
+                        "text":"FP.8 Die Fertigkeitsprobe endet."
+                     }
+                  ]
+               }
+            ],
+            "rules":[
+               {
+                  "id":"Skill_Test_1",
+                  "title":"FP.1 Fertigkeit für die Probe bestimmen. Die Probe auf diese Fertigkeit beginnt jetzt.",
+                  "text":"Dieser Schritt stellt den formalen Beginn der Fertigkeitsprobe dar. Es gibt vier Arten von Fertigkeitsproben: Willenskraftproben, Intellektproben, Kampfproben und Beweglichkeitsproben. Die Kartenfähigkeit oder die Spielregel bestimmt, welche Probe nötig ist und damit beginnt eine Probe dieser Art."
+               },
+               {
+                  "id":"Skill_Test_2",
+                  "title":"FP.2 Karten von der Hand zur Fertigkeitsprobe beitragen.",
+                  "text":"Der Ermittler, der die Fertigkeitsprobe durchführt, darf eine beliebige Anzahl Karten von seiner Hand mit dem entsprechenden Fertigkeitssymbol zur Probe beitragen. \n\nJeder andere Ermittler am selben Ort wie der Ermittler, der die Probe ablegt, darf eine Karte von seiner Hand mit dem entsprechenden Fertigkeitssymbol zur Probe beitragen. \n\nEin entsprechendes Fertigkeitssymbol ist entweder eins, das der Probe entspricht, oder ein Jokersymbol. Der Ermittler, der die Probe durchführt, bekommt +1 auf seinen Fertigkeitswert für diese Probe pro entsprechendem Fertigkeitssymbol, das zu dieser Probe beigetragen wird. \n\nKarten, denen das entsprechende Fertigkeitssymbol fehlt, dürfen nicht zur Probe beigetragen werden. Wird eine Karte zu einer Fertigkeitsprobe beigetragen, werden keine Ressourcenkosten für die Karte gezahlt."
+               },
+               {
+                  "id":"Skill_Test_3",
+                  "title":"FP.3 Chaosmarker enthüllen.",
+                  "text":"Der Ermittler, der die Probe durchführt, enthüllt einen zufälligen Chaosmarker aus dem Chaosbeutel.\n\nSiehe auch \"[Abhandlung mehrerer enthüllter Chaosmarker](#Resolving_Multiple_Revealed_Chaos_Tokens)\"."
+               },
+               {
+                  "id":"Skilll_Test_4",
+                  "title":"FP.4 Chaossymbol-Effekte abhandeln..",
+                  "text":"Die Effekte, die durch das Symbol auf dem enthüllten Chaosmarker initiiert werden, werden angewendet. Jedes der folgenden Symbole zeigt an, dass eine Fähigkeit auf der Szenarioübersichtskarte initiiert werden muss: [skull], [cultist], [tablet], oder [elder_thing].\n\nDas [elder_sign]-Symbol zeigt an, dass die [elder_sign]-Fähigkeit auf der Ermittlerkarte des Spielers, der diese Probe durchführt, initiiert werden muss.\n\nFalls keines der oben angegebenen Symbole enthüllt worden ist oder falls das Symbol keine entsprechende Fähigkeit hat, wird dieser Schritt ohne Effekt abgeschlossen."
+               },
+               {
+                  "id":"Skill_Test_5",
+                  "title":"FP.5 Modifizierten Fertigkeitswert des Ermittlers bestimmen.",
+                  "text":"Man beginnt mit dem Grundwert der Fertigkeit (der abzulegenden Probe) des Ermittlers, der die Probe durchführt, und wendet alle aktiven Modifikatoren an, einschließlich der entsprechenden Symbole, die zur Probe beigetragen wurden, der Effekte von enthüllten Chaosmarkern und allen aktiven Kartenfähigkeiten, die den Fertigkeitswert des Ermittlers modifizieren."
+               },
+               {
+                  "id":"Skill_Test_6",
+                  "title":"FP.6 Bestimmen, ob die Fertigkeitsprobe gelingt/misslingt.",
+                  "text":"Der modifizierte Fertigkeitswert wird mit der Schwierigkeit der Fertigkeitsprobe verglichen. \n\nFalls der modifizierte Fertigkeitswert der Schwierigkeit der Probe entspricht oder höher ist (angegeben auf der Karte oder durch den Spielmechanismus, der diese Probe hervorgerufen hat), gelingt dem Ermittler die Probe.\n\n\n- Falls einem Ermittler eine Probe durch eine Kartenfähigkeit automatisch gelingt, gilt die Gesamtschwierigkeit der Probe als 0.\n\nFalls der Fertigkeitswert des Ermittlers niedriger ist als die Schwierigkeit dieser Probe, misslingt dem Ermittler die Probe.\n\n\n- Falls einem Ermittler eine Fertigkeitsprobe durch eine Kartenfähigkeit oder das Enthüllen des [auto_fail]-Symbols automatisch misslingt, ist der Gesamt-Fertigkeitswert des Ermittlers für diese Probe 0.\n\nSiehe auch \"[Automatischer Erfolg/Misserfolg](#Automatic_Failure_Success)\"."
+               },
+               {
+                  "id":"Skill_Test_7",
+                  "title":"FP.7 Ergebnis der Fertigkeitsprobe anwenden.",
+                  "text":"Die Kartenfähigkeit oder Spielregel, die eine Fertigkeitsprobe initiiert hat, gibt normalerweise die Konsequenz eines Erfolges und/oder eines Misserfolges dieser Probe an. (Außerdem können zu diesem Zeitpunkt einige andere Karten zusätzliche Konsequenzen beitragen oder bestehende Konsequenzen verändern.) Die entsprechenden Konsequenzen (des in FP.6 bestimmten Erfolges oder Misserfolges) werden zu diesem Zeitpunkt abgehandelt. \n\nFalls mehrere Ergebnisse in diesem Schritt angewendet werden müssen, wählt der Ermittler, der die Probe durchführt, in welcher Reihenfolge die Ergebnisse angewendet werden."
+               },
+               {
+                  "id":"Skill_Test_8",
+                  "title":"FP.8 Die Fertigkeitsprobe endet.",
+                  "text":"Dieser Schritt stellt das formale Ende der Fertigkeitsprobe dar. Alle Karten, die zur Probe beigetragen worden sind, werden abgelegt und alle enthüllten Chaosmarker werden zurück in den Chaosbeutel gelegt."
+               }
+            ]
+         }
+      ]
+   },
+   {
+      "id":"Appendix_III_Setting_Up_The_Game",
+      "title":"Anhang III: Spielvorbereitung",
+      "text":"Um ein Spiel vorzubereiten, werden folgende Schritte in angegebener Reihenfolge durchgeführt:\n\n<b>1. Ermittler wählen.</b> Jeder Spieler wählt einen anderen Ermittler und platziert die entsprechende Ermittlerkarte in seine Spielzone.\n\n<b>2. Schaden/-Horror durch Traumata nehmen.</b> Im Kampagnenspiel platziert jeder Spieler Schaden in Höhe seines körperlichen Traumas und Horror in Höhe seines seelischen Traumas auf seiner Ermittlerkarte.\n\n<b>3. Einen der Ermittler als Ermittlungsleiter für dieses Spiel wählen.</b>\n\n<b>4. Ermittlerdecks erstellen und mischen.</b>\n\n<b>5. Markervorrat erstellen.</b> Die Schadens-, Horror-, Hinweis-/Verderbens- und Ressourcenmarker werden für jeden Spieler leicht erreichbar bereitlegt.\n\n<b>6. Chaosbeutel erstellen.</b> Die in der Kampagnenvorbereitung angegebenen Chaosmarker werden in den Chaosbeutel gelegt. Die übrigen Chaosmarker kommen zurück in die Spielschachtel.\n\n\n- Im Kampagnenmodus wird der Chaosbeutel so verwendet, wie er am Ende des vorherigen Szenarios war.\n\n<b>7. Startressourcen nehmen.</b> Jeder Ermittler erhält 5 Ressourcen aus dem Markervorrat.\n\n<b>8. Starthand ziehen.</b> Jeder Spieler zieht 5 Karten. Jeder Spieler darf in Spielerreihenfolge einen Mulligan nehmen.\n\n\n- Jede Schwächekarte, die in diesem Schritt gezogen wird, wird ignoriert, beiseitegelegt (ohne sie abzuhandeln) und durch eine neu gezogene Karte vom Deck ersetzt. Nach Abschluss dieses Schrittes wird jede gezogene Schwächekarte zurück in das Deck ihres Besitzers gemischt.\n\n<b>9. Szenarioeinführung im Kampagnenhandbuch lesen.</b>\n\n<b>10. Die im Kampagnenhandbuch angegebenen Schritte zur Szenariovorbereitung durchführen.</b> Dazu gehört das Heraussuchen der in den Vorbereitungsanweisungen angegebenen Begegnungssets, die Platzierung der Orte, die Platzierung der kleinen Ermittlerkarten an den Orten, an denen jeder Ermittler das Spiel beginnt, das Beiseitelegen von dafür angegebenen Karten und das Mischen der übrigen Begegnungskarten, um das Begegnungsdeck zu erstellen.\n\n<b>11. Agendadeck vorbereiten.</b> Das Agendadeck wird in der angegebenen Reihenfolge zusammengestellt, jeweils mit der Seite nach oben, die das Kartenbild zeigt. Agenda 1a ist nun die oberste Karte des Decks. Ein Spieler liest den Storytext auf Agenda 1a vor.\n\n<b>12. Szenendeck vorbereiten.</b> Das Szenendeck wird in der angegebenen Reihenfolge zusammengestellt, jeweils mit der Seite nach oben, die das Kartenbild zeigt. Szene 1a ist nun die oberste Karte des Decks. Ein Spieler liest den Storytext auf Szene 1a vor.\n\n<b>13. Szenarioübersichtskarte neben das Agendadeck platzieren.</b>\n\nWährend der Vorbereitung gibt es kein Spielerfenster. Die Spieler dürfen während der Vorbereitung nur Spielerkartenfähigkeiten auslösen oder Karten von der Hand spielen, falls die spezielle Auslösebedingung der Karte oder der Fähigkeit erfüllt ist."
+   },
+   {
+      "id":"Appendix_IV_Card_Anatomy",
+      "title":"Anhang IV: Aufbau der Karten",
+      "text":"In diesem Abschnitt findet ihr detaillierte Angaben zum Aufbau jedes Kartentyps."
+   }
 ]


### PR DESCRIPTION
Updated the German rules:

- added missing rules
- copied missing translations from the respective german rule PDFs
- added some missing card links (mostly in examples)
- made some of the formatting more consistent
- ordered entries alphebetically

I checked the translated rules in Android Studio.