### PR TITLE
Double-check Inescapable setups

### DIFF
--- a/campaigns/tdc/05_the_western_wall.json
+++ b/campaigns/tdc/05_the_western_wall.json
@@ -125,9 +125,10 @@
           {
             "boolCondition": true,
             "steps": ["east_story", "check_do_no_harm",
-              "setup_v2", "setup_locations_v2", "location_layout_v2",
-              "setup_act_v2",
+              "setup_v2", 
               "$check_killed_creature",
+              "setup_locations_v2", "location_layout_v2",
+              "setup_act_v2",
               "set_aside_cards_v2",
               "set_aside_star_spawn",
               "$choose_artifacts_or_support",

--- a/campaigns/tdc/07_the_apiary.json
+++ b/campaigns/tdc/07_the_apiary.json
@@ -68,10 +68,11 @@
               "east_story",
               "add_tablet", "check_walk_in_faith",
               "$check_good_money_setup",
-              "setup_v2", "setup_location", "act_deck_v2",
+              "setup_v2", 
+              "maybe_gather_inescapable",
+              "setup_location", "act_deck_v2",
               "remove_maria", "set_aside_v2",
               "$choose_artifacts_or_support",
-              "$check_killed_creature",
               "encounter_deck_v2"
             ]
           }
@@ -295,6 +296,35 @@
     {
       "id": "set_aside_v2",
       "text": "Set each of the following aside, out of play: each [[Apiary]] location, the Grotesque Amalgam, Mother, and double-sided Squamous Parasite [tdc_rune_t] enemies, the Grisly \"Mask\" and Ancient Relic [tdc_rune_s] story assets, and each copy of the Parasitic Transformation weakness."
+    },
+    {
+      "id": "maybe_gather_inescapable",
+      "text": "Check the campaign log. If <i>the creature was defeated:</i>",
+      "type": "branch",
+      "condition": {
+        "type": "campaign_log",
+        "section": "campaign_notes",
+        "id": "the_creature_was_defeated",
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": ["$no_inescapable_encounter_set"]
+          },
+          {
+            "boolCondition": false,
+            "steps": [
+              "gather_inescapable"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "gather_inescapable",
+      "bullet_type": "small",
+      "type": "encounter_sets",
+      "encounter_sets": [ "the_inescapable"],
+      "text": "Also gather <i>The Inescapable</i> encounter set, and set it aside, out of play."
     },
     {
       "id": "encounter_deck_v1",

--- a/campaigns/tdc/09_court_of_the_ancients.json
+++ b/campaigns/tdc/09_court_of_the_ancients.json
@@ -12,11 +12,11 @@
     "check_plumb_the_depths",
     "$check_good_money_setup",
     "encounter_sets",
+    "maybe_gather_inescapable",
     "setup_locations",
     "choose_location_layout",
     "setup_check_west",
     "set_aside_cards",
-    "$check_killed_creature",
     "$choose_artifacts_or_support",
     "encounter_deck",
     "sliding_locations_rule",
@@ -627,6 +627,35 @@
     {
       "id": "set_aside_cards",
       "text": "Set the Shard of Y'ch'lecht story asset and the Colossal Tyrant enemy aside, out of play."
+    },
+    {
+      "id": "maybe_gather_inescapable",
+      "text": "Check the campaign log. If <i>the creature was defeated:</i>",
+      "type": "branch",
+      "condition": {
+        "type": "campaign_log",
+        "section": "campaign_notes",
+        "id": "the_creature_was_defeated",
+        "options": [
+          {
+            "boolCondition": true,
+            "steps": ["$no_inescapable_encounter_set"]
+          },
+          {
+            "boolCondition": false,
+            "steps": [
+              "gather_inescapable"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "gather_inescapable",
+      "bullet_type": "small",
+      "type": "encounter_sets",
+      "encounter_sets": [ "the_inescapable"],
+      "text": "Also gather <i>The Inescapable</i> encounter set. Set The Inescapable enemy aside, out of play."
     },
     {
       "id": "encounter_deck",


### PR DESCRIPTION
I'm not sure moving these in the setup order is okay, especially since it _can't_ move to the same place in Obsidian Canyons (it needs to be after location setup, at the earliest). The fixes for Apiary and Court are the only ones needed for scenario logic.