### PR TITLE
Fix Eon Chart (4) taboo text

### DIFF
--- a/taboos.json
+++ b/taboos.json
@@ -1033,7 +1033,7 @@
       {
         "code": "08100",
         "text": "This card should read \"following basic actions\" instead of \"following actions.\"",
-        "replacement_text": "Mutated. Uses (3 secrets).\n[fast]During your turn, exhaust Eon Chart and spend 1 secret: Choose and take two of the following basic actions, in any order (move, evade, or investigate)."
+        "replacement_text": "Mutated. Uses (3 secrets).\n[fast] During your turn, exhaust Eon Chart and spend 1 secret: Choose and take two different basic actions of the following, in any order (move, evade, or investigate)."
       },
       {
         "code": "08093",
@@ -1502,7 +1502,7 @@
       {
         "code": "08100",
         "text": "This card should read \"following basic actions\" instead of \"following actions.\"",
-        "replacement_text": "Mutated. Uses (3 secrets).\n[fast]During your turn, exhaust Eon Chart and spend 1 secret: Choose and take two of the following basic actions, in any order (move, evade, or investigate)."
+        "replacement_text": "Mutated. Uses (3 secrets).\n[fast] During your turn, exhaust Eon Chart and spend 1 secret: Choose and take two different basic actions of the following, in any order (move, evade, or investigate)."
       },
       {
         "code": "08093",
@@ -1983,7 +1983,7 @@
       {
         "code": "08100",
         "text": "This card should read \"following basic actions\" instead of \"following actions.\"",
-        "replacement_text": "Mutated. Uses (3 secrets).\n[fast]During your turn, exhaust Eon Chart and spend 1 secret: Choose and take two of the following basic actions, in any order (move, evade, or investigate)."
+        "replacement_text": "Mutated. Uses (3 secrets).\n[fast] During your turn, exhaust Eon Chart and spend 1 secret: Choose and take two different basic actions of the following, in any order (move, evade, or investigate)."
       },
       {
         "code": "08113",


### PR DESCRIPTION
The errata that adds this is missing from the list, but I'm not sure if adding it would break anything (two erratas for one card).

<img width="436" alt="Screenshot 2025-04-15 at 23 56 18" src="https://github.com/user-attachments/assets/71b32516-c39e-45cc-a42f-5463b185f6e1" />
<img width="334" alt="Screenshot 2025-04-15 at 23 57 34" src="https://github.com/user-attachments/assets/e4cb9aaa-7daa-4601-af02-ba492ff857e9" />
