### PR TITLE
[TDC] fix rules not opening due to unreferenced step $hidden

### DIFF
--- a/campaigns/tdc/campaign.json
+++ b/campaigns/tdc/campaign.json
@@ -85,10 +85,6 @@
     {
       "title": "Seal",
       "steps": ["$seal_rule"]
-    },
-    {
-      "title": "Hidden",
-      "steps": ["$hidden"]
     }
   ],
   "steps": [


### PR DESCRIPTION
@zzorba quick look into https://github.com/zzorba/ArkhamCards/issues/669 revealed an exception while loading the step `$hidden`.
```
ERROR Could not find step: $hidden [Component Stack]
ERROR  Warning: Error: Could not find step: $hidden
```

I checked the [campaign guide](https://images-cdn.fantasyflightgames.com/filer_public/c1/3b/c13b0e74-62bb-49bc-bc85-036ab9d1ef10/ahc84_campaign_guide-web_1.pdf) again and if this is supposed to refer to the hidden card trait, it's not mentioned in this campaign. if it is, there's no referenced step. if you wanted a hidden section, I think this is the wrong spot for it?
