### PR TITLE
Fix i18n issue in GER tdc

### DIFF
--- a/i18n/de/campaigns/tdc/core.po
+++ b/i18n/de/campaigns/tdc/core.po
@@ -108,7 +108,7 @@ msgid "In player order, each player may choose 1 [[Item]] asset from the <i>Expe
 msgstr "In Spielerreihenfolge darf jeder Spieler eine [[Gegenstand]]-Vorteilskarte aus dem Begegnungsset <i>Expedition</i> wählen. Diese startet das Spiel unter seiner/ihrer Kontrolle."
 
 msgid "In player order, each player may choose 1 earned [[Artifact]] asset or 1 [[Item]] asset from the <i>Expedition</i> encounter set to begin in play under their control."
-msgstr "In Spielerreihenfolge darf jeder Spieler eine verdiente [[Artefakt]]- oder [[Gegenstand]]-Vorteilskarte aus dem Begegnungsset <i>Expedition</i> wählen. Diese startet das Spiel unter seiner/ihrer Kontrolle."
+msgstr "In Spielerreihenfolge darf jeder Spieler 1 verdiente [[Artefakt]]- oder 1 [[Gegenstand]]-Vorteilskarte aus dem Begegnungsset <i>Expedition</i> wählen. Diese startet das Spiel unter seiner/ihrer Kontrolle."
 
 msgid "Investigators may acquire certain [[Artifact]] story assets also referred to as simply \"artifacts\" through the course of <i>The Drowned City</i> campaign. Artifacts function like any other asset, except for the following:"
 msgstr "Die Ermittler können im Verlauf der Kampagne Die versunkene Stadt bestimmte [[Artefakt]]-Storyvorteilskarten erhalten (vereinfacht auch als „Artefakte“ bezeichnet). Artefakte funktionieren wie normale Vorteilskarten mit folgenden Ausnahmen:"


### PR DESCRIPTION
It's a minor detail, but it makes a grammatical difference, in which the previous translation is misleading.

The new text is the same as in the booklet:
<img width="1029" height="198" alt="grafik" src="https://github.com/user-attachments/assets/8e035eeb-2256-48c8-b429-8bb0e3661f41" />
