### PR TITLE
[PtC]: fix resolution step of last king, to hide R1 and R2

### DIFF
--- a/campaigns/ptc/the_last_king.json
+++ b/campaigns/ptc/the_last_king.json
@@ -543,6 +543,7 @@
       },
       "title": "Resolution 1",
       "text": "The brisk autumn air embraces you as you exit the manor. There is no doubt in your mind that the cast and crew of The King in Yellow have become affected by madness. Perhaps it’s getting to you, as well. You feel an encroaching darkness, a presence in your mind not unlike the gaze of the Stranger. Startled, you peer about the front yard for the first time since escaping the manor. The scene is…different. The front windows are not smashed as they were when you first approached. The trail of blood you had noticed on the porch has been wiped clean, and instead of the disturbingly warped music you had heard upon entering, the soothing tones of slow jazz drift out from the courtyard.",
+      "hidden": true,
       "steps": [
         "vips_interviewed",
         "check_vips_slain",
@@ -565,6 +566,7 @@
       },
       "title": "Resolution 2",
       "text": "“Excuse me, but it’s very late,” you hear a server say as he gently taps you on your shoulder. You realize that you are sitting on a couch in the manor’s living room, and that you have been asleep for some time. The party appears to be winding down. No music fills the halls, the food is all but gone, and only a few guests remain. “Perhaps you would like for me to get your coat?” the server asks with a trained smile. You wobble as you rise to your feet, leaning against the couch’s armrest. Your head pounds with a dizzying intensity, and your vision is spotted. You insist that you are fine, and begin walking toward the foyer.\nYou no longer see any of the guests you were searching for earlier, not even the hostess, Mrs. Dumaine. All traces of the madness and horror you’ve experienced are gone. Even the oddities you witnessed upon entering the manor have vanished—the signs of struggle, the broken windows, the blood trail on the porch… Every piece of evidence has been erased. But you still remember the night’s events, and in your memory you will find your answers.",
+      "hidden": true,
       "steps": [
         "vips_interviewed",
         "check_vips_slain",


### PR DESCRIPTION
R1 and R2 are implicitly selected by the other resolutions and not asked for or instructed by the scenario directly

tried it with a local run, but please verify

<img width="412" height="154" alt="image" src="https://github.com/user-attachments/assets/f7ab49d1-d7f6-481a-8514-80cd882ae293" />
