### PR TITLE
Remove duplicated "The Drowned Quarter" encounter set string

### DIFF
--- a/i18n/cs/encounter_sets.po
+++ b/i18n/cs/encounter_sets.po
@@ -1559,9 +1559,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/it/encounter_sets.po
+++ b/i18n/it/encounter_sets.po
@@ -1303,9 +1303,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/pl/encounter_sets.po
+++ b/i18n/pl/encounter_sets.po
@@ -1549,9 +1549,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/pt/encounter_sets.po
+++ b/i18n/pt/encounter_sets.po
@@ -1331,9 +1331,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/ru/encounter_sets.po
+++ b/i18n/ru/encounter_sets.po
@@ -1411,9 +1411,6 @@ msgstr "Подводные существа"
 msgid "The Western Wall"
 msgstr "Западная стена"
 
-msgid "The Drowned Quarter"
-msgstr "Затонувший квартал"
-
 msgid "Elder Mist"
 msgstr "Древний туман"
 

--- a/i18n/uk/encounter_sets.po
+++ b/i18n/uk/encounter_sets.po
@@ -1562,9 +1562,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/vi/encounter_sets.po
+++ b/i18n/vi/encounter_sets.po
@@ -1553,9 +1553,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/zh-cn/encounter_sets.po
+++ b/i18n/zh-cn/encounter_sets.po
@@ -1247,9 +1247,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 

--- a/i18n/zh/encounter_sets.po
+++ b/i18n/zh/encounter_sets.po
@@ -1264,9 +1264,6 @@ msgstr ""
 msgid "The Western Wall"
 msgstr ""
 
-msgid "The Drowned Quarter"
-msgstr ""
-
 msgid "Elder Mist"
 msgstr ""
 


### PR DESCRIPTION
This removes duplicated entries across all `.po` files (I believe #1488 introduced this) - PoEdit isn't happy about this. No translation will be harmed due to this PR (RU has it double-translated).